### PR TITLE
refactor: TaskDetailViewの課題更新+エラーハンドリング重複を解消

### DIFF
--- a/SportsNote_iOS/View/Task/TaskDetailView.swift
+++ b/SportsNote_iOS/View/Task/TaskDetailView.swift
@@ -44,18 +44,7 @@ struct TaskDetailView: View {
             Section(header: Text(LocalizedStrings.title)) {
                 TextField(LocalizedStrings.title, text: $taskTitle)
                     .onChange(of: taskTitle) { _ in
-                        Task {
-                            guard !groups.isEmpty, groups.indices.contains(selectedGroupIndex) else { return }
-                            let result = await viewModel.updateTask(
-                                taskID: taskData.taskID,
-                                title: taskTitle,
-                                cause: cause,
-                                groupID: groups[selectedGroupIndex].groupID
-                            )
-                            if case .failure(let error) = result {
-                                viewModel.showErrorAlert(error)
-                            }
-                        }
+                        persistTaskChanges()
                     }
             }
             // 原因
@@ -66,18 +55,7 @@ struct TaskDetailView: View {
                     minHeight: 50
                 )
                 .onChange(of: cause) { _ in
-                    Task {
-                        guard !groups.isEmpty, groups.indices.contains(selectedGroupIndex) else { return }
-                        let result = await viewModel.updateTask(
-                            taskID: taskData.taskID,
-                            title: taskTitle,
-                            cause: cause,
-                            groupID: groups[selectedGroupIndex].groupID
-                        )
-                        if case .failure(let error) = result {
-                            viewModel.showErrorAlert(error)
-                        }
-                    }
+                    persistTaskChanges()
                 }
             }
             // グループ
@@ -87,18 +65,7 @@ struct TaskDetailView: View {
                         selectedGroupIndex: $selectedGroupIndex,
                         viewModel: groupViewModel,
                         onSelectionChanged: {
-                            Task {
-                                guard !groups.isEmpty, groups.indices.contains(selectedGroupIndex) else { return }
-                                let result = await viewModel.updateTask(
-                                    taskID: taskData.taskID,
-                                    title: taskTitle,
-                                    cause: cause,
-                                    groupID: groups[selectedGroupIndex].groupID
-                                )
-                                if case .failure(let error) = result {
-                                    viewModel.showErrorAlert(error)
-                                }
-                            }
+                            persistTaskChanges()
                         }
                     )
                 }
@@ -212,6 +179,22 @@ struct TaskDetailView: View {
             if newAlertType == nil {
                 // アラートが閉じられたらエラー状態をクリア
                 viewModel.hideErrorAlert()
+            }
+        }
+    }
+
+    /// タイトル・原因・グループの変更をRealmへ反映し、失敗時はエラーアラートを表示する
+    private func persistTaskChanges() {
+        Task {
+            guard !groups.isEmpty, groups.indices.contains(selectedGroupIndex) else { return }
+            let result = await viewModel.updateTask(
+                taskID: taskData.taskID,
+                title: taskTitle,
+                cause: cause,
+                groupID: groups[selectedGroupIndex].groupID
+            )
+            if case .failure(let error) = result {
+                viewModel.showErrorAlert(error)
             }
         }
     }


### PR DESCRIPTION
## 概要
`TaskDetailView.swift`内でタイトル変更・原因変更・グループ変更の3箇所に完全重複していた「課題更新→失敗時エラーアラート表示」のTaskブロックを、`private func persistTaskChanges()`に集約した。各`onChange`/`onSelectionChanged`ハンドラは新メソッドの呼び出しのみに置き換え。

Closes #64

## 変更ファイル一覧
- `SportsNote_iOS/View/Task/TaskDetailView.swift`（+19/-36行）

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test` → TEST SUCCEEDED（442件全成功）

## 完了条件
- [x] 3箇所の重複ブロックが1つのprivateメソッドに集約されていること
- [x] タイトル変更・原因変更・グループ変更のいずれの操作でも、以前と同じ挙動（Realm保存＋エラー時のアラート表示）が維持されていること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立したサブエージェントによるクロスレビューを実施。3箇所の抽出前後のコードが完全に同一（意味的等価性を確認）、ビルド・テストも独立に再実行し成功を確認。must-fix/should-fix/nitともに指摘0件で合格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)