### PR TITLE
refactor: Group/Measures/TaskViewModelのorder計算処理をRealmManager.getNextOrderに集約 (#50)

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -295,6 +295,20 @@ final class RealmManager {
         }
     }
 
+    /// 汎用的な次のorder値取得メソッド（新規レコードのorder初期値算出に使用）
+    /// - Parameters:
+    ///   - clazz: 取得するデータ型のクラス（"order"プロパティを持つ必要がある）
+    ///   - predicate: 絞り込み条件（省略時はisDeleted==falseのみで絞り込み）
+    /// - Returns: 次に割り当てるべきorder値（取得に失敗した場合は0）
+    func getNextOrder<T: Object>(clazz: T.Type, predicate: NSPredicate? = nil) -> Int {
+        do {
+            let maxOrder = try getMaxOrder(clazz: clazz, predicate: predicate)
+            return (maxOrder ?? -1) + 1
+        } catch {
+            return 0
+        }
+    }
+
     /// groupIDに合致する完了した課題を取得
     /// - Parameter groupID: groupID
     /// - Returns: 完了した課題のリスト

--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -74,7 +74,7 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
         created_at: Date? = nil
     ) async -> Result<Void, SportsNoteError> {
         let newGroupID = groupID ?? UUIDGenerator.generateID()
-        let newOrder = order ?? getDefaultOrder()
+        let newOrder = order ?? RealmManager.shared.getNextOrder(clazz: Group.self)
         let newCreatedAt = created_at ?? Date()
 
         let group = Group(
@@ -111,18 +111,6 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
         } catch {
             let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-moveGroup")
             return .failure(sportsNoteError)
-        }
-    }
-
-    /// デフォルトの並び順を取得する
-    /// - Returns: 並び順
-    private func getDefaultOrder() -> Int {
-        do {
-            let maxOrder = try RealmManager.shared.getMaxOrder(clazz: Group.self)
-            return (maxOrder ?? -1) + 1
-        } catch {
-            // エラー時は0を返す（デフォルト値）
-            return 0
         }
     }
 

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -110,7 +110,12 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
         created_at: Date? = nil
     ) async -> Result<Void, SportsNoteError> {
         let newMeasuresID = measuresID ?? UUIDGenerator.generateID()
-        let newOrder = order ?? getDefaultOrderForTask(taskID: taskID)
+        let newOrder =
+            order
+            ?? RealmManager.shared.getNextOrder(
+                clazz: Measures.self,
+                predicate: NSPredicate(format: "taskID == %@", taskID)
+            )
         let newCreatedAt = created_at ?? Date()
 
         let measures = Measures(
@@ -123,21 +128,6 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
 
         let isUpdate = measuresID != nil
         return await save(measures, isUpdate: isUpdate)
-    }
-
-    /// 指定課題のデフォルトの並び順を取得する
-    /// - Parameter taskID: 課題ID
-    /// - Returns: 並び順
-    private func getDefaultOrderForTask(taskID: String) -> Int {
-        do {
-            let maxOrder = try RealmManager.shared.getMaxOrder(
-                clazz: Measures.self,
-                predicate: NSPredicate(format: "taskID == %@", taskID)
-            )
-            return (maxOrder ?? -1) + 1
-        } catch {
-            return 0
-        }
     }
 
     /// 対策保存処理（プロトコル準拠）

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -348,16 +348,10 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         } else {
             // 新規作成の場合: 新しいTaskDataを作成
             let newTaskID = UUIDGenerator.generateID()
-            let newOrder: Int
-            do {
-                let maxOrder = try RealmManager.shared.getMaxOrder(
-                    clazz: TaskData.self,
-                    predicate: NSPredicate(format: "groupID == %@", groupID)
-                )
-                newOrder = (maxOrder ?? -1) + 1
-            } catch {
-                newOrder = 0
-            }
+            let newOrder = RealmManager.shared.getNextOrder(
+                clazz: TaskData.self,
+                predicate: NSPredicate(format: "groupID == %@", groupID)
+            )
 
             return TaskData(
                 taskID: newTaskID,

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -189,6 +189,52 @@ struct RealmManagerTests {
         manager.clearAll()
     }
 
+    // MARK: - getNextOrder テスト（issue #50: order初期値算出ロジックの共通ヘルパー）
+
+    @Test("getNextOrder - データが1件もない場合は0を返す")
+    func getNextOrder_returnsZeroWhenNoData() async throws {
+        let nextOrder = manager.getNextOrder(clazz: Group.self)
+        #expect(nextOrder == 0)
+
+        manager.clearAll()
+    }
+
+    @Test("getNextOrder - 既存データがある場合は最大order+1を返す")
+    func getNextOrder_returnsMaxOrderPlusOne() async throws {
+        try manager.saveItem(Group(groupID: "g1", title: "G1", color: 0, order: 2, created_at: Date()))
+        try manager.saveItem(Group(groupID: "g2", title: "G2", color: 0, order: 5, created_at: Date()))
+
+        let nextOrder = manager.getNextOrder(clazz: Group.self)
+        #expect(nextOrder == 6)
+
+        manager.clearAll()
+    }
+
+    @Test("getNextOrder - predicateによるスコープ絞り込みが機能する")
+    func getNextOrder_scopesByPredicate() async throws {
+        let task1 = TaskData()
+        task1.taskID = "t1"
+        task1.groupID = "gA"
+        task1.order = 3
+
+        let task2 = TaskData()
+        task2.taskID = "t2"
+        task2.groupID = "gB"
+        task2.order = 99
+
+        try manager.saveItem(task1)
+        try manager.saveItem(task2)
+
+        // groupID "gA" にスコープした場合、gBの99は無視され3+1=4が返るはず
+        let nextOrderForGroupA = manager.getNextOrder(
+            clazz: TaskData.self,
+            predicate: NSPredicate(format: "groupID == %@", "gA")
+        )
+        #expect(nextOrderForGroupA == 4)
+
+        manager.clearAll()
+    }
+
     // MARK: - 論理削除テスト
 
     @Test("logicalDelete - データを論理削除できる")


### PR DESCRIPTION
## 概要
`GroupViewModel`/`MeasuresViewModel`/`TaskViewModel`の3ファイルで完全重複していた「デフォルトの並び順（次のorder値）を計算する」処理（`RealmManager.shared.getMaxOrder`呼び出し→`(maxOrder ?? -1) + 1`、エラー時は`0`）を、`RealmManager.getNextOrder(clazz:predicate:)`に一元化しました。

Closes #50

## 変更内容
- `RealmManager.swift`: `getMaxOrder`の直後に`getNextOrder<T: Object>(clazz:predicate:)`を新設（内部で`getMaxOrder`を呼び出し、エラー時は`0`を返す非throwingラッパー）
- `GroupViewModel.swift`: `private func getDefaultOrder()`を削除し、呼び出し元を`RealmManager.shared.getNextOrder(clazz: Group.self)`に置き換え
- `MeasuresViewModel.swift`: `private func getDefaultOrderForTask(taskID:)`を削除し、呼び出し元を`taskID`のpredicate付きで`getNextOrder`経由に置き換え
- `TaskViewModel.swift`: `createTaskData`内のインラインdo/catchブロックを`groupID`のpredicate付きで`getNextOrder`経由に置き換え
- `RealmManagerTests.swift`: `getNextOrder`の単体テストを3件追加（データなし→0、既存データあり→max+1、predicateによるスコープ絞り込み）。既存の`getMaxOrder`テストセクション（issue #21）の直後に配置し、同様の慣習を踏襲

`getMaxOrder`自体のクエリロジック、order値の意味・並び順の仕様は変更していません（スコープ外）。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/RealmManager.swift`
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`
- `SportsNote_iOS/ViewModel/MeasuresViewModel.swift`
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOSTests/Managers/RealmManagerTests.swift`

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（エラー・警告0件、iPhone 16eシミュレータ `id=F0355670-E20E-41A6-A5B9-B41E21EC87CB` 明示指定）
- `xcodebuild test`: **TEST SUCCEEDED**（442件全成功、新規3件含む）

## 完了条件チェックリスト
- [x] order計算ロジックが1箇所（`RealmManager.getNextOrder`）に集約されている
- [x] GroupViewModel/MeasuresViewModel/TaskViewModelの3箇所が共通ロジック経由に置き換わっている
- [x] 既存のGroupViewModelTests.swift/MeasuresViewModelTests.swift/TaskViewModelTests.swiftが成功する
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー
独立したサブエージェントによるクロスレビューを1ラウンド実施。ビルド・テストを独自に再実行し申告内容と一致することを確認、`getMaxOrder`/`getDefaultOrder`の残存呼び出しがないことも`grep`で確認済み。**指摘0件（must-fix/should-fix/nitいずれもなし）で合格。**