### PR TITLE
Fix: 旧データマイグレーションで必須フィールド欠損時にTask/Target/Note/フリーノートが恒久的に消失する問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Error/MigrationError.swift
+++ b/SportsNote_iOS/Model/Error/MigrationError.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// 旧データマイグレーション処理専用のエラー型
+/// `MigrationManager`の各migrateXxxメソッドが必須フィールドの欠損・型不一致を検知した際にthrowする
+enum MigrationError: Error {
+    /// 旧Firestoreドキュメントの必須フィールドが欠損・型不一致で変換できなかった
+    case invalidData(entity: String, documentID: String)
+}

--- a/SportsNote_iOS/Model/Manager/MigrationManager.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationManager.swift
@@ -9,6 +9,7 @@ final class MigrationManager {
 
     static let shared = MigrationManager()
     private let db = Firestore.firestore()
+    private let stepRunner = MigrationStepRunner()
 
     private init() {}
 
@@ -30,8 +31,12 @@ final class MigrationManager {
         print("OldTask変換開始")
         let oldTaskDocs = try await fetchOldTaskDocuments()
         for doc in oldTaskDocs {
-            try await migrateTask(data: doc.data())
-            try await markOldTaskDeleted(documentID: doc.documentID)
+            try await stepRunner.run(
+                entity: "Task",
+                documentID: doc.documentID,
+                migrate: { try await self.migrateTask(documentID: doc.documentID, data: doc.data()) },
+                markDeleted: { try await self.markOldTaskDeleted(documentID: doc.documentID) }
+            )
         }
         print("OldTask変換終了: \(oldTaskDocs.count)件")
 
@@ -43,16 +48,24 @@ final class MigrationManager {
                 print("OldTarget変換開始")
                 let docs = try await fetchOldTargetDocuments()
                 for doc in docs {
-                    try await migrateTarget(data: doc.data())
-                    try await markOldTargetDeleted(documentID: doc.documentID)
+                    try await stepRunner.run(
+                        entity: "Target",
+                        documentID: doc.documentID,
+                        migrate: { try await self.migrateTarget(documentID: doc.documentID, data: doc.data()) },
+                        markDeleted: { try await self.markOldTargetDeleted(documentID: doc.documentID) }
+                    )
                 }
                 print("OldTarget変換終了: \(docs.count)件")
             }
             group.addTask { [self] in
                 print("OldFreeNote変換開始")
                 if let doc = try await fetchOldFreeNoteDocument() {
-                    try await migrateFreeNote(data: doc.data())
-                    try await deleteOldFreeNoteDocument(userID: currentUserID)
+                    try await stepRunner.run(
+                        entity: "FreeNote",
+                        documentID: doc.documentID,
+                        migrate: { try await self.migrateFreeNote(documentID: doc.documentID, data: doc.data()) },
+                        markDeleted: { try await self.deleteOldFreeNoteDocument(userID: currentUserID) }
+                    )
                     print("OldFreeNote変換終了: 1件")
                 } else {
                     print("OldFreeNote変換終了: 0件（データなし）")
@@ -65,8 +78,12 @@ final class MigrationManager {
         print("OldNote変換開始")
         let oldNoteDocs = try await fetchOldNoteDocuments()
         for doc in oldNoteDocs {
-            try await migrateNote(data: doc.data())
-            try await markOldNoteDeleted(documentID: doc.documentID)
+            try await stepRunner.run(
+                entity: "Note",
+                documentID: doc.documentID,
+                migrate: { try await self.migrateNote(documentID: doc.documentID, data: doc.data()) },
+                markDeleted: { try await self.markOldNoteDeleted(documentID: doc.documentID) }
+            )
         }
         print("OldNote変換終了: \(oldNoteDocs.count)件")
 
@@ -148,13 +165,13 @@ final class MigrationManager {
 
     /// 旧課題データを TaskData + Measures + Memo に変換して保存
     /// measuresData: [対策タイトル: [[有効性コメント: ノートID(Int)]]]
-    private func migrateTask(data: [String: Any]) async throws {
+    private func migrateTask(documentID: String, data: [String: Any]) async throws {
         guard
             let title = data["taskTitle"] as? String,
             let cause = data["taskCause"] as? String,
             let isAchieve = data["taskAchievement"] as? Bool,
             let isDeleted = data["isDeleted"] as? Bool
-        else { return }
+        else { throw MigrationError.invalidData(entity: "Task", documentID: documentID) }
 
         let order = data["order"] as? Int ?? 0
         let userID = getUserID()
@@ -174,7 +191,7 @@ final class MigrationManager {
 
         // 未分類グループに割り当て（旧データにグループ概念なし）
         if let groups = try? RealmManager.shared.getDataList(clazz: Group.self),
-           let uncategorized = groups.first
+            let uncategorized = groups.first
         {
             task.groupID = uncategorized.groupID
         } else {
@@ -229,13 +246,13 @@ final class MigrationManager {
 
     /// 旧目標データを Target に変換して保存
     /// month == 13 は年間目標を示す旧仕様
-    private func migrateTarget(data: [String: Any]) async throws {
+    private func migrateTarget(documentID: String, data: [String: Any]) async throws {
         guard
             let year = data["year"] as? Int,
             let month = data["month"] as? Int,
             let detail = data["detail"] as? String,
             let isDeleted = data["isDeleted"] as? Bool
-        else { return }
+        else { throw MigrationError.invalidData(entity: "Target", documentID: documentID) }
 
         let userID = getUserID()
         let now = Date()
@@ -257,11 +274,11 @@ final class MigrationManager {
 
     /// 旧フリーノートデータを Note(free) に変換して保存
     /// Realm に既存のフリーノートがあれば内容を上書き、なければ新規作成
-    private func migrateFreeNote(data: [String: Any]) async throws {
+    private func migrateFreeNote(documentID: String, data: [String: Any]) async throws {
         guard
             let title = data["title"] as? String,
             let detail = data["detail"] as? String
-        else { return }
+        else { throw MigrationError.invalidData(entity: "FreeNote", documentID: documentID) }
 
         let userID = getUserID()
         let now = Date()
@@ -300,7 +317,7 @@ final class MigrationManager {
 
     /// 旧ノートデータを Note(practice/tournament) に変換して保存
     /// noteID は旧 Int を String に変換して保持（Memo との紐付けを維持するため）
-    private func migrateNote(data: [String: Any]) async throws {
+    private func migrateNote(documentID: String, data: [String: Any]) async throws {
         guard
             let oldNoteIDInt = data["noteID"] as? Int,
             let noteTypeStr = data["noteType"] as? String,
@@ -312,7 +329,7 @@ final class MigrationManager {
             let physicalCondition = data["physicalCondition"] as? String,
             let reflection = data["reflection"] as? String,
             let isDeleted = data["isDeleted"] as? Bool
-        else { return }
+        else { throw MigrationError.invalidData(entity: "Note", documentID: documentID) }
 
         let purpose = data["purpose"] as? String ?? ""
         let detail = data["detail"] as? String ?? ""
@@ -328,7 +345,7 @@ final class MigrationManager {
         switch noteTypeStr {
         case "練習記録": noteType = NoteType.practice.rawValue
         case "大会記録": noteType = NoteType.tournament.rawValue
-        default:         noteType = NoteType.practice.rawValue
+        default: noteType = NoteType.practice.rawValue
         }
 
         let note = Note()
@@ -431,10 +448,10 @@ final class MigrationManager {
     /// 旧天気文字列（"晴れ"/"くもり"/"雨"）を Weather enum の rawValue に変換
     private func convertWeather(from weatherString: String) -> Int {
         switch weatherString {
-        case "晴れ":   return Weather.sunny.rawValue
+        case "晴れ": return Weather.sunny.rawValue
         case "くもり": return Weather.cloudy.rawValue
-        case "雨":     return Weather.rainy.rawValue
-        default:       return Weather.sunny.rawValue
+        case "雨": return Weather.rainy.rawValue
+        default: return Weather.sunny.rawValue
         }
     }
 }

--- a/SportsNote_iOS/Model/Manager/MigrationStepRunner.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationStepRunner.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// 旧データマイグレーションの「変換→旧データ削除」という制御フローを、
+/// `MigrationManager`（Firebase依存）から切り離して独立にテストできるようにするための実行役
+///
+/// 変換（migrate）が`MigrationError`で失敗した場合、旧データ削除（markDeleted）を呼ばずに
+/// 旧データを保持したまま処理を継続させる（issue #35: 必須フィールド欠損によるデータ恒久消失の防止）。
+/// `MigrationError`以外のエラー（Firestore通信エラー等）はそのままrethrowし、
+/// 既存の異常系挙動（`migrateAll()`全体の中断）を変えない。
+@MainActor
+struct MigrationStepRunner {
+
+    /// ログ出力先（テストでは注入して呼び出し内容を検証する）
+    private let logger: (String) -> Void
+
+    init(logger: @escaping (String) -> Void = { print($0) }) {
+        self.logger = logger
+    }
+
+    /// 1件の旧データについて、変換→旧データ削除を実行する
+    /// - Parameters:
+    ///   - entity: ログ出力用のエンティティ名（例: "Task"）
+    ///   - documentID: ログ出力用の旧ドキュメントID
+    ///   - migrate: 変換処理（`MigrationError.invalidData`をthrowした場合はスキップ扱いとする）
+    ///   - markDeleted: 変換成功時にのみ実行する旧データ削除処理
+    /// - Throws: `migrate`/`markDeleted`が`MigrationError`以外のエラーをthrowした場合、そのまま伝播する
+    func run(
+        entity: String,
+        documentID: String,
+        migrate: () async throws -> Void,
+        markDeleted: () async throws -> Void
+    ) async throws {
+        do {
+            try await migrate()
+        } catch let error as MigrationError {
+            logger("旧\(entity)データの変換に失敗したため、旧データを保持します: documentID=\(documentID), error=\(error)")
+            return
+        }
+        try await markDeleted()
+    }
+}

--- a/SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift
+++ b/SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift
@@ -1,0 +1,116 @@
+//
+//  MigrationStepRunnerTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/07/27.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// `MigrationManager`はFirebaseFirestoreに直接依存し、Firebase未設定のテスト環境では
+/// インスタンス化するとクラッシュするため、`MigrationManager`/`FirebaseManager`には一切触れず
+/// `MigrationStepRunner`単体をスタブクロージャで検証する（issue #35）。
+@Suite("MigrationStepRunner Tests")
+@MainActor
+struct MigrationStepRunnerTests {
+
+    private enum StubError: Error {
+        case network
+    }
+
+    @Test("migrate/markDeletedが共に成功する場合、両方が1回ずつ呼ばれる")
+    func run_bothSucceed_callsMigrateAndMarkDeletedOnce() async throws {
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+        var loggedMessages: [String] = []
+
+        let runner = MigrationStepRunner(logger: { loggedMessages.append($0) })
+
+        try await runner.run(
+            entity: "Task",
+            documentID: "doc1",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: { markDeletedCallCount += 1 }
+        )
+
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 1)
+        #expect(loggedMessages.isEmpty)
+    }
+
+    @Test(
+        "migrateがMigrationError.invalidDataをthrowした場合、markDeletedは呼ばれず旧データが保持される",
+        arguments: ["Task", "Target", "Note", "FreeNote"]
+    )
+    func run_migrateThrowsInvalidData_skipsMarkDeletedAndLogs(entity: String) async throws {
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+        var loggedMessages: [String] = []
+
+        let runner = MigrationStepRunner(logger: { loggedMessages.append($0) })
+
+        // MigrationErrorはstepRunner内で吸収されるため、run自体はthrowしないことも同時に検証する
+        try await runner.run(
+            entity: entity,
+            documentID: "doc-\(entity)",
+            migrate: {
+                migrateCallCount += 1
+                throw MigrationError.invalidData(entity: entity, documentID: "doc-\(entity)")
+            },
+            markDeleted: { markDeletedCallCount += 1 }
+        )
+
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 0)
+        #expect(loggedMessages.count == 1)
+        #expect(loggedMessages[0].contains(entity))
+        #expect(loggedMessages[0].contains("doc-\(entity)"))
+    }
+
+    @Test("migrateがMigrationError以外のエラーをthrowした場合、markDeletedは呼ばれずエラーが呼び出し元に伝播する")
+    func run_migrateThrowsOtherError_propagatesAndSkipsMarkDeleted() async {
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+        var loggedMessages: [String] = []
+
+        let runner = MigrationStepRunner(logger: { loggedMessages.append($0) })
+
+        await #expect(throws: StubError.self) {
+            try await runner.run(
+                entity: "Task",
+                documentID: "doc1",
+                migrate: {
+                    migrateCallCount += 1
+                    throw StubError.network
+                },
+                markDeleted: { markDeletedCallCount += 1 }
+            )
+        }
+
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 0)
+        // Firestore通信エラー等はMigrationErrorではないため、既存の異常系挙動を変えずログ出力もしない
+        #expect(loggedMessages.isEmpty)
+    }
+
+    @Test("markDeletedがエラーをthrowした場合、そのエラーが呼び出し元に伝播する")
+    func run_markDeletedThrows_propagatesError() async {
+        var migrateCallCount = 0
+
+        let runner = MigrationStepRunner()
+
+        await #expect(throws: StubError.self) {
+            try await runner.run(
+                entity: "Task",
+                documentID: "doc1",
+                migrate: { migrateCallCount += 1 },
+                markDeleted: { throw StubError.network }
+            )
+        }
+
+        #expect(migrateCallCount == 1)
+    }
+}


### PR DESCRIPTION
## 概要
`MigrationManager`の`migrateTask`/`migrateTarget`/`migrateNote`/`migrateFreeNote`は、旧Firestoreドキュメントの必須フィールドが欠損・型不一致の場合に`guard let ... else { return }`で何もエラーを出さず静かに処理を終えていた。呼び出し元の`migrateAll()`はこの早期returnを検知できず、直後に`markOldXxxDeleted`（フリーノートは物理削除の`deleteOldFreeNoteDocument`）を無条件に実行してしまい、変換に失敗したレコードが新形式データを作らないまま旧データごと恒久的に消失する不具合を修正します。

Closes #35

## 変更内容
- `SportsNote_iOS/Model/Error/MigrationError.swift`（新規）: マイグレーション変換失敗を表す`MigrationError.invalidData(entity:documentID:)`を追加
- `SportsNote_iOS/Model/Manager/MigrationStepRunner.swift`（新規）: 「変換→旧データ削除」の制御フローを`MigrationManager`（Firebase依存）から切り出した独立コンポーネント。`MigrationError`発生時は`markDeleted`をスキップして旧データを保持し、ログを出力する。`MigrationError`以外の例外はそのままrethrowし既存の異常系挙動を変えない
- `SportsNote_iOS/Model/Manager/MigrationManager.swift`: `migrateTask`/`migrateTarget`/`migrateNote`/`migrateFreeNote`の`guard let ... else { return }`を`else { throw MigrationError.invalidData(...) }`に変更し、`migrateAll()`内の4箇所（Task/Target/FreeNote/Note）を`MigrationStepRunner.run`経由の呼び出しに置き換え
- `SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift`（新規）: `MigrationManager`がFirebase依存でテスト環境でインスタンス化できない制約（issue #30対応時と同様）のため、`MigrationStepRunner`単体をスタブクロージャで検証（migrate/markDeleted双方成功、`MigrationError`発生時にmarkDeletedがスキップされログが出力される、`MigrationError`以外のエラーは伝播する、markDeleted自体の失敗も伝播する）

## 変更ファイル一覧
- `SportsNote_iOS/Model/Error/MigrationError.swift`（新規）
- `SportsNote_iOS/Model/Manager/MigrationStepRunner.swift`（新規）
- `SportsNote_iOS/Model/Manager/MigrationManager.swift`
- `SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift`（新規）

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED（警告0件、iPhone 16eシミュレータ`id=F0355670-E20E-41A6-A5B9-B41E21EC87CB`明示指定）
- `xcodebuild test`: TEST SUCCEEDED（443件全成功、新規4テストメソッド含む）
- `swift-format`適用済み

## issue完了条件チェックリスト
- [x] migrateTask/migrateTarget/migrateNote/migrateFreeNoteのいずれかで必須フィールドが欠損している場合、対応するmarkOldXxxDeleted/deleteOldFreeNoteDocumentが呼ばれず、旧データが保持されることを確認できる単体テストがある
- [x] 変換失敗が発生した場合にログが出力されることを確認できる
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で説明したデータ消失（変換失敗にもかかわらず旧データが削除される）が再現しないこと

## クロスレビュー結果
独立コンテキストのサブエージェントによるクロスレビューを実施。must-fix指摘なしで合格（1ラウンドで合格）。以下2件のshould-fix指摘が残っています（対応は見送り、将来課題として記録）。

- `MigrationManager.migrateAll()`内の4箇所（Task/Target/Note/FreeNote）すべてが実際に`MigrationStepRunner.run`経由になっているかを自動検証するテストは存在しない（`MigrationManager`がFirestore依存でテスト環境インスタンス化不可のため）。今回はレビュアーがコードを目視して4箇所とも配線されていることを確認済み。issue #30と同一の既知の制約。
- `migrateTask`内部の`guard let measuresData = ... else { return }`（Task本体保存後の付随データ用ガード、今回のissueのスコープ外）は素通りしても`markOldTaskDeleted`が無条件実行されるため、旧TaskData文書に含まれるMeasures/Memoデータはログも残さず恒久的に失われる残存リスクがある。issue本文の主目的（Task/Target/Note/FreeNote本体の消失防止）は満たしているが、将来issue化を検討する余地あり。

## 備考
- issue #30（重複作成、PR #34・未マージ）の`MigrationDedupeGuard`とは責務が異なる（重複防止 vs 消失防止）別コンポーネントとして独立実装しています。将来PR #34がマージされる際、`migrateAll()`にマージコンフリクトが生じる可能性がありますが、両者は`migrateAll()`内で入れ子にして両立可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)