### PR TITLE
Fix: FirebaseManagerのuserID取得処理重複を解消

### DIFF
--- a/SportsNote_iOS/Model/Manager/FirebaseManager.swift
+++ b/SportsNote_iOS/Model/Manager/FirebaseManager.swift
@@ -10,6 +10,16 @@ final class FirebaseManager {
 
     private init() {}
 
+    /**
+     * 現在のuserIDを取得
+     *
+     * @return userID
+     */
+    private func currentUserID() -> String {
+        UserDefaultsManager.get(
+            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+    }
+
     // MARK: - Create
 
     /**
@@ -196,8 +206,7 @@ final class FirebaseManager {
      * @return 取得したドキュメント
      */
     private func getAllDocuments(collection: String) async throws -> [QueryDocumentSnapshot] {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
 
         do {
             return try await withCheckedThrowingContinuation { continuation in
@@ -499,8 +508,7 @@ final class FirebaseManager {
      * @param group グループデータ
      */
     func updateGroup(group: Group) async throws {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
         let documentID = "\(userID)_\(group.groupID)"
 
         let data: [String: Any] = [
@@ -520,8 +528,7 @@ final class FirebaseManager {
      * @param task 課題データ
      */
     func updateTask(task: TaskData) async throws {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
         let documentID = "\(userID)_\(task.taskID)"
 
         let data: [String: Any] = [
@@ -543,8 +550,7 @@ final class FirebaseManager {
      * @param measures 対策データ
      */
     func updateMeasures(measures: Measures) async throws {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
         let documentID = "\(userID)_\(measures.measuresID)"
 
         let data: [String: Any] = [
@@ -563,8 +569,7 @@ final class FirebaseManager {
      * @param memo メモデータ
      */
     func updateMemo(memo: Memo) async throws {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
         let documentID = "\(userID)_\(memo.memoID)"
 
         let data: [String: Any] = [
@@ -582,8 +587,7 @@ final class FirebaseManager {
      * @param target 目標データ
      */
     func updateTarget(target: Target) async throws {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
         let documentID = "\(userID)_\(target.targetID)"
 
         let data: [String: Any] = [
@@ -604,8 +608,7 @@ final class FirebaseManager {
      * @param note ノートデータ
      */
     func updateNote(note: Note) async throws {
-        let userID = UserDefaultsManager.get(
-            key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
+        let userID = currentUserID()
         let documentID = "\(userID)_\(note.noteID)"
 
         let data: [String: Any] = [


### PR DESCRIPTION
## 概要
`FirebaseManager.swift`内で7箇所に重複していたuserID取得処理を、`private func currentUserID() -> String`ヘルパーに集約する。

Closes #9

## 変更内容
- `FirebaseManager`に`private func currentUserID() -> String`を新規追加し、`UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())`の呼び出しをそこに集約
- `getAllDocuments`, `updateGroup`, `updateTask`, `updateMeasures`, `updateMemo`, `updateTarget`, `updateNote`の7箇所の重複コードを`currentUserID()`呼び出しに置き換え

## 変更ファイル一覧
| ファイルパス | 変更種別 | 変更概要 |
|-------------|---------|---------|
| `SportsNote_iOS/Model/Manager/FirebaseManager.swift` | 修正 | userID取得処理をヘルパーメソッドに集約（1 file changed, 17 insertions, 14 deletions） |

## ビルド・テスト結果
- swift-format: 実行済み
- ビルド: BUILD SUCCEEDED
- テスト: TEST SUCCEEDED（既存414件すべて成功、`FirebaseManager`を直接対象とする単体テストは元々存在しないため回帰リスクは限定的）

## 完了条件チェック
- [x] `FirebaseManager.swift`内のuserID取得処理が1箇所のヘルパーメソッド/プロパティに集約されている
- [x] 7箇所の呼び出し元がすべてヘルパー経由に置き換えられている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立サブエージェントによるクロスレビューを実施。実ファイル・grepによる網羅性確認・ビルド/テストの独立再実行を行い、must-fix/should-fix/nitいずれも指摘なし（1ラウンドで合格）。

## 補足
`MigrationManager.swift`の既存`getUserID()`ヘルパーとの統合、および`UserDefaultsManager.get`自体の実装変更は、issue本文で明示的にスコープ外とされているため本PRでは対応していない。