### PR TITLE
Fix: UserDefaultsManager.getのuserID特別処理がOptional型呼び出し時にnilを返す問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/UserDefaultsManager.swift
+++ b/SportsNote_iOS/Model/Manager/UserDefaultsManager.swift
@@ -52,8 +52,8 @@ class UserDefaultsManager {
     static func get<T>(key: String, defaultValue: T) -> T {
         // ユーザーIDの特別な処理
         if key == Keys.userID {
-            if let cachedID = cachedUserID as? T {
-                return cachedID
+            if let cachedID = cachedUserID {
+                return cachedID as! T
             }
             if let savedID = userDefaults.string(forKey: key) {
                 cachedUserID = savedID

--- a/SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift
@@ -123,6 +123,43 @@ struct UserDefaultsManagerTests {
         UserDefaultsManager.clearAll()
     }
 
+    @Test("userID - Optional型(String?)呼び出し時もcachedUserIDがnilなら新規UUIDが返る（#37回帰防止）")
+    func userID_optionalCall_returnsGeneratedUUIDWhenCacheIsNil() {
+        // cachedUserIDはinit()のclearAll()でnilになっている（コールドスタート相当）
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: nil) as String?
+        #expect(value != nil)
+        #expect(UUIDGenerator.isValidUUID(value ?? ""))
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("userID - Optional型(String?)呼び出し時、永続化済みIDがcachedUserID未設定でも返る（#37回帰防止）")
+    func userID_optionalCall_returnsPersistedValueWhenCacheIsNil() {
+        // キャッシュを経由せず、UserDefaultsに直接値を仕込む（コールドスタート相当）
+        UserDefaults.standard.set("persisted-id", forKey: UserDefaultsManager.Keys.userID)
+
+        let value = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: nil) as String?
+        #expect(value == "persisted-id")
+
+        UserDefaultsManager.clearAll()
+    }
+
+    @Test("userID - Optional型(String?)呼び出しと非Optional呼び出しで同一の永続化済みIDが返る")
+    func userID_optionalAndNonOptionalCallsReturnSameValue() {
+        UserDefaults.standard.set("shared-id", forKey: UserDefaultsManager.Keys.userID)
+
+        let optionalValue = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: nil) as String?
+        UserDefaultsManager.clearAll()
+        UserDefaults.standard.set("shared-id", forKey: UserDefaultsManager.Keys.userID)
+        let nonOptionalValue = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
+
+        #expect(optionalValue == "shared-id")
+        #expect(nonOptionalValue == "shared-id")
+        #expect(optionalValue == nonOptionalValue)
+
+        UserDefaultsManager.clearAll()
+    }
+
     // MARK: - remove
 
     @Test("remove - 指定キーの値が削除されデフォルト値に戻る")


### PR DESCRIPTION
## 概要
`UserDefaultsManager.get(key:defaultValue:)`は、`Keys.userID`を`defaultValue: nil`（型`String?`）付きで呼び出すと、内部の`cachedUserID as? T`（`T`が`String?`）が、`cachedUserID`が`nil`であっても常に成功してしまい（Optional-to-Optionalキャストの罠）、`UserDefaults`への永続値確認や新規ID生成に到達しないまま`nil`を返してしまう問題を修正しました。この呼び出しパターンは`InitializationManager.initializeApp()`内でCrashlyticsへのuserID設定に使われており、初回起動を除く全てのアプリ起動（コールドスタート）でCrashlyticsへのuserID設定が失敗していました。

Closes #37

## 変更内容
`SportsNote_iOS/Model/Manager/UserDefaultsManager.swift`の`get<T>`内、userID特別処理の判定を`cachedID as? T`から`cachedUserID`自体のnil判定（`if let cachedID = cachedUserID`）に変更し、値が存在する場合のみ`as! T`でキャストする形にしました。`T = String`（非Optional呼び出し）・`T = String?`（Optional呼び出し）のいずれでも、非Optional値からのキャストは常に成功するため安全です。

`InitializationManager.swift`側の呼び出し方自体は変更していません（issue本文のスコープ外）。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/UserDefaultsManager.swift`（userID特別処理のnil判定ロジック修正）
- `SportsNote_iOSTests/Managers/UserDefaultsManagerTests.swift`（回帰防止テスト3件追加）

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED（警告0件）
- `xcodebuild test`: TEST SUCCEEDED（442件全成功、新規3件含む）
- クロスレビュー（独立サブエージェント）でも同様にビルド・テストを再実行し、申告内容と一致することを確認済み

## 完了条件チェックリスト
- [x] `defaultValue: nil`（`T = String?`）で`get`を呼び出した際、`cachedUserID`が`nil`でも永続化されたuserIDまたは新規生成IDが正しく返ることを確認できる単体テストがある
- [x] 既存の`defaultValue: ""`等、非Optional型での呼び出しが従来通り動作することを確認できる回帰テストがある
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で説明したCrashlyticsへのuserID未設定が再現しないこと（`InitializationManager.swift`29行目と同一のAPI呼び出しシグネチャで新規テストを追加し、論理的に解消を確認）

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitともに指摘0件、合格。レビュアーが独立に、修正前コードへのロールバック実験で新規テスト3件が正しく失敗すること・修正後は全件成功することを確認済み。

マージはユーザーが内容を確認の上、手動で行います。