### PR TITLE
Fix: FreeNoteViewのローディング表示を多言語化ルールに準拠させる

### DIFF
--- a/SportsNote_iOS/View/Note/FreeNoteView.swift
+++ b/SportsNote_iOS/View/Note/FreeNoteView.swift
@@ -13,7 +13,7 @@ struct FreeNoteView: View {
             ZStack {
                 if viewModel.isLoading {
                     VStack {
-                        Text("Loading note...")
+                        Text(LocalizedStrings.loading)
                             .foregroundColor(.gray)
                             .italic()
                         ProgressView()


### PR DESCRIPTION
## 概要
`FreeNoteView.swift`のローディング表示テキストがハードコードされた英語文字列（`"Loading note..."`）になっており、多言語化ルール（CLAUDE.md「すべてのユーザー向け文字列はLocalizable.stringsで定義する必要がある」）に反していたため、既存の`LocalizedStrings.loading`経由の表示に置き換えた。

Closes #13

## 変更ファイル一覧
- `SportsNote_iOS/View/Note/FreeNoteView.swift`（1行変更: `Text("Loading note...")` → `Text(LocalizedStrings.loading)`）

## ビルド・テスト結果
- swift-format: 正常完了（対象ファイルに差分なし、既存フォーマット済み）
- ビルド: BUILD SUCCEEDED（警告0件、iPhone 16eシミュレータ `id=F0355670-E20E-41A6-A5B9-B41E21EC87CB`）
- テスト: TEST SUCCEEDED（439件全成功）

## 完了条件チェックリスト
- [x] `FreeNoteView.swift`のハードコード文字列が`LocalizedStrings.loading`経由の表示に置き換えられている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー
独立コンテキストのレビュアーが実装差分・ビルド・テストを独立に再確認し、指摘なしで合格（1ラウンド目で完了）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)