### PR TITLE
Add: UserDefaultsManagerの単体テストを追加

### DIFF
--- a/SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift
@@ -1,0 +1,200 @@
+//
+//  UserDefaultsManagerTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/07/26.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("UserDefaultsManager Tests", .serialized)
+struct UserDefaultsManagerTests {
+
+    init() {
+        // 前のテストの残留状態（cachedUserID含む）を必ずリセットする
+        UserDefaultsManager.clearAll()
+    }
+
+    // MARK: - 基本的なset/get（型ごと）
+
+    @Test("set/get - String型を保存・取得できる")
+    func setGet_string() {
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.address, value: "test@example.com")
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.address, defaultValue: "")
+        #expect(value == "test@example.com")
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("set/get - Int型を保存・取得できる")
+    func setGet_int() {
+        let key = "testIntKey"
+        UserDefaultsManager.set(key: key, value: 42)
+        let value = UserDefaultsManager.get(key: key, defaultValue: 0)
+        #expect(value == 42)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("set/get - Bool型を保存・取得できる")
+    func setGet_bool() {
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.isLogin, value: true)
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.isLogin, defaultValue: false)
+        #expect(value == true)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("set/get - Double型を保存・取得できる")
+    func setGet_double() {
+        let key = "testDoubleKey"
+        UserDefaultsManager.set(key: key, value: 3.14)
+        let value = UserDefaultsManager.get(key: key, defaultValue: 0.0)
+        #expect(value == 3.14)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("get - 未保存キーはdefaultValueを返す")
+    func get_returnsDefaultValueWhenKeyNotSaved() {
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.firstLaunch, defaultValue: true)
+        #expect(value == true)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("set - 同一キーへの再設定で値が上書きされる")
+    func set_overwritesExistingValue() {
+        let key = "testOverwriteKey"
+        UserDefaultsManager.set(key: key, value: "first")
+        UserDefaultsManager.set(key: key, value: "second")
+        let value = UserDefaultsManager.get(key: key, defaultValue: "")
+        #expect(value == "second")
+
+        UserDefaultsManager.clearAll()
+    }
+
+    // MARK: - Keys.userIDの特殊処理
+
+    @Test("userID - 未保存時は自動生成されたUUIDが返り、UserDefaultsにも保存される")
+    func userID_autoGeneratesUUIDWhenNotSaved() {
+        let id = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(UUIDGenerator.isValidUUID(id))
+
+        // set が実際に永続化されていることの検証（UserDefaults側を直接確認）
+        let savedValue = UserDefaults.standard.string(forKey: UserDefaultsManager.Keys.userID)
+        #expect(savedValue == id)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("userID - 保存済みの場合はその値がそのまま返る")
+    func userID_returnsExistingValueWhenAlreadySaved() {
+        // キャッシュを経由せず、UserDefaultsに直接値を仕込む
+        UserDefaults.standard.set("existing-id", forKey: UserDefaultsManager.Keys.userID)
+
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(value == "existing-id")
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("userID - cachedUserIDが優先される（UserDefaultsの値と異なっていても優先）")
+    func userID_prefersCachedValueOverUserDefaults() {
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.userID, value: "cached-id")
+        // UserDefaults側だけを直接書き換える（cachedUserIDは変わらない）
+        UserDefaults.standard.set("direct-id", forKey: UserDefaultsManager.Keys.userID)
+
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(value == "cached-id")
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("userID - 2回連続でgetしても同じ値が返る（都度UUIDが再生成されない）")
+    func userID_returnsSameValueOnConsecutiveGets() {
+        let first = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        let second = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(first == second)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    // MARK: - remove
+
+    @Test("remove - 指定キーの値が削除されデフォルト値に戻る")
+    func remove_deletesValueAndReturnsToDefault() {
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.firstLaunch, value: false)
+        UserDefaultsManager.remove(key: UserDefaultsManager.Keys.firstLaunch)
+
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.firstLaunch, defaultValue: true)
+        #expect(value == true)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("remove - userIDキー削除後はcachedUserIDもクリアされ、次回getで新しいUUIDが生成される")
+    func remove_userIDClearsCacheAndRegeneratesOnNextGet() {
+        let originalID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        UserDefaultsManager.remove(key: UserDefaultsManager.Keys.userID)
+
+        let newID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(newID != originalID)
+        #expect(UUIDGenerator.isValidUUID(newID))
+
+        UserDefaultsManager.clearAll()
+    }
+
+    // MARK: - clearAll
+
+    @Test("clearAll - 複数キーをすべて削除する")
+    func clearAll_deletesAllKeys() {
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.firstLaunch, value: false)
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.address, value: "test@example.com")
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.password, value: "password123")
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.isLogin, value: true)
+
+        UserDefaultsManager.clearAll()
+
+        #expect(UserDefaults.standard.object(forKey: UserDefaultsManager.Keys.firstLaunch) == nil)
+        #expect(UserDefaults.standard.object(forKey: UserDefaultsManager.Keys.address) == nil)
+        #expect(UserDefaults.standard.object(forKey: UserDefaultsManager.Keys.password) == nil)
+        #expect(UserDefaults.standard.object(forKey: UserDefaultsManager.Keys.isLogin) == nil)
+    }
+
+    @Test("clearAll - userIDのcachedUserIDもクリアされる")
+    func clearAll_clearsCachedUserID() {
+        let originalID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        UserDefaultsManager.clearAll()
+
+        let newID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(newID != originalID)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    // MARK: - resetUserInfo
+
+    @Test("resetUserInfo - 指定したuserIDが保存される")
+    func resetUserInfo_savesSpecifiedUserID() {
+        UserDefaultsManager.resetUserInfo(userID: "specified-id")
+
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(value == "specified-id")
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("resetUserInfo - 引数省略時は自動生成されたUUIDが保存される")
+    func resetUserInfo_generatesUUIDWhenArgumentOmitted() {
+        UserDefaultsManager.resetUserInfo()
+
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+        #expect(UUIDGenerator.isValidUUID(value))
+
+        UserDefaultsManager.clearAll()
+    }
+}


### PR DESCRIPTION
## 概要
`UserDefaultsManager`に対応する単体テストファイルが存在しなかったため、`set`/`get`の基本動作・`Keys.userID`の特殊処理・`remove`/`clearAll`/`resetUserInfo`の挙動を検証するテストを新規追加する。

Closes #15

## 変更内容
- `SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift`を新規追加（Swift Testing使用、`@Suite(.serialized)`）
- テストケース: 基本型（String/Int/Bool/Double）のset/get、未保存キーのdefaultValue、上書き、`Keys.userID`の自動UUID生成・保存済み値の優先・`cachedUserID`キャッシュ優先・再現性、`remove`（通常キー・userIDキャッシュクリア含む）、`clearAll`（全キー削除・cachedUserIDクリア）、`resetUserInfo`（指定ID・省略時自動生成）を網羅（計16テスト）
- 既存の`RealmManagerTests.swift`の構成・クリーンアップ作法（各テスト末尾での明示的クリーンアップ）を踏襲し、`init()`でも前テストの残留状態をリセット

## 変更ファイル一覧
| ファイルパス | 変更種別 | 変更概要 |
|-------------|---------|---------|
| `SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift` | 新規 | `UserDefaultsManager`の単体テスト16件を追加 |

## ビルド・テスト結果
- swift-format: 実行済み（差分なし）
- ビルド: BUILD SUCCEEDED（警告0件）
- テスト: TEST SUCCEEDED（430件全成功、新規16件含む。既存414件は変わらず全成功）

## 完了条件チェック
- [x] `UserDefaultsManagerTests.swift`が追加され、`set`/`get`の基本動作・`Keys.userID`の特殊処理・`remove`/`clearAll`/`resetUserInfo`を検証するテストが含まれている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功、かつ新規追加テストも成功する

## クロスレビュー結果
独立サブエージェントによるクロスレビューを実施（独立環境でのビルド・テスト再実行込み、`review-insights.md`記載の過去指摘パターンも踏まえて確認）。must-fix指摘なし、1ラウンドで合格。以下のshould-fix指摘が残っているが、今回のスコープでは対応を見送る:

- **should-fix**: `init()`・各テスト末尾で`UserDefaultsManager.clearAll()`（`UserDefaults.standard`の全キー削除）を呼んでいるが、同じ`UserDefaults.standard`上の別キー（`Keys.agree`）を使う`TermsManagerTests`（`.serialized`なし）と並行実行された場合に巻き添え削除が起きうる。`.serialized`は自スイート内のみの直列化でスイート間の並行実行は防げないため、CI環境やテストプラン設定が変わるとフレーキーになるリスクが残る（issue #11で指摘済みの同種パターンの再発。今回のCI設定では顕在化せず合格扱い）。

## 補足
`FirebaseManager`/`SyncManager`/`InitializationManager`/`MigrationManager`/`TestDataManager`のテスト追加は、issue本文で明示的にスコープ外とされているため本PRでは対応していない。