### PR TITLE
refactor: RealmManager.getObjectByIdの型分岐重複をSoftDeletableプロトコルで解消

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -6,6 +6,21 @@ struct RealmConstants {
     static let schemaVersion: UInt64 = 0
 }
 
+/// 論理削除フラグ(isDeleted)を持つRealmモデルの共通インターフェース
+/// issue #38でmarkAsDeleted用にSoftDeletableプロトコルが新設された場合は、
+/// 本プロトコルとの重複を解消し統合すること
+protocol SoftDeletable {
+    var isDeleted: Bool { get }
+}
+
+// Realmモデルに対してSoftDeletableプロトコルを適用する拡張
+extension Note: SoftDeletable {}
+extension Group: SoftDeletable {}
+extension TaskData: SoftDeletable {}
+extension Measures: SoftDeletable {}
+extension Memo: SoftDeletable {}
+extension Target: SoftDeletable {}
+
 /// Realmデータベースを管理するクラス
 @MainActor
 final class RealmManager {
@@ -218,18 +233,8 @@ final class RealmManager {
 
             // 削除されていないオブジェクトのみを返す
             if let object = realm.object(ofType: type, forPrimaryKey: id) {
-                // オブジェクトがisDeletedプロパティを持っているか確認
-                if let noteObj = object as? Note, noteObj.isDeleted {
-                    return nil
-                } else if let groupObj = object as? Group, groupObj.isDeleted {
-                    return nil
-                } else if let taskObj = object as? TaskData, taskObj.isDeleted {
-                    return nil
-                } else if let measuresObj = object as? Measures, measuresObj.isDeleted {
-                    return nil
-                } else if let memoObj = object as? Memo, memoObj.isDeleted {
-                    return nil
-                } else if let targetObj = object as? Target, targetObj.isDeleted {
+                // SoftDeletableに適合し、かつisDeleted == trueなら論理削除済みとみなす
+                if (object as? SoftDeletable)?.isDeleted == true {
                     return nil
                 }
                 return object


### PR DESCRIPTION
## 概要
`RealmManager.getObjectById`内にあった、`Note`/`Group`/`TaskData`/`Measures`/`Memo`/`Target`の6型に対する同型の`if let ... as?`分岐チェーンを、軽量な`SoftDeletable`プロトコル（`isDeleted: Bool { get }`）への適合と`(object as? SoftDeletable)?.isDeleted == true`の1行に置き換えました。

`markAsDeleted`（issue #38対象）は本issueのスコープ外のため変更していません。issue #38が将来着手され`SoftDeletable`相当のプロトコルを新設する場合に備え、統合を促すコメントをコード内に残しています。

Closes #59

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/RealmManager.swift`（1ファイルのみ）

## ビルド・テスト結果
- `xcodebuild ... build` → **BUILD SUCCEEDED**（警告0件）
- `xcodebuild ... test` → **TEST SUCCEEDED**（439件全成功、`RealmManagerTests`の論理削除関連テスト含む）

## 完了条件チェックリスト
- [x] `getObjectById`の6分岐チェーンが1行相当の共通化された実装に置き換わっている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（論理削除されたオブジェクトが`getObjectById`でnilを返す既存動作に回帰がないこと）

## クロスレビュー
独立したサブエージェントによるクロスレビューを実施。差分の意味的等価性の検証、モデル側`isDeleted`プロパティの確認、ビルド・テストの独立再実行、テストの検知力の実験的確認（判定ロジックを意図的に巻き戻してテストが失敗することを確認）を経て、**1ラウンド目で合格**（must-fix/should-fix/nitともに指摘0件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>