### PR TITLE
refactor: RealmManager.getObjectByIdの死んだコードを削除

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -180,28 +180,6 @@ final class RealmManager {
 
     // MARK: - Select
 
-    /// 指定したクラスに対応するプライマリキーのプロパティ名を取得
-    /// - Returns: Tに対応するプライマリキーのプロパティ名
-    /// - Throws: 対応していないクラスの場合にスローされる
-    private func getPrimaryKeyName<T: Object>(_ type: T.Type) -> String {
-        switch type {
-        case is Group.Type:
-            return "groupID"
-        case is Measures.Type:
-            return "measuresID"
-        case is Memo.Type:
-            return "memoID"
-        case is Note.Type:
-            return "noteID"
-        case is Target.Type:
-            return "targetID"
-        case is TaskData.Type:
-            return "taskID"
-        default:
-            fatalError("Unsupported class")
-        }
-    }
-
     /// 汎用的なデータ取得メソッド（ID指定）
     /// - Parameter id: 検索するID（文字列）
     /// - Returns: 取得データ（存在しない場合は`nil`）
@@ -213,8 +191,6 @@ final class RealmManager {
 
         do {
             let realm = try getRealm()
-            // PrimaryKeyで安全に検索
-            _ = getPrimaryKeyName(type)
 
             // 削除されていないオブジェクトのみを返す
             if let object = realm.object(ofType: type, forPrimaryKey: id) {


### PR DESCRIPTION
## 概要
`RealmManager.getObjectById`内で呼び出していた`getPrimaryKeyName(type)`の戻り値が`_`で完全に破棄されており、後続の`realm.object(ofType:forPrimaryKey:)`（Realm標準APIで型のスキーマから自動解決される）では一切使用されていなかった。この死んだコードと、唯一の呼び出し元だった`getPrimaryKeyName`メソッド自体を削除した。

Closes #69

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/RealmManager.swift`（24行削除のみ）

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED（コード側warning 0件）
- `xcodebuild test`: TEST SUCCEEDED（442件全成功）

## 完了条件チェックリスト
- [x] `getObjectById`内から意味のない`getPrimaryKeyName`呼び出しが削除されていること
- [x] `getPrimaryKeyName`メソッドが他で使われていなければ削除されていること（`grep`で呼び出し箇所0件を確認）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー
独立したレビューサブエージェントによる1ラウンド目のレビューで、must-fix/should-fix/nitともに指摘0件で合格。レビュアーが独立に以下を検証済み:
- `getPrimaryKeyName`の他参照が本当に存在しないことをgrepで再確認
- 削除ロジックが意味的に変更前と完全に等価であることを実コードで確認（純粋関数・副作用なし）
- `xcodebuild build`/`test`を独立に再実行し申告内容と完全一致することを確認
- swift-formatの再適用でdiffが発生しないことを確認

マージはユーザーが内容を確認の上、手動で行ってください。