### PR TITLE
Fix: オフライン削除後の同期で削除済みデータが復活する問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -261,6 +261,27 @@ final class RealmManager {
         }
     }
 
+    /// 汎用的なデータ一覧取得メソッド（論理削除済みも含む）
+    /// Firebaseとの同期比較（`SyncManager`）専用に使用し、isDeletedによる絞り込みは行わない
+    /// - Parameter clazz: 取得するデータ型のクラス
+    /// - Returns: 論理削除フラグに関わらない全データのリスト
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getDataListIncludingDeleted<T: Object>(clazz: T.Type) throws -> [T] {
+        do {
+            let realm = try getRealm()
+            var results = realm.objects(clazz)
+            // "order" プロパティが存在する場合のみソート
+            if let schema = clazz.sharedSchema(),
+                schema.properties.contains(where: { $0.name == "order" })
+            {
+                results = results.sorted(byKeyPath: "order", ascending: true)
+            }
+            return Array(results)
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getDataListIncludingDeleted-\(String(describing: T.self))")
+        }
+    }
+
     /// 汎用的なデータカウント取得メソッド
     /// - Parameter clazz: RealmObjectのクラス型
     /// - Returns: isDeletedがfalseのデータ数
@@ -560,6 +581,8 @@ final class RealmManager {
     }
 
     /// 任意のオブジェクトを論理削除
+    /// updated_atも現在時刻に更新し、Firebaseとの同期時に削除操作が
+    /// Firebase側の未削除コピーより新しいと判定されるようにする
     /// - Parameters:
     ///   - item: データ
     ///   - realm: Realmインスタンス
@@ -567,21 +590,27 @@ final class RealmManager {
         // itemが「削除フラグ」を持っているかどうかでチェックし、削除マークを付ける
         if let itemWithDeleteFlag = item as? Note {
             itemWithDeleteFlag.isDeleted = true
+            itemWithDeleteFlag.updated_at = Date()
             realm.add(itemWithDeleteFlag, update: .modified)
         } else if let itemWithDeleteFlag = item as? Group {
             itemWithDeleteFlag.isDeleted = true
+            itemWithDeleteFlag.updated_at = Date()
             realm.add(itemWithDeleteFlag, update: .modified)
         } else if let itemWithDeleteFlag = item as? TaskData {
             itemWithDeleteFlag.isDeleted = true
+            itemWithDeleteFlag.updated_at = Date()
             realm.add(itemWithDeleteFlag, update: .modified)
         } else if let itemWithDeleteFlag = item as? Measures {
             itemWithDeleteFlag.isDeleted = true
+            itemWithDeleteFlag.updated_at = Date()
             realm.add(itemWithDeleteFlag, update: .modified)
         } else if let itemWithDeleteFlag = item as? Memo {
             itemWithDeleteFlag.isDeleted = true
+            itemWithDeleteFlag.updated_at = Date()
             realm.add(itemWithDeleteFlag, update: .modified)
         } else if let itemWithDeleteFlag = item as? Target {
             itemWithDeleteFlag.isDeleted = true
+            itemWithDeleteFlag.updated_at = Date()
             realm.add(itemWithDeleteFlag, update: .modified)
         }
     }

--- a/SportsNote_iOS/Model/Manager/SyncManager.swift
+++ b/SportsNote_iOS/Model/Manager/SyncManager.swift
@@ -121,68 +121,139 @@ final class SyncManager {
     }
 
     /// Group を同期
+    /// - Parameters は本番のFirebase/Realm呼び出しをデフォルト値として注入可能にしている。
+    ///   テストでは`getFirebaseData`等のみをスタブに差し替え、`getRealmData`は本番実装（`RealmManager`）を
+    ///   そのまま経由させることで、実際の同期処理の配線（isDeleted復活バグ対策の実装箇所）を検証できる
     @MainActor
-    private func syncGroup() async throws {
+    func syncGroup(
+        getFirebaseData: @MainActor () async throws -> [Group] = { try await FirebaseManager.shared.getAllGroup() },
+        getRealmData: @MainActor () throws -> [Group] = {
+            try RealmManager.shared.getDataListIncludingDeleted(clazz: Group.self)
+        },
+        saveToFirebase: @MainActor (Group) async throws -> Void = {
+            try await FirebaseManager.shared.saveGroup(group: $0)
+        },
+        updateFirebase: @MainActor (Group) async throws -> Void = {
+            try await FirebaseManager.shared.updateGroup(group: $0)
+        }
+    ) async throws {
         try await syncData(
-            getFirebaseData: { try await FirebaseManager.shared.getAllGroup() },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Group.self) },
-            saveToFirebase: { try await FirebaseManager.shared.saveGroup(group: $0) },
-            updateFirebase: { try await FirebaseManager.shared.updateGroup(group: $0) }
+            getFirebaseData: getFirebaseData,
+            getRealmData: getRealmData,
+            saveToFirebase: saveToFirebase,
+            updateFirebase: updateFirebase
         )
     }
 
-    /// Task を同期
+    /// Task を同期（テスト容易性のためデフォルト引数を持つ。syncGroupの説明を参照）
     @MainActor
-    private func syncTask() async throws {
+    func syncTask(
+        getFirebaseData: @MainActor () async throws -> [TaskData] = { try await FirebaseManager.shared.getAllTask() },
+        getRealmData: @MainActor () throws -> [TaskData] = {
+            try RealmManager.shared.getDataListIncludingDeleted(clazz: TaskData.self)
+        },
+        saveToFirebase: @MainActor (TaskData) async throws -> Void = {
+            try await FirebaseManager.shared.saveTask(task: $0)
+        },
+        updateFirebase: @MainActor (TaskData) async throws -> Void = {
+            try await FirebaseManager.shared.updateTask(task: $0)
+        }
+    ) async throws {
         try await syncData(
-            getFirebaseData: { try await FirebaseManager.shared.getAllTask() },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: TaskData.self) },
-            saveToFirebase: { try await FirebaseManager.shared.saveTask(task: $0) },
-            updateFirebase: { try await FirebaseManager.shared.updateTask(task: $0) }
+            getFirebaseData: getFirebaseData,
+            getRealmData: getRealmData,
+            saveToFirebase: saveToFirebase,
+            updateFirebase: updateFirebase
         )
     }
 
-    /// Measures を同期
+    /// Measures を同期（テスト容易性のためデフォルト引数を持つ。syncGroupの説明を参照）
     @MainActor
-    private func syncMeasures() async throws {
+    func syncMeasures(
+        getFirebaseData: @MainActor () async throws -> [Measures] = {
+            try await FirebaseManager.shared.getAllMeasures()
+        },
+        getRealmData: @MainActor () throws -> [Measures] = {
+            try RealmManager.shared.getDataListIncludingDeleted(clazz: Measures.self)
+        },
+        saveToFirebase: @MainActor (Measures) async throws -> Void = {
+            try await FirebaseManager.shared.saveMeasures(measures: $0)
+        },
+        updateFirebase: @MainActor (Measures) async throws -> Void = {
+            try await FirebaseManager.shared.updateMeasures(measures: $0)
+        }
+    ) async throws {
         try await syncData(
-            getFirebaseData: { try await FirebaseManager.shared.getAllMeasures() },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Measures.self) },
-            saveToFirebase: { try await FirebaseManager.shared.saveMeasures(measures: $0) },
-            updateFirebase: { try await FirebaseManager.shared.updateMeasures(measures: $0) }
+            getFirebaseData: getFirebaseData,
+            getRealmData: getRealmData,
+            saveToFirebase: saveToFirebase,
+            updateFirebase: updateFirebase
         )
     }
 
-    /// Memo を同期
+    /// Memo を同期（テスト容易性のためデフォルト引数を持つ。syncGroupの説明を参照）
     @MainActor
-    private func syncMemo() async throws {
+    func syncMemo(
+        getFirebaseData: @MainActor () async throws -> [Memo] = { try await FirebaseManager.shared.getAllMemo() },
+        getRealmData: @MainActor () throws -> [Memo] = {
+            try RealmManager.shared.getDataListIncludingDeleted(clazz: Memo.self)
+        },
+        saveToFirebase: @MainActor (Memo) async throws -> Void = {
+            try await FirebaseManager.shared.saveMemo(memo: $0)
+        },
+        updateFirebase: @MainActor (Memo) async throws -> Void = {
+            try await FirebaseManager.shared.updateMemo(memo: $0)
+        }
+    ) async throws {
         try await syncData(
-            getFirebaseData: { try await FirebaseManager.shared.getAllMemo() },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Memo.self) },
-            saveToFirebase: { try await FirebaseManager.shared.saveMemo(memo: $0) },
-            updateFirebase: { try await FirebaseManager.shared.updateMemo(memo: $0) }
+            getFirebaseData: getFirebaseData,
+            getRealmData: getRealmData,
+            saveToFirebase: saveToFirebase,
+            updateFirebase: updateFirebase
         )
     }
 
-    /// Target を同期
+    /// Target を同期（テスト容易性のためデフォルト引数を持つ。syncGroupの説明を参照）
     @MainActor
-    private func syncTarget() async throws {
+    func syncTarget(
+        getFirebaseData: @MainActor () async throws -> [Target] = { try await FirebaseManager.shared.getAllTarget() },
+        getRealmData: @MainActor () throws -> [Target] = {
+            try RealmManager.shared.getDataListIncludingDeleted(clazz: Target.self)
+        },
+        saveToFirebase: @MainActor (Target) async throws -> Void = {
+            try await FirebaseManager.shared.saveTarget(target: $0)
+        },
+        updateFirebase: @MainActor (Target) async throws -> Void = {
+            try await FirebaseManager.shared.updateTarget(target: $0)
+        }
+    ) async throws {
         try await syncData(
-            getFirebaseData: { try await FirebaseManager.shared.getAllTarget() },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Target.self) },
-            saveToFirebase: { try await FirebaseManager.shared.saveTarget(target: $0) },
-            updateFirebase: { try await FirebaseManager.shared.updateTarget(target: $0) }
+            getFirebaseData: getFirebaseData,
+            getRealmData: getRealmData,
+            saveToFirebase: saveToFirebase,
+            updateFirebase: updateFirebase
         )
     }
 
-    /// Note を同期
+    /// Note を同期（テスト容易性のためデフォルト引数を持つ。syncGroupの説明を参照）
     @MainActor
-    private func syncNote() async throws {
+    func syncNote(
+        getFirebaseData: @MainActor () async throws -> [Note] = { try await FirebaseManager.shared.getAllNote() },
+        getRealmData: @MainActor () throws -> [Note] = {
+            try RealmManager.shared.getDataListIncludingDeleted(clazz: Note.self)
+        },
+        saveToFirebase: @MainActor (Note) async throws -> Void = {
+            try await FirebaseManager.shared.saveNote(note: $0)
+        },
+        updateFirebase: @MainActor (Note) async throws -> Void = {
+            try await FirebaseManager.shared.updateNote(note: $0)
+        }
+    ) async throws {
         try await syncData(
-            getFirebaseData: { try await FirebaseManager.shared.getAllNote() },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Note.self) },
-            saveToFirebase: { try await FirebaseManager.shared.saveNote(note: $0) },
-            updateFirebase: { try await FirebaseManager.shared.updateNote(note: $0) }
+            getFirebaseData: getFirebaseData,
+            getRealmData: getRealmData,
+            saveToFirebase: saveToFirebase,
+            updateFirebase: updateFirebase
         )
     }
 }

--- a/SportsNote_iOS/Model/Manager/SyncManager.swift
+++ b/SportsNote_iOS/Model/Manager/SyncManager.swift
@@ -73,7 +73,7 @@ final class SyncManager {
     /// @param getRealmData Realm からデータを取得する関数
     /// @param saveToFirebase Firebase にデータを保存する関数
     /// @param updateFirebase Firebase のデータを更新する関数
-    private func syncData<T>(
+    func syncData<T>(
         getFirebaseData: @MainActor () async throws -> [T],
         getRealmData: @MainActor () throws -> [T],
         saveToFirebase: @MainActor (T) async throws -> Void,
@@ -125,7 +125,7 @@ final class SyncManager {
     private func syncGroup() async throws {
         try await syncData(
             getFirebaseData: { try await FirebaseManager.shared.getAllGroup() },
-            getRealmData: { try RealmManager.shared.getDataList(clazz: Group.self) },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Group.self) },
             saveToFirebase: { try await FirebaseManager.shared.saveGroup(group: $0) },
             updateFirebase: { try await FirebaseManager.shared.updateGroup(group: $0) }
         )
@@ -136,7 +136,7 @@ final class SyncManager {
     private func syncTask() async throws {
         try await syncData(
             getFirebaseData: { try await FirebaseManager.shared.getAllTask() },
-            getRealmData: { try RealmManager.shared.getDataList(clazz: TaskData.self) },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: TaskData.self) },
             saveToFirebase: { try await FirebaseManager.shared.saveTask(task: $0) },
             updateFirebase: { try await FirebaseManager.shared.updateTask(task: $0) }
         )
@@ -147,7 +147,7 @@ final class SyncManager {
     private func syncMeasures() async throws {
         try await syncData(
             getFirebaseData: { try await FirebaseManager.shared.getAllMeasures() },
-            getRealmData: { try RealmManager.shared.getDataList(clazz: Measures.self) },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Measures.self) },
             saveToFirebase: { try await FirebaseManager.shared.saveMeasures(measures: $0) },
             updateFirebase: { try await FirebaseManager.shared.updateMeasures(measures: $0) }
         )
@@ -158,7 +158,7 @@ final class SyncManager {
     private func syncMemo() async throws {
         try await syncData(
             getFirebaseData: { try await FirebaseManager.shared.getAllMemo() },
-            getRealmData: { try RealmManager.shared.getDataList(clazz: Memo.self) },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Memo.self) },
             saveToFirebase: { try await FirebaseManager.shared.saveMemo(memo: $0) },
             updateFirebase: { try await FirebaseManager.shared.updateMemo(memo: $0) }
         )
@@ -169,7 +169,7 @@ final class SyncManager {
     private func syncTarget() async throws {
         try await syncData(
             getFirebaseData: { try await FirebaseManager.shared.getAllTarget() },
-            getRealmData: { try RealmManager.shared.getDataList(clazz: Target.self) },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Target.self) },
             saveToFirebase: { try await FirebaseManager.shared.saveTarget(target: $0) },
             updateFirebase: { try await FirebaseManager.shared.updateTarget(target: $0) }
         )
@@ -180,7 +180,7 @@ final class SyncManager {
     private func syncNote() async throws {
         try await syncData(
             getFirebaseData: { try await FirebaseManager.shared.getAllNote() },
-            getRealmData: { try RealmManager.shared.getDataList(clazz: Note.self) },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Note.self) },
             saveToFirebase: { try await FirebaseManager.shared.saveNote(note: $0) },
             updateFirebase: { try await FirebaseManager.shared.updateNote(note: $0) }
         )

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -261,21 +261,26 @@ struct RealmManagerTests {
     @Test("logicalDelete - 連鎖削除（Group -> Task -> Measures -> Memo）")
     func logicalDelete_cascadesDeletion() async throws {
         // let manager = RealmManager.shared
+        let oldDate = Date().addingTimeInterval(-3600)  // 1時間前
 
-        // 階層データ作成
-        let group = Group(groupID: "g-cascade", title: "Group", color: 0, order: 0, created_at: Date())
+        // 階層データ作成（updated_atをいずれも過去日時にしておき、カスケード削除で更新されるか確認する）
+        let group = Group(groupID: "g-cascade", title: "Group", color: 0, order: 0, created_at: oldDate)
+        group.updated_at = oldDate
 
         let task = TaskData()
         task.taskID = "t-cascade"
         task.groupID = "g-cascade"
+        task.updated_at = oldDate
 
         let measures = Measures()
         measures.measuresID = "m-cascade"
         measures.taskID = "t-cascade"
+        measures.updated_at = oldDate
 
         let memo = Memo()
         memo.memoID = "memo-cascade"
         memo.measuresID = "m-cascade"
+        memo.updated_at = oldDate
 
         try manager.saveItem(group)
         try manager.saveItem(task)
@@ -297,6 +302,12 @@ struct RealmManagerTests {
         #expect(rawTask?.isDeleted == true)
         #expect(rawMeasures?.isDeleted == true)
         #expect(rawMemo?.isDeleted == true)
+
+        // issue #26: カスケード削除された子レコードもupdated_atが更新されている（markAsDeleted共通関数経由）
+        #expect(rawGroup != nil && rawGroup!.updated_at > oldDate)
+        #expect(rawTask != nil && rawTask!.updated_at > oldDate)
+        #expect(rawMeasures != nil && rawMeasures!.updated_at > oldDate)
+        #expect(rawMemo != nil && rawMemo!.updated_at > oldDate)
 
         manager.clearAll()
     }

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -104,6 +104,31 @@ struct RealmManagerTests {
         manager.clearAll()
     }
 
+    // MARK: - getDataListIncludingDeleted テスト（issue #26: 同期時の削除復活バグ対策）
+
+    @Test("getDataListIncludingDeleted - 論理削除済みレコードも含めて取得できる")
+    func getDataListIncludingDeleted_includesLogicallyDeletedRecords() async throws {
+        let group1 = Group(groupID: "g1", title: "Group 1", color: 0, order: 1, created_at: Date())
+        let group2 = Group(groupID: "g2", title: "Group 2", color: 0, order: 0, created_at: Date())  // orderが小さい
+        let group3 = Group(groupID: "g3", title: "Group 3", color: 0, order: 2, created_at: Date())
+        group3.isDeleted = true  // 削除済み
+
+        try manager.saveItem(group1)
+        try manager.saveItem(group2)
+        try manager.saveItem(group3)
+
+        let results = try manager.getDataListIncludingDeleted(clazz: Group.self)
+
+        // 削除済みも含めて全件（3件）返る
+        #expect(results.count == 3)
+        #expect(results[0].groupID == "g2")  // order順（0 -> 1 -> 2）
+        #expect(results[1].groupID == "g1")
+        #expect(results[2].groupID == "g3")
+        #expect(results[2].isDeleted == true)
+
+        manager.clearAll()
+    }
+
     @Test("getCount - 有効なデータ件数を取得できる")
     func getCount_returnsValidCount() async throws {
         // let manager = RealmManager.shared
@@ -211,6 +236,24 @@ struct RealmManagerTests {
         let rawNote = manager.getRawObjectById(id: "del-1", type: Note.self)
         #expect(rawNote != nil)
         #expect(rawNote?.isDeleted == true)
+
+        manager.clearAll()
+    }
+
+    @Test("logicalDelete - updated_atが更新される（issue #26: Firebase同期時に削除が新しいと判定されるようにするため）")
+    func logicalDelete_updatesUpdatedAt() async throws {
+        let oldDate = Date().addingTimeInterval(-3600)  // 1時間前
+
+        let group = Group(groupID: "g-updated-at", title: "Group", color: 0, order: 0, created_at: oldDate)
+        group.updated_at = oldDate
+        try manager.saveItem(group)
+
+        try manager.logicalDelete(id: "g-updated-at", type: Group.self)
+
+        let rawGroup = manager.getRawObjectById(id: "g-updated-at", type: Group.self)
+        #expect(rawGroup?.isDeleted == true)
+        #expect(rawGroup != nil)
+        #expect(rawGroup!.updated_at > oldDate)
 
         manager.clearAll()
     }

--- a/SportsNote_iOSTests/Managers/SyncManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/SyncManagerTests.swift
@@ -1,0 +1,128 @@
+//
+//  SyncManagerTests.swift
+//  SportsNote_iOSTests
+//
+//  issue #26: オフライン削除後の同期で削除済みデータが復活する不具合の回帰テスト
+//
+
+import Foundation
+import RealmSwift
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("SyncManager Tests", .serialized)
+@MainActor
+struct SyncManagerTests {
+
+    let syncManager = SyncManager.shared
+
+    init() async throws {
+        // テストごとにインメモリRealmを設定（syncData内でRealmManager.shared.saveItemが呼ばれる分岐を検証するため）
+        RealmManager.shared.setupInMemoryRealm()
+    }
+
+    // MARK: - issue #26: 削除の同期伝播テスト
+
+    @Test(
+        "syncData - ローカルでオフライン削除されたレコード（isDeleted=true, updated_atが新しい）は、Firebase側の古い未削除コピーで上書きされず、削除がFirebaseへ反映される"
+    )
+    func syncData_localDeletionNewerThanFirebase_propagatesDeleteToFirebase() async throws {
+        let id = "g-local-delete"
+        let oldDate = Date().addingTimeInterval(-3600)
+        let newDate = Date()
+
+        // Firebase側はまだ削除前の古いコピー
+        let firebaseGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
+        firebaseGroup.updated_at = oldDate
+        firebaseGroup.isDeleted = false
+
+        // ローカルはオフラインで論理削除済み（markAsDeletedによりupdated_atが更新されている想定）
+        let realmGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
+        realmGroup.updated_at = newDate
+        realmGroup.isDeleted = true
+
+        var updateFirebaseCalledWith: Group?
+        var saveToFirebaseCalled = false
+
+        try await syncManager.syncData(
+            getFirebaseData: { [firebaseGroup] },
+            getRealmData: { [realmGroup] },
+            saveToFirebase: { _ in saveToFirebaseCalled = true },
+            updateFirebase: { item in updateFirebaseCalledWith = item }
+        )
+
+        // Realm側の削除済みレコード（isDeleted=true）がFirebaseへの更新として反映される
+        #expect(updateFirebaseCalledWith != nil)
+        #expect(updateFirebaseCalledWith?.isDeleted == true)
+        #expect(saveToFirebaseCalled == false)
+    }
+
+    @Test(
+        "syncData - Firebase側で削除された（isDeleted=true, updated_atが新しい）レコードは、Realm側にも削除として反映される（saveItem経由でisDeletedを含めて上書きされる）"
+    )
+    func syncData_firebaseDeletionNewerThanRealm_propagatesDeleteToRealm() async throws {
+        let id = "g-firebase-delete"
+        let oldDate = Date().addingTimeInterval(-3600)
+        let newDate = Date()
+
+        // ローカルはまだ削除前（未削除、古い更新日時）
+        let realmGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
+        realmGroup.updated_at = oldDate
+        realmGroup.isDeleted = false
+        try RealmManager.shared.saveItem(realmGroup)
+
+        // Firebase側は他デバイスでオンライン削除済み（isDeleted=true, updated_atが新しい）
+        let firebaseGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
+        firebaseGroup.updated_at = newDate
+        firebaseGroup.isDeleted = true
+
+        try await syncManager.syncData(
+            getFirebaseData: { [firebaseGroup] },
+            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Group.self) },
+            saveToFirebase: { _ in Issue.record("saveToFirebaseは呼ばれないはず") },
+            updateFirebase: { _ in Issue.record("updateFirebaseは呼ばれないはず") }
+        )
+
+        // Realm側にFirebaseの削除済みコピーが保存され、isDeleted=trueとなる
+        let rawGroup = RealmManager.shared.getRawObjectById(id: id, type: Group.self)
+        #expect(rawGroup != nil)
+        #expect(rawGroup?.isDeleted == true)
+
+        RealmManager.shared.clearAll()
+    }
+
+    @Test("syncData - Realmにのみ存在する新規データはFirebaseへ保存される（既存ロジックの回帰確認）")
+    func syncData_onlyInRealm_savesToFirebase() async throws {
+        let realmOnlyGroup = Group(groupID: "g-only-realm", title: "G", color: 0, order: 0, created_at: Date())
+
+        var saveToFirebaseCalledWith: Group?
+
+        try await syncManager.syncData(
+            getFirebaseData: { [] },
+            getRealmData: { [realmOnlyGroup] },
+            saveToFirebase: { item in saveToFirebaseCalledWith = item },
+            updateFirebase: { _ in Issue.record("updateFirebaseは呼ばれないはず") }
+        )
+
+        #expect(saveToFirebaseCalledWith?.groupID == "g-only-realm")
+    }
+
+    @Test("syncData - Firebaseにのみ存在するデータはRealmへ保存される（既存ロジックの回帰確認）")
+    func syncData_onlyInFirebase_savesToRealm() async throws {
+        let firebaseOnlyGroup = Group(groupID: "g-only-firebase", title: "G", color: 0, order: 0, created_at: Date())
+
+        try await syncManager.syncData(
+            getFirebaseData: { [firebaseOnlyGroup] },
+            getRealmData: { [] },
+            saveToFirebase: { _ in Issue.record("saveToFirebaseは呼ばれないはず") },
+            updateFirebase: { _ in Issue.record("updateFirebaseは呼ばれないはず") }
+        )
+
+        let rawGroup = RealmManager.shared.getRawObjectById(id: "g-only-firebase", type: Group.self)
+        #expect(rawGroup != nil)
+        #expect(rawGroup?.groupID == "g-only-firebase")
+
+        RealmManager.shared.clearAll()
+    }
+}

--- a/SportsNote_iOSTests/Managers/SyncManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/SyncManagerTests.swift
@@ -18,50 +18,61 @@ struct SyncManagerTests {
     let syncManager = SyncManager.shared
 
     init() async throws {
-        // テストごとにインメモリRealmを設定（syncData内でRealmManager.shared.saveItemが呼ばれる分岐を検証するため）
+        // テストごとにインメモリRealmを設定
+        // getFirebaseData/saveToFirebase/updateFirebaseのみスタブに差し替え、
+        // getRealmDataは本番実装（RealmManager.shared.getDataListIncludingDeleted）を
+        // そのまま経由させることで、SyncManager.syncGroup内の実際の配線（isDeleted復活バグ対策）を検証する
         RealmManager.shared.setupInMemoryRealm()
     }
 
-    // MARK: - issue #26: 削除の同期伝播テスト
+    // MARK: - issue #26: 削除の同期伝播テスト（syncGroupの本番配線を経由）
 
     @Test(
-        "syncData - ローカルでオフライン削除されたレコード（isDeleted=true, updated_atが新しい）は、Firebase側の古い未削除コピーで上書きされず、削除がFirebaseへ反映される"
+        "syncGroup - ローカルでオフライン削除されたレコード（isDeleted=true, updated_atが新しい）は、Firebase側の古い未削除コピーで上書きされず、削除がFirebaseへ反映される"
     )
-    func syncData_localDeletionNewerThanFirebase_propagatesDeleteToFirebase() async throws {
+    func syncGroup_localDeletionNewerThanFirebase_propagatesDeleteToFirebase() async throws {
         let id = "g-local-delete"
         let oldDate = Date().addingTimeInterval(-3600)
-        let newDate = Date()
 
-        // Firebase側はまだ削除前の古いコピー
+        // ローカルはオフラインで論理削除済み（実際にRealmへ保存し、logicalDeleteでupdated_atも更新させる）
+        let realmGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
+        realmGroup.updated_at = oldDate
+        try RealmManager.shared.saveItem(realmGroup)
+        try RealmManager.shared.logicalDelete(id: id, type: Group.self)
+
+        // Firebase側はまだ削除前の古いコピー（isDeleted=false, updated_atが古いまま）
         let firebaseGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
         firebaseGroup.updated_at = oldDate
         firebaseGroup.isDeleted = false
 
-        // ローカルはオフラインで論理削除済み（markAsDeletedによりupdated_atが更新されている想定）
-        let realmGroup = Group(groupID: id, title: "G", color: 0, order: 0, created_at: oldDate)
-        realmGroup.updated_at = newDate
-        realmGroup.isDeleted = true
-
         var updateFirebaseCalledWith: Group?
         var saveToFirebaseCalled = false
 
-        try await syncManager.syncData(
+        // getRealmDataは本番デフォルト（RealmManager.shared.getDataListIncludingDeleted）をそのまま使う。
+        // ここでgetDataList（isDeletedフィルタあり）に戻す退行が起きた場合、
+        // ローカル削除済みレコードがrealmMapに含まれなくなりonlyFirebaseID扱いとなって
+        // Firebase側の古いコピーで上書き（削除が復活）されるため、本テストは失敗する
+        try await syncManager.syncGroup(
             getFirebaseData: { [firebaseGroup] },
-            getRealmData: { [realmGroup] },
             saveToFirebase: { _ in saveToFirebaseCalled = true },
             updateFirebase: { item in updateFirebaseCalledWith = item }
         )
 
-        // Realm側の削除済みレコード（isDeleted=true）がFirebaseへの更新として反映される
         #expect(updateFirebaseCalledWith != nil)
         #expect(updateFirebaseCalledWith?.isDeleted == true)
         #expect(saveToFirebaseCalled == false)
+
+        // 削除復活バグが起きていないことも直接確認する
+        let rawGroup = RealmManager.shared.getRawObjectById(id: id, type: Group.self)
+        #expect(rawGroup?.isDeleted == true)
+
+        RealmManager.shared.clearAll()
     }
 
     @Test(
-        "syncData - Firebase側で削除された（isDeleted=true, updated_atが新しい）レコードは、Realm側にも削除として反映される（saveItem経由でisDeletedを含めて上書きされる）"
+        "syncGroup - Firebase側で削除された（isDeleted=true, updated_atが新しい）レコードは、Realm側にも削除として反映される（saveItem経由でisDeletedを含めて上書きされる）"
     )
-    func syncData_firebaseDeletionNewerThanRealm_propagatesDeleteToRealm() async throws {
+    func syncGroup_firebaseDeletionNewerThanRealm_propagatesDeleteToRealm() async throws {
         let id = "g-firebase-delete"
         let oldDate = Date().addingTimeInterval(-3600)
         let newDate = Date()
@@ -77,9 +88,8 @@ struct SyncManagerTests {
         firebaseGroup.updated_at = newDate
         firebaseGroup.isDeleted = true
 
-        try await syncManager.syncData(
+        try await syncManager.syncGroup(
             getFirebaseData: { [firebaseGroup] },
-            getRealmData: { try RealmManager.shared.getDataListIncludingDeleted(clazz: Group.self) },
             saveToFirebase: { _ in Issue.record("saveToFirebaseは呼ばれないはず") },
             updateFirebase: { _ in Issue.record("updateFirebaseは呼ばれないはず") }
         )
@@ -92,29 +102,30 @@ struct SyncManagerTests {
         RealmManager.shared.clearAll()
     }
 
-    @Test("syncData - Realmにのみ存在する新規データはFirebaseへ保存される（既存ロジックの回帰確認）")
-    func syncData_onlyInRealm_savesToFirebase() async throws {
+    @Test("syncGroup - Realmにのみ存在する新規データはFirebaseへ保存される（既存ロジックの回帰確認）")
+    func syncGroup_onlyInRealm_savesToFirebase() async throws {
         let realmOnlyGroup = Group(groupID: "g-only-realm", title: "G", color: 0, order: 0, created_at: Date())
+        try RealmManager.shared.saveItem(realmOnlyGroup)
 
         var saveToFirebaseCalledWith: Group?
 
-        try await syncManager.syncData(
+        try await syncManager.syncGroup(
             getFirebaseData: { [] },
-            getRealmData: { [realmOnlyGroup] },
             saveToFirebase: { item in saveToFirebaseCalledWith = item },
             updateFirebase: { _ in Issue.record("updateFirebaseは呼ばれないはず") }
         )
 
         #expect(saveToFirebaseCalledWith?.groupID == "g-only-realm")
+
+        RealmManager.shared.clearAll()
     }
 
-    @Test("syncData - Firebaseにのみ存在するデータはRealmへ保存される（既存ロジックの回帰確認）")
-    func syncData_onlyInFirebase_savesToRealm() async throws {
+    @Test("syncGroup - Firebaseにのみ存在するデータはRealmへ保存される（既存ロジックの回帰確認）")
+    func syncGroup_onlyInFirebase_savesToRealm() async throws {
         let firebaseOnlyGroup = Group(groupID: "g-only-firebase", title: "G", color: 0, order: 0, created_at: Date())
 
-        try await syncManager.syncData(
+        try await syncManager.syncGroup(
             getFirebaseData: { [firebaseOnlyGroup] },
-            getRealmData: { [] },
             saveToFirebase: { _ in Issue.record("saveToFirebaseは呼ばれないはず") },
             updateFirebase: { _ in Issue.record("updateFirebaseは呼ばれないはず") }
         )


### PR DESCRIPTION
## 概要
オフラインで削除した課題・グループ・対策・メモ・目標・ノートが、オンライン復帰後の全体同期（`SyncManager.syncAllData`）によって復活してしまう不具合を修正した。

### 原因
- `SyncManager.syncData`が同期比較に使うRealm側データ取得（`RealmManager.getDataList`）は`isDeleted == false`でフィルタするため、オフラインで論理削除したレコードは比較対象から除外される
- 一方Firebase側の取得（`FirebaseManager.getAllXxx`）は`isDeleted`フィルタなしで全件返すため、削除前の古いコピーが残ったままになる
- 結果、削除済みIDは「Firebaseにしかないデータ」として扱われ、`RealmManager.shared.saveItem`によってFirebase側の未削除コピーでRealmが上書きされ、削除が復活する
- さらに`RealmManager.markAsDeleted`が`updated_at`を更新していなかったため、仮に両者を比較可能にしても「更新日時が新しい方を採用する」既存ロジックだけでは削除を正しく伝播できなかった

### 対応内容
- `RealmManager`に`getDataListIncludingDeleted<T: Object>(clazz:)`を新規追加し、`SyncManager`の同期比較専用データ取得として使用（既存の`getDataList`は20箇所以上で使われているため変更していない）
- `RealmManager.markAsDeleted`で論理削除時に`updated_at`も現在時刻に更新し、削除操作がFirebase側の未削除コピーより新しいと判定されるように修正
- `SyncManager.syncGroup`〜`syncNote`の`getRealmData`を`getDataListIncludingDeleted`に差し替え
- テスト容易性のため、`syncGroup`〜`syncNote`をデフォルト引数（本番実装）付きの`internal`関数に変更し、`syncData`も`internal`に変更（実際の同期配線を経由したテストを可能にするため）

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/RealmManager.swift`: `getDataListIncludingDeleted`新規追加、`markAsDeleted`で`updated_at`更新
- `SportsNote_iOS/Model/Manager/SyncManager.swift`: `syncData`を`internal`化、`syncGroup`〜`syncNote`をデフォルト引数付き`internal`関数に変更し`getRealmData`を差し替え
- `SportsNote_iOSTests/Managers/RealmManagerTests.swift`: `getDataListIncludingDeleted`のテスト追加、`logicalDelete`のupdated_at更新テスト追加、カスケード削除のupdated_at検証追加
- `SportsNote_iOSTests/Managers/SyncManagerTests.swift`（新規）: `syncGroup`の実際の配線を経由した回帰テスト4件（ローカル削除→Firebase反映、Firebase削除→Realm反映、Realmのみ新規データ、Firebaseのみデータ）

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test`: **TEST SUCCEEDED**、445件全成功（既存439件＋新規6件）
- 回帰検知力の確認: `SyncManager.swift`内の`getDataListIncludingDeleted`を意図的に`getDataList`へ戻し、追加した回帰テストが正しく失敗することを確認済み（テストが「バグがあれば失敗する」設計になっていることを実験で検証）

## 完了条件
- [x] `SyncManager`が同期比較に使うRealm側データ取得が、論理削除済みレコードを含めて取得するように変更されている
- [x] `RealmManager.markAsDeleted`が論理削除時に`updated_at`を更新するように変更されている
- [x] オフライン削除後にオンライン復帰して同期しても、削除したレコードが復活しないことを検証する単体テストが追加されている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順（オフライン削除→オンライン復帰→同期）で問題が再現しないこと（単体テストで再現・検証）

## クロスレビュー
- 1ラウンド目: must-fix 1件（`SyncManagerTests`が`syncData`を直接呼び出しており、実際の修正箇所`syncGroup`〜`syncNote`内の差し替えを経由せず検証力がなかった）、should-fix 1件（カスケード削除時のupdated_at未検証）を指摘。両方修正し再レビュー
- 2ラウンド目: 指摘なし、合格

Closes #26