### PR TITLE
Fix: 旧データマイグレーションでmarkOldXxxDeleted失敗時にTask/Target/Noteが重複作成される問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/MigrationDedupeGuard.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationDedupeGuard.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// 旧ドキュメント単位でのマイグレーション重複実行を防ぐガード
+///
+/// `MigrationManager.migrateAll()`は「新形式への変換・保存（migrate）」と
+/// 「旧ドキュメントの削除フラグ更新（markDeleted）」を別々のFirestore操作として実行しており、
+/// migrateが成功した直後にmarkDeletedだけが失敗すると、次回のマイグレーション再実行時に
+/// 同一の旧ドキュメントが再度migrateされ、新規IDで重複レコードが作成されてしまう。
+///
+/// このガードは、旧ドキュメントIDごとに「migrate済みかどうか」をUserDefaultsに記録し、
+/// 既にmigrate済みの場合はmigrateをスキップしてmarkDeletedのみ再試行することで、
+/// 同一旧ドキュメントに対するmigrateの重複実行を防ぐ。
+/// Firestore/Realmのいずれにも依存しないため、単体テストが容易な独立コンポーネントとして切り出している。
+/// 呼び出し元の`MigrationManager`が`@MainActor`のため、クロージャの受け渡しで
+/// アクター境界を跨がないよう本型自体も`@MainActor`にしている。
+@MainActor
+struct MigrationDedupeGuard {
+
+    private func key(entity: String, documentID: String) -> String {
+        "migratedOldDoc_\(entity)_\(documentID)"
+    }
+
+    /// 指定した旧ドキュメントが既にmigrate済みかどうか
+    func isAlreadyMigrated(entity: String, documentID: String) -> Bool {
+        UserDefaultsManager.get(key: key(entity: entity, documentID: documentID), defaultValue: false)
+    }
+
+    /// 指定した旧ドキュメントをmigrate済みとして記録する
+    func markMigrated(entity: String, documentID: String) {
+        UserDefaultsManager.set(key: key(entity: entity, documentID: documentID), value: true)
+    }
+
+    /// 指定した旧ドキュメントのmigrate済みフラグを削除する
+    func clearMigrated(entity: String, documentID: String) {
+        UserDefaultsManager.remove(key: key(entity: entity, documentID: documentID))
+    }
+
+    /// migrate → (成功したら)migrate済みフラグ記録 → markDeleted → (成功したら)フラグ削除、の順で実行する
+    ///
+    /// 既にmigrate済みフラグが立っている場合はmigrateをスキップし、markDeletedのみ再試行する。
+    /// これにより、migrate成功後にmarkDeletedだけが失敗して再実行された場合でも、
+    /// migrateが2度実行されることはない。
+    ///
+    /// - Parameters:
+    ///   - entity: エンティティ種別を表す識別子（"Task"/"Target"/"Note"等）。旧ドキュメントIDと組み合わせてフラグキーを構成する
+    ///   - documentID: 旧Firestoreドキュメントのドキュメント ID
+    ///   - migrate: 新形式への変換・保存処理
+    ///   - markDeleted: 旧ドキュメントの削除フラグ更新処理
+    func run(
+        entity: String,
+        documentID: String,
+        migrate: () async throws -> Void,
+        markDeleted: () async throws -> Void
+    ) async throws {
+        if !isAlreadyMigrated(entity: entity, documentID: documentID) {
+            try await migrate()
+            markMigrated(entity: entity, documentID: documentID)
+        }
+        try await markDeleted()
+        clearMigrated(entity: entity, documentID: documentID)
+    }
+}

--- a/SportsNote_iOS/Model/Manager/MigrationManager.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationManager.swift
@@ -9,6 +9,7 @@ final class MigrationManager {
 
     static let shared = MigrationManager()
     private let db = Firestore.firestore()
+    private let dedupeGuard = MigrationDedupeGuard()
 
     private init() {}
 
@@ -30,8 +31,12 @@ final class MigrationManager {
         print("OldTask変換開始")
         let oldTaskDocs = try await fetchOldTaskDocuments()
         for doc in oldTaskDocs {
-            try await migrateTask(data: doc.data())
-            try await markOldTaskDeleted(documentID: doc.documentID)
+            try await dedupeGuard.run(
+                entity: "Task",
+                documentID: doc.documentID,
+                migrate: { try await self.migrateTask(data: doc.data()) },
+                markDeleted: { try await self.markOldTaskDeleted(documentID: doc.documentID) }
+            )
         }
         print("OldTask変換終了: \(oldTaskDocs.count)件")
 
@@ -43,8 +48,12 @@ final class MigrationManager {
                 print("OldTarget変換開始")
                 let docs = try await fetchOldTargetDocuments()
                 for doc in docs {
-                    try await migrateTarget(data: doc.data())
-                    try await markOldTargetDeleted(documentID: doc.documentID)
+                    try await self.dedupeGuard.run(
+                        entity: "Target",
+                        documentID: doc.documentID,
+                        migrate: { try await self.migrateTarget(data: doc.data()) },
+                        markDeleted: { try await self.markOldTargetDeleted(documentID: doc.documentID) }
+                    )
                 }
                 print("OldTarget変換終了: \(docs.count)件")
             }
@@ -65,8 +74,12 @@ final class MigrationManager {
         print("OldNote変換開始")
         let oldNoteDocs = try await fetchOldNoteDocuments()
         for doc in oldNoteDocs {
-            try await migrateNote(data: doc.data())
-            try await markOldNoteDeleted(documentID: doc.documentID)
+            try await dedupeGuard.run(
+                entity: "Note",
+                documentID: doc.documentID,
+                migrate: { try await self.migrateNote(data: doc.data()) },
+                markDeleted: { try await self.markOldNoteDeleted(documentID: doc.documentID) }
+            )
         }
         print("OldNote変換終了: \(oldNoteDocs.count)件")
 
@@ -174,7 +187,7 @@ final class MigrationManager {
 
         // 未分類グループに割り当て（旧データにグループ概念なし）
         if let groups = try? RealmManager.shared.getDataList(clazz: Group.self),
-           let uncategorized = groups.first
+            let uncategorized = groups.first
         {
             task.groupID = uncategorized.groupID
         } else {
@@ -328,7 +341,7 @@ final class MigrationManager {
         switch noteTypeStr {
         case "練習記録": noteType = NoteType.practice.rawValue
         case "大会記録": noteType = NoteType.tournament.rawValue
-        default:         noteType = NoteType.practice.rawValue
+        default: noteType = NoteType.practice.rawValue
         }
 
         let note = Note()
@@ -431,10 +444,10 @@ final class MigrationManager {
     /// 旧天気文字列（"晴れ"/"くもり"/"雨"）を Weather enum の rawValue に変換
     private func convertWeather(from weatherString: String) -> Int {
         switch weatherString {
-        case "晴れ":   return Weather.sunny.rawValue
+        case "晴れ": return Weather.sunny.rawValue
         case "くもり": return Weather.cloudy.rawValue
-        case "雨":     return Weather.rainy.rawValue
-        default:       return Weather.sunny.rawValue
+        case "雨": return Weather.rainy.rawValue
+        default: return Weather.sunny.rawValue
         }
     }
 }

--- a/SportsNote_iOSTests/Managers/MigrationDedupeGuardTests.swift
+++ b/SportsNote_iOSTests/Managers/MigrationDedupeGuardTests.swift
@@ -1,0 +1,156 @@
+//
+//  MigrationDedupeGuardTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/07/27.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// テスト用のエラー
+private struct StubError: Error {}
+
+@Suite("MigrationDedupeGuard Tests", .serialized)
+@MainActor
+struct MigrationDedupeGuardTests {
+
+    init() {
+        // 前のテストの残留状態をリセットする
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("run - migrate/markDeletedが共に成功すると、完了後はmigrate済みフラグが残らない")
+    func run_bothSucceed_clearsFlagAfterCompletion() async throws {
+        let guardInstance = MigrationDedupeGuard()
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+
+        try await guardInstance.run(
+            entity: "Task",
+            documentID: "doc1",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: { markDeletedCallCount += 1 }
+        )
+
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 1)
+        #expect(guardInstance.isAlreadyMigrated(entity: "Task", documentID: "doc1") == false)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test(
+        "run - migrate成功後にmarkDeletedだけ失敗して再実行しても、migrateは再実行されない（issue #30の再現・修正確認）"
+    )
+    func run_markDeletedFailsThenRetried_doesNotDuplicateMigrate() async throws {
+        let guardInstance = MigrationDedupeGuard()
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+
+        // 1回目: migrateは成功するが、markDeletedがネットワーク断等で失敗するケースを再現
+        await #expect(throws: StubError.self) {
+            try await guardInstance.run(
+                entity: "Task",
+                documentID: "doc1",
+                migrate: { migrateCallCount += 1 },
+                markDeleted: {
+                    markDeletedCallCount += 1
+                    throw StubError()
+                }
+            )
+        }
+
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 1)
+        // markDeletedが失敗した時点では、migrate済みフラグが残っていること（次回のスキップ判定に使われる）
+        #expect(guardInstance.isAlreadyMigrated(entity: "Task", documentID: "doc1") == true)
+
+        // 2回目: 次回のmigrateAll()再実行を模す。今度はmarkDeletedが成功する
+        try await guardInstance.run(
+            entity: "Task",
+            documentID: "doc1",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: { markDeletedCallCount += 1 }
+        )
+
+        // ガードがなければここでmigrateCallCountは2になり重複変換が発生してしまう
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 2)
+        // 最終的に成功したので、フラグは掃除されていること
+        #expect(guardInstance.isAlreadyMigrated(entity: "Task", documentID: "doc1") == false)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("run - migrate自体が失敗した場合はフラグが立たず、次回もmigrateから再実行される")
+    func run_migrateFails_doesNotMarkAsMigrated() async throws {
+        let guardInstance = MigrationDedupeGuard()
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+
+        await #expect(throws: StubError.self) {
+            try await guardInstance.run(
+                entity: "Task",
+                documentID: "doc1",
+                migrate: {
+                    migrateCallCount += 1
+                    throw StubError()
+                },
+                markDeleted: { markDeletedCallCount += 1 }
+            )
+        }
+
+        #expect(migrateCallCount == 1)
+        // migrateが失敗した場合、markDeletedは呼ばれない
+        #expect(markDeletedCallCount == 0)
+        #expect(guardInstance.isAlreadyMigrated(entity: "Task", documentID: "doc1") == false)
+
+        // 次回再実行時も、migrateから再度実行されること
+        try await guardInstance.run(
+            entity: "Task",
+            documentID: "doc1",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: { markDeletedCallCount += 1 }
+        )
+
+        #expect(migrateCallCount == 2)
+        #expect(markDeletedCallCount == 1)
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("run - entityが異なれば同じdocumentIDでも独立してガードされる")
+    func run_differentEntitySameDocumentID_isIndependentlyGuarded() async throws {
+        let guardInstance = MigrationDedupeGuard()
+        var taskMigrateCallCount = 0
+        var targetMigrateCallCount = 0
+
+        // Task側はmarkDeletedが失敗してフラグが残る
+        await #expect(throws: StubError.self) {
+            try await guardInstance.run(
+                entity: "Task",
+                documentID: "sameID",
+                migrate: { taskMigrateCallCount += 1 },
+                markDeleted: { throw StubError() }
+            )
+        }
+
+        // Target側は同じdocumentIDだが、Taskとは無関係にmigrateが実行されること
+        try await guardInstance.run(
+            entity: "Target",
+            documentID: "sameID",
+            migrate: { targetMigrateCallCount += 1 },
+            markDeleted: {}
+        )
+
+        #expect(taskMigrateCallCount == 1)
+        #expect(targetMigrateCallCount == 1)
+        #expect(guardInstance.isAlreadyMigrated(entity: "Task", documentID: "sameID") == true)
+        #expect(guardInstance.isAlreadyMigrated(entity: "Target", documentID: "sameID") == false)
+
+        UserDefaultsManager.clearAll()
+    }
+}


### PR DESCRIPTION
## 概要
旧アプリ（UIKit版）データのマイグレーション処理（`MigrationManager.migrateAll()`）で、新形式データの保存後に旧データの削除フラグ更新（`markOldXxxDeleted`）だけが失敗すると、次回起動時に同一データが重複して再作成される問題を修正した。

### 原因
- `migrateAll()`は各旧ドキュメントに対し「新形式への変換・保存（`migrateXxx`）」と「旧ドキュメントの削除フラグ更新（`markOldXxxDeleted`）」を別々のFirestore操作として順に実行している
- `migrateTask`/`migrateTarget`は呼び出しごとに`UUIDGenerator.generateID()`で新規UUIDを採番するため、`markOldXxxDeleted`だけがネットワーク断等で失敗して`migrateAll()`が例外throwすると、`migrationV1Completed`フラグは立たないまま
- 次回起動時、旧ドキュメントの`isDeleted`が更新されていないため同一ドキュメントが再取得され、`migrateTask`/`migrateTarget`が再実行されて新しいUUIDで重複レコードが作成される
- 事前調査で、`migrateNote`（noteIDが旧Int IDから決定論的に生成される）と`migrateFreeNote`（既存レコード検索により同一IDを再利用）は`RealmManager.saveItem`のupsert（`realm.add(item, update: .modified)`）・`FirebaseManager.saveXxx`のdocumentID固定（`"\(userID)_\(entityID)"`）により実質的に既に安全であることを確認したが、コードの一貫性・将来の頑健性のためTask/Target/Noteの3ループすべてに同じガードを適用した

### 対応内容
- Firestore/Realmに依存しない独立コンポーネント`MigrationDedupeGuard`を新規追加し、旧ドキュメントID単位で「migrate済みかどうか」をUserDefaults上の動的キーに記録
- `migrateAll()`内のTask/Target/Note各ループを、`migrateXxx`と`markOldXxxDeleted`を`dedupeGuard.run(...)`経由で呼び出すように変更。既にmigrate済みの場合は`migrateXxx`をスキップし`markOldXxxDeleted`のみ再試行する
- `MigrationDedupeGuard`は呼び出し元`MigrationManager`が`@MainActor`のため、Swift Concurrencyのsendable検査に対応して`@MainActor`にしている

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/MigrationDedupeGuard.swift`（新規）: 重複防止ガードロジック
- `SportsNote_iOS/Model/Manager/MigrationManager.swift`: Task/Target/Noteの3ループを`dedupeGuard.run`経由に変更（末尾のインデント・switch整列差分はCLAUDE.md記載のswift-format必須実行による副作用で、意味的な変更はなし）
- `SportsNote_iOSTests/Managers/MigrationDedupeGuardTests.swift`（新規）: `MigrationDedupeGuard`の単体テスト4件（正常系、migrate成功後にmarkDeleted失敗→再実行で重複しないことの再現確認、migrate自体の失敗、entity違いでの独立性）

## ビルド・テスト結果
- swift-format: 正常完了
- ビルド: BUILD SUCCEEDED（警告0件、`id=F0355670-E20E-41A6-A5B9-B41E21EC87CB`のiPhone 16eシミュレータ明示指定）
- テスト: TEST SUCCEEDED（443件全成功、既存439件＋新規4件）

## 完了条件チェックリスト
- [x] `migrateXxx`成功後に`markOldXxxDeleted`が失敗しても、次回のマイグレーション再実行で同一データが重複作成されないことを確認できる（`MigrationDedupeGuard`のロジックで保証、単体テストで再現・検証）
- [x] 上記シナリオを再現する単体テストを追加し、修正後にテストが成功する
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で問題が再現しないこと（`MigrationDedupeGuardTests.run_markDeletedFailsThenRetried_doesNotDuplicateMigrate`で、ガードがなければmigrate呼び出し回数が2になってしまう箇所を明示的に検証）

## クロスレビュー結果
独立コンテキストのレビュアーが実装差分・ビルド・テストを独立に再確認（must-fixなし、1ラウンドで合格）。以下のshould-fix/nit指摘が残っているが、実害は確認されておらず今回のスコープでは対応を見送る:

- **should-fix**: `MigrationDedupeGuard`単体のテストのみで、`MigrationManager.migrateAll()`のTask/Target/Note3ループが実際に`dedupeGuard.run`経由になっているかを検証する配線テストが存在しない。`MigrationManager`はFirestoreへの直接依存（`@MainActor`かつ`Firestore.firestore()`）を持ちテスト環境でインスタンス化するとクラッシュするため、同程度の手間でのテスト容易性確保は本PRのスコープでは見送った。
- **nit**: `MigrationDedupeGuardTests`の`init()`で`UserDefaultsManager.clearAll()`（全キー削除）を呼んでいる点は、既存の多数のテストスイート（`UserDefaultsManagerTests`等）が既に採用しているパターンを踏襲したもの（issue #11/#15で指摘済みの既知の技術的負債で、本PR固有の新規劣化ではない）。

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)