### PR TITLE
Fix: CalendarView.swiftの未使用重複関数colorForWeekdayを削除

### DIFF
--- a/SportsNote_iOS/View/Target/Components/CalendarView.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarView.swift
@@ -11,7 +11,7 @@ struct CalendarView: View {
     @State private var slideDirection: CGFloat = 0  // スライド方向（-1: 左, 1: 右）
     @State private var isAnimating: Bool = false  // アニメーション中かどうか
     @ObservedObject var noteViewModel: NoteViewModel  // 親から渡されるNoteViewModel
-    @State private var datesWithPractice: Set<Date> = []   // 練習ノートがある日付のセット
+    @State private var datesWithPractice: Set<Date> = []  // 練習ノートがある日付のセット
     @State private var datesWithTournament: Set<Date> = []  // 大会ノートがある日付のセット
 
     // 曜日の配列（日曜始まり）
@@ -242,18 +242,6 @@ struct CalendarView: View {
 
     // 曜日ヘッダーの色を返す関数（0=Sunday, 6=Saturday）
     private func colorForWeekdayHeader(_ weekday: Int) -> Color {
-        switch weekday {
-        case 0:  // Sunday
-            return .red
-        case 6:  // Saturday
-            return .blue
-        default:
-            return .primary
-        }
-    }
-
-    // 曜日に応じた色を返す関数（日付セルの色）
-    private func colorForWeekday(_ weekday: Int) -> Color {
         switch weekday {
         case 0:  // Sunday
             return .red


### PR DESCRIPTION
## 概要
`SportsNote_iOS/View/Target/Components/CalendarView.swift`内で、`colorForWeekdayHeader(_:)`と実装が完全同一の未使用関数`colorForWeekday(_:)`（255-265行目）を削除した。

Closes #39

## 変更ファイル一覧
- `SportsNote_iOS/View/Target/Components/CalendarView.swift`（デッドコード削除13行、swift-formatによる空白整形1箇所）

## 実装メモ
- 削除前後で`grep -rn "colorForWeekday" --include="*.swift" .`を実行し、リポジトリ全体で`colorForWeekday(_:)`単体への参照が元々0件（呼び出し元なし）であること、削除後も`colorForWeekdayHeader`関連2箇所（呼び出し・定義）のみが残ることを確認済み。
- `colorForWeekdayHeader(_:)`自体の実装・呼び出し箇所（209行目）は変更していない。

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（`id=F0355670-E20E-41A6-A5B9-B41E21EC87CB`のiPhone 16eシミュレータ明示指定）
- `xcodebuild test`: **TEST SUCCEEDED**（439件全成功）

## 完了条件チェックリスト
- [x] `colorForWeekday(_:)`が削除されている
- [x] リポジトリ全体で`colorForWeekday`への参照がゼロであることを確認済み（`colorForWeekdayHeader`除く）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立コンテキストのレビュアーがdiff内容・grep網羅性・ビルド・テストを再実行し、申告内容と完全一致することを確認。指摘事項なし（must-fix/should-fix/nitともに0件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)