### PR TITLE
refactor: TutorialViewModelのページ文言を多言語化対応 (#49)

### DIFF
--- a/SportsNote_iOS/Resource/LocalizedString.swift
+++ b/SportsNote_iOS/Resource/LocalizedString.swift
@@ -208,4 +208,18 @@ struct LocalizedStrings {
     static let userCollisionError = "userCollisionError".localized
     static let weakPasswordError = "weakPasswordError".localized
     static let recentLoginRequiredError = "recentLoginRequiredError".localized
+
+    // MARK: Tutorial
+    static let tutorialPage1Title = "tutorialPage1Title".localized
+    static let tutorialPage1Description = "tutorialPage1Description".localized
+    static let tutorialPage2Title = "tutorialPage2Title".localized
+    static let tutorialPage2Description = "tutorialPage2Description".localized
+    static let tutorialPage3Title = "tutorialPage3Title".localized
+    static let tutorialPage3Description = "tutorialPage3Description".localized
+    static let tutorialPage4Title = "tutorialPage4Title".localized
+    static let tutorialPage4Description = "tutorialPage4Description".localized
+    static let tutorialPage5Title = "tutorialPage5Title".localized
+    static let tutorialPage5Description = "tutorialPage5Description".localized
+    static let tutorialPage6Title = "tutorialPage6Title".localized
+    static let tutorialPage6Description = "tutorialPage6Description".localized
 }

--- a/SportsNote_iOS/Resource/en.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/en.lproj/Localizable.strings
@@ -199,3 +199,17 @@
 "userCollisionError" = "This email is already in use";
 "weakPasswordError" = "Please use a stronger password";
 "recentLoginRequiredError" = "Please login again before this operation";
+
+// MARK: Tutorial
+"tutorialPage1Title" = "About SportsNote";
+"tutorialPage1Description" = "A note-taking app focused on solving challenges.\nThink through causes and countermeasures, put them into practice, and work toward resolution through reflection.";
+"tutorialPage2Title" = "Managing Tasks (1)";
+"tutorialPage2Description" = "Manage your tasks in a list view.\nYou can create groups to organize and categorize your tasks.";
+"tutorialPage3Title" = "Managing Tasks (2)";
+"tutorialPage3Description" = "Register causes and countermeasures for each task.\nThe measure with the highest priority is automatically loaded into your notes.";
+"tutorialPage4Title" = "Create a Note";
+"tutorialPage4Description" = "Create practice notes.\nRegistered tasks are loaded into the note, letting you record your progress on each one.";
+"tutorialPage5Title" = "Reflection";
+"tutorialPage5Description" = "Review what you've recorded in your notes.\nGo from Task to Measures to review a summary of everything you've done for that task.";
+"tutorialPage6Title" = "Completing a Task";
+"tutorialPage6Description" = "Marking a resolved task as complete keeps it from being loaded into notes.\nEven after completion, you can look back on completed tasks at any time.";

--- a/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
@@ -199,3 +199,17 @@
 "userCollisionError" = "このメールアドレスは既に使用されています";
 "weakPasswordError" = "より強力なパスワードを設定してください";
 "recentLoginRequiredError" = "再度ログインしてから操作を行ってください";
+
+// MARK: Tutorial
+"tutorialPage1Title" = "SportsNoteとは";
+"tutorialPage1Description" = "課題解決に特化したノートアプリです。\n原因と対策を考えて実践し、反省を通して解決を目指すことができます。";
+"tutorialPage2Title" = "課題の管理①";
+"tutorialPage2Description" = "課題を一覧で管理できます。\nグループを作成することで課題を分類して管理することができます。";
+"tutorialPage3Title" = "課題の管理②";
+"tutorialPage3Description" = "課題毎に原因と対策を登録できます。\n優先度が最も高い対策がノートに読み込まれるようになります。";
+"tutorialPage4Title" = "ノートを作成";
+"tutorialPage4Description" = "練習ノートを作成できます。\nノートには登録した課題が読み込まれ、課題の取り組みを記録しておくことができます。";
+"tutorialPage5Title" = "振り返り";
+"tutorialPage5Description" = "記録した内容はノートで振り返ることができます。\n課題＞対策へと進めば、その課題の取り組み内容をまとめて振り返ることもできます。";
+"tutorialPage6Title" = "課題を完了にする";
+"tutorialPage6Description" = "解決した課題は完了にすることでノートへ読み込まれなくなります。\n完了にしても完了した課題からいつでも振り返ることができます。";

--- a/SportsNote_iOS/ViewModel/TutorialViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TutorialViewModel.swift
@@ -22,51 +22,33 @@ class TutorialViewModel: ObservableObject {
     private func setupTutorialPages() {
         pages = [
             TutorialPage(
-                title: "SportsNoteとは",
-                description: """
-                    課題解決に特化したノートアプリです。
-                    原因と対策を考えて実践し、反省を通して解決を目指すことができます。
-                    """,
+                title: LocalizedStrings.tutorialPage1Title,
+                description: LocalizedStrings.tutorialPage1Description,
                 imageName: "screenshot_1"
             ),
             TutorialPage(
-                title: "課題の管理①",
-                description: """
-                    課題を一覧で管理できます。
-                    グループを作成することで課題を分類して管理することができます。
-                    """,
+                title: LocalizedStrings.tutorialPage2Title,
+                description: LocalizedStrings.tutorialPage2Description,
                 imageName: "screenshot_2"
             ),
             TutorialPage(
-                title: "課題の管理②",
-                description: """
-                    課題毎に原因と対策を登録できます。
-                    優先度が最も高い対策がノートに読み込まれるようになります。
-                    """,
+                title: LocalizedStrings.tutorialPage3Title,
+                description: LocalizedStrings.tutorialPage3Description,
                 imageName: "screenshot_3"
             ),
             TutorialPage(
-                title: "ノートを作成",
-                description: """
-                    練習ノートを作成できます。
-                    ノートには登録した課題が読み込まれ、課題の取り組みを記録しておくことができます。
-                    """,
+                title: LocalizedStrings.tutorialPage4Title,
+                description: LocalizedStrings.tutorialPage4Description,
                 imageName: "screenshot_4"
             ),
             TutorialPage(
-                title: "振り返り",
-                description: """
-                    記録した内容はノートで振り返ることができます。
-                    課題＞対策へと進めば、その課題の取り組み内容をまとめて振り返ることもできます。
-                    """,
+                title: LocalizedStrings.tutorialPage5Title,
+                description: LocalizedStrings.tutorialPage5Description,
                 imageName: "screenshot_5"
             ),
             TutorialPage(
-                title: "課題を完了にする",
-                description: """
-                    解決した課題は完了にすることでノートへ読み込まれなくなります。
-                    完了にしても完了した課題からいつでも振り返ることができます。
-                    """,
+                title: LocalizedStrings.tutorialPage6Title,
+                description: LocalizedStrings.tutorialPage6Description,
                 imageName: "screenshot_6"
             ),
         ]


### PR DESCRIPTION
## 概要
`TutorialViewModel.setupTutorialPages()`内の全チュートリアルページ（6ページ分のタイトル・説明文、計12文字列）が日本語の文字列リテラルで直接記述されており、`LocalizedStrings`/`Localizable.strings`を経由していなかったため、英語ロケールでも日本語のまま表示される問題を修正しました。

Closes #49

## 変更内容
- `LocalizedString.swift`: `// MARK: Tutorial`セクションを新設し、`tutorialPage1Title`〜`tutorialPage6Description`の12キーを追加
- `ja.lproj/Localizable.strings`: 12キーを追加。値は元の日本語リテラルと完全一致（複数行文字列は`\n`エスケープの1行キーに変換）
- `en.lproj/Localizable.strings`: `doc/spec/18_tutorial.md`のページ内容をもとに、日本語の直訳ではなく自然な英訳を12キー追加
- `TutorialViewModel.swift`: `setupTutorialPages()`内の全`TutorialPage`のtitle/descriptionを`LocalizedStrings`経由の値に置き換え

`TutorialPage`構造体自体の設計・スクリーンショット画像（`imageName`）・UIレイアウトは変更していません（スコープ外）。

## 変更ファイル一覧
- `SportsNote_iOS/Resource/LocalizedString.swift`
- `SportsNote_iOS/Resource/ja.lproj/Localizable.strings`
- `SportsNote_iOS/Resource/en.lproj/Localizable.strings`
- `SportsNote_iOS/ViewModel/TutorialViewModel.swift`

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（エラー・警告0件、iPhone 16eシミュレータ `id=F0355670-E20E-41A6-A5B9-B41E21EC87CB` 明示指定）
- `xcodebuild test`: **TEST SUCCEEDED**（439件全成功、`TutorialViewModelTests`の日本語リテラル比較テストを含む）

## 完了条件チェックリスト
- [x] TutorialViewModel.swiftのtitle/descriptionが全て`LocalizedStrings`経由の値になっている
- [x] ja.lproj/en.lproj双方のLocalizable.stringsに対応するキーが追加され、英語版は日本語と異なる自然な英訳になっている
- [x] 既存のTutorialViewModelTests.swiftが成功する（変更不要だった。開発言語`ja`のためja.lprojの値をNSLocalizedStringが解決し、既存の日本語リテラル比較テストがそのまま通過することを確認）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー
独立したサブエージェントによるクロスレビューを1ラウンド実施。ビルド・テストを独自に再実行し申告内容と一致することを確認、ja.lprojの新規12値が元の日本語リテラルと1文字も違わず完全一致していることも`git show main:...`との突き合わせで確認済み。**指摘0件（must-fix/should-fix/nitいずれもなし）で合格。**

参考共有として、`TutorialViewModelTests.swift`の一部テストが`.localized`経由の値を日本語リテラルと直接比較しており、シミュレータのロケール設定に依存する既存のテスト設計である点が挙げられましたが、これは本issueのスコープ外（既存のテスト設計を踏襲）であり、issue本文の完了条件は満たしているためmust-fix/should-fixとしては扱いませんでした。