### PR TITLE
Refactor: GroupViewModel/TargetViewModel/MemoViewModelでperformBackgroundSyncを使用するよう統一

### DIFF
--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -138,13 +138,8 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
             // Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 
-            // Firebase同期を非同期で実行（MainActorを維持）
-            Task {
-                let syncResult = await syncEntityToFirebase(entity, isUpdate: isUpdate)
-                if case .failure(let error) = syncResult {
-                    showErrorAlert(error)
-                }
-            }
+            // Firebase同期はバックグラウンドで実行
+            performBackgroundSync(entity, isUpdate: isUpdate)
 
             // UI更新
             groups = try RealmManager.shared.getDataList(clazz: Group.self)
@@ -191,13 +186,10 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
             // Realm操作はMainActorで実行
             try RealmManager.shared.logicalDelete(id: id, type: Group.self)
 
-            // Firebase同期を非同期で実行（削除前に取得したオブジェクトを使用）
+            // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
             if let groupToDelete = groupToDelete {
                 Task {
-                    let syncResult = await syncEntityToFirebase(groupToDelete, isUpdate: true)
-                    if case .failure(let error) = syncResult {
-                        showErrorAlert(error)
-                    }
+                    performBackgroundSync(groupToDelete, isUpdate: true)
                 }
             }
 

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -75,13 +75,8 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             // Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 
-            // Firebase同期を非同期で実行（MainActorを維持）
-            Task {
-                let syncResult = await syncEntityToFirebase(entity, isUpdate: isUpdate)
-                if case .failure(let error) = syncResult {
-                    showErrorAlert(error)
-                }
-            }
+            // Firebase同期はバックグラウンドで実行
+            performBackgroundSync(entity, isUpdate: isUpdate)
 
             // UI更新
             memoList = try RealmManager.shared.getDataList(clazz: Memo.self)
@@ -107,13 +102,10 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             // Realm操作はMainActorで実行
             try RealmManager.shared.logicalDelete(id: id, type: Memo.self)
 
-            // Firebase同期を非同期で実行（MainActorを維持）
+            // Firebase同期はバックグラウンドで実行（論理削除なので更新として扱う）
             if let memo = memoToDelete {
                 Task {
-                    let syncResult = await syncEntityToFirebase(memo, isUpdate: true)  // 論理削除なので更新として扱う
-                    if case .failure(let error) = syncResult {
-                        showErrorAlert(error)
-                    }
+                    performBackgroundSync(memo, isUpdate: true)
                 }
             }
 

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -119,13 +119,8 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
             // Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 
-            // Firebase同期を非同期で実行（MainActorを維持）
-            Task {
-                let syncResult = await syncEntityToFirebase(entity, isUpdate: isUpdate)
-                if case .failure(let error) = syncResult {
-                    showErrorAlert(error)
-                }
-            }
+            // Firebase同期はバックグラウンドで実行
+            performBackgroundSync(entity, isUpdate: isUpdate)
 
             // UI更新 - 現在の年月のデータを再取得
             let allTargets = try RealmManager.shared.getDataList(clazz: Target.self)
@@ -203,13 +198,10 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
             // Realm操作はMainActorで実行
             try RealmManager.shared.logicalDelete(id: id, type: Target.self)
 
-            // Firebase同期を非同期で実行（MainActorを維持）
+            // Firebase同期はバックグラウンドで実行（論理削除なので更新として扱う）
             if let target = targetToDelete {
                 Task {
-                    let syncResult = await syncEntityToFirebase(target, isUpdate: true)  // 論理削除なので更新として扱う
-                    if case .failure(let error) = syncResult {
-                        showErrorAlert(error)
-                    }
+                    performBackgroundSync(target, isUpdate: true)
                 }
             }
 


### PR DESCRIPTION
## 概要
`FirebaseSyncable`に定義済みの共通ヘルパー`performBackgroundSync`が一部のViewModelでしか使われておらず、`GroupViewModel`・`TargetViewModel`・`MemoViewModel`の3ファイル・6箇所（save/delete内）でFirebase同期のTask/Result判定コードがインラインで重複していた。既に`MeasuresViewModel`・`NoteViewModel`・`TaskViewModel`で使われている`performBackgroundSync`呼び出しに統一し、重複を解消する。

Closes #12

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`（save内142-147行目、delete内196-201行目）
- `SportsNote_iOS/ViewModel/TargetViewModel.swift`（save内123-128行目、delete内208-213行目）
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`（save内79-84行目、delete内112-117行目）

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test`: **TEST SUCCEEDED**（430件全成功）

## 完了条件チェックリスト
- [x] `GroupViewModel.swift`・`TargetViewModel.swift`・`MemoViewModel.swift`の該当6箇所が`performBackgroundSync`呼び出しに置き換えられている
- [x] `grep`で`if case .failure(let error) = syncResult`の重複パターンが上記3ファイルのsave/delete内に存在しないことを確認（`TargetViewModel.swift`・`MemoViewModel.swift`にそれぞれ1件ずつ残るが、これは`syncToFirebase()`内の全件一括同期ループという別パターンであり、本issueが指摘した6箇所とは無関係。クロスレビューでも該当箇所を直接確認し、issueスコープ外であることを検証済み）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立したサブエージェントによるクロスレビューを実施。must-fix指摘なし、should-fixなし、nit 1件のみのため合格扱い（1ラウンドで完了）。

- **nit**: `delete()`内で`performBackgroundSync`を不要な外側`Task { }`で二重に包んでいる（`save()`では直接呼び出しなのに対し、`delete()`では`if let ... { Task { performBackgroundSync(...) } }`という形で不統一）。動作上のバグではなく、既存の`MeasuresViewModel`等の`delete()`実装スタイルを踏襲したもの（issue記載の対応方針の範囲内）。次回同様の置き換えを行う際の参考として`references/review-insights.md`に記録済み。

マージはユーザーによる手動確認後にお願いします。