### PR TITLE
Fix: GroupColor.allCases[Int(group.color)]の範囲外インデックスアクセスによるクラッシュを修正

### DIFF
--- a/SportsNote_iOS/Model/Group.swift
+++ b/SportsNote_iOS/Model/Group.swift
@@ -48,6 +48,12 @@ class Group: Object {
     override static func primaryKey() -> String? {
         return "groupID"
     }
+
+    /// 安全にGroupColorを取得するアクセサ
+    /// - Note: colorがGroupColorの範囲外（Firestore経由の不正値等）の場合はgrayにフォールバックする
+    var groupColor: GroupColor {
+        GroupColor(rawValue: color) ?? .gray
+    }
 }
 
 enum GroupColor: Int, CaseIterable {

--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -455,7 +455,7 @@ final class RealmManager {
                             .filter("groupID == %@", taskData.groupID)
                             .first
                         {
-                            return GroupColor.allCases[Int(group.color)].color
+                            return group.groupColor.color
                         }
                     }
                 }

--- a/SportsNote_iOS/View/Group/Components/GroupForm.swift
+++ b/SportsNote_iOS/View/Group/Components/GroupForm.swift
@@ -46,7 +46,7 @@ struct GroupForm: View {
                     ForEach(groups, id: \.groupID) { group in
                         HStack(spacing: 12) {
                             GroupColorCircle(
-                                color: Color(GroupColor.allCases[Int(group.color)].color),
+                                color: Color(group.groupColor.color),
                                 size: 16
                             )
                             Text(group.title)

--- a/SportsNote_iOS/View/Group/GroupView.swift
+++ b/SportsNote_iOS/View/Group/GroupView.swift
@@ -14,7 +14,7 @@ struct GroupView: View {
         self.viewModel = viewModel
         _selectedGroup = State(initialValue: group)
         _title = State(initialValue: group.title)
-        _selectedColor = State(initialValue: GroupColor.allCases[Int(group.color)])
+        _selectedColor = State(initialValue: group.groupColor)
     }
 
     var body: some View {
@@ -27,7 +27,7 @@ struct GroupView: View {
             onSelectGroup: { group in
                 selectedGroup = group
                 title = group.title
-                selectedColor = GroupColor.allCases[Int(group.color)]
+                selectedColor = group.groupColor
             },
             onMoveGroup: { source, destination in
                 Task {
@@ -63,7 +63,7 @@ struct GroupView: View {
                         if let first = viewModel.groups.first {
                             selectedGroup = first
                             title = first.title
-                            selectedColor = GroupColor.allCases[Int(first.color)]
+                            selectedColor = first.groupColor
                         } else {
                             dismiss()
                         }

--- a/SportsNote_iOS/View/Task/Components/GroupListSection.swift
+++ b/SportsNote_iOS/View/Task/Components/GroupListSection.swift
@@ -43,7 +43,7 @@ private struct GroupChip: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: 6) {
-                GroupColorCircle(color: Color(GroupColor.allCases[Int(group.color)].color))
+                GroupColorCircle(color: Color(group.groupColor.color))
 
                 Text(group.title)
                     .font(.subheadline)
@@ -76,7 +76,7 @@ private struct GroupChip: View {
 
     private func chipBackgroundColor() -> Color {
         if isSelected {
-            return Color(GroupColor.allCases[Int(group.color)].color).opacity(0.2)
+            return Color(group.groupColor.color).opacity(0.2)
         } else {
             return Color(.tertiarySystemBackground)
         }
@@ -84,7 +84,7 @@ private struct GroupChip: View {
 
     private func chipStrokeColor() -> Color {
         if isSelected {
-            return Color(GroupColor.allCases[Int(group.color)].color)
+            return Color(group.groupColor.color)
         } else {
             return Color(.systemGray4)
         }
@@ -92,7 +92,7 @@ private struct GroupChip: View {
 
     private func infoIconColor() -> Color {
         if isSelected {
-            return Color(GroupColor.allCases[Int(group.color)].color)
+            return Color(group.groupColor.color)
         } else {
             return Color(.systemGray)
         }

--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -231,7 +231,7 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
     /// - Returns: GroupColorの列挙型
     static func getGroupColor(groupID: String) -> GroupColor {
         if let group = try? RealmManager.shared.getObjectById(id: groupID, type: Group.self) {
-            return GroupColor.allCases[Int(group.color)]
+            return group.groupColor
         }
         return GroupColor.gray
     }

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -564,6 +564,37 @@ struct RealmManagerTests {
         manager.clearAll()
     }
 
+    @Test("getNoteBackgroundColor - 範囲外のcolor値でもクラッシュせずgrayを返す（issue #43）")
+    func getNoteBackgroundColor_returnsGrayForOutOfRangeColor() async throws {
+        // Group.colorがGroupColorの範囲外（0〜7外）の不正値を持つケース
+        let group = Group(
+            groupID: "g-invalid-color", title: "Broken Group", color: 99, order: 0, created_at: Date())
+
+        let task = TaskData()
+        task.taskID = "t-invalid-color"
+        task.groupID = "g-invalid-color"
+
+        let measures = Measures()
+        measures.measuresID = "m-invalid-color"
+        measures.taskID = "t-invalid-color"
+
+        let memo = Memo()
+        memo.memoID = "memo-invalid-color"
+        memo.measuresID = "m-invalid-color"
+        memo.noteID = "n-invalid-color"
+
+        try manager.saveItem(group)
+        try manager.saveItem(task)
+        try manager.saveItem(measures)
+        try manager.saveItem(memo)
+
+        let color = manager.getNoteBackgroundColor(noteID: "n-invalid-color")
+
+        #expect(color.cgColor == GroupColor.gray.color.cgColor)
+
+        manager.clearAll()
+    }
+
     // MARK: - パラメータ化テスト
 
     @Test("searchNotesByQuery - 複数のクエリパターン", arguments: ["Swift", "Testing", "Learn"])

--- a/SportsNote_iOSTests/Models/GroupTests.swift
+++ b/SportsNote_iOSTests/Models/GroupTests.swift
@@ -1,0 +1,37 @@
+//
+//  GroupTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/07/29.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("Group Model Tests")
+struct GroupTests {
+
+    // MARK: - groupColor テスト（issue #43: 範囲外colorでのクラッシュ防止）
+
+    @Test(
+        "groupColor - 正常範囲(0-7)では対応するGroupColorを返す",
+        arguments: GroupColor.allCases)
+    func groupColor_returnsCorrectColorForValidRange(color: GroupColor) {
+        let group = Group(
+            groupID: "g1", title: "Test", color: color.rawValue, order: 0, created_at: Date())
+
+        #expect(group.groupColor == color)
+    }
+
+    @Test(
+        "groupColor - 範囲外の値ではクラッシュせずgrayを返す",
+        arguments: [-1, 8, 99, Int.max, Int.min])
+    func groupColor_returnsGrayForOutOfRangeValue(invalidColor: Int) {
+        let group = Group(
+            groupID: "g1", title: "Test", color: invalidColor, order: 0, created_at: Date())
+
+        #expect(group.groupColor == .gray)
+    }
+}

--- a/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
@@ -335,6 +335,21 @@ struct GroupViewModelTests {
         #expect(color == .gray)
     }
 
+    @Test("getGroupColor - 範囲外のcolor値でもクラッシュせずgrayを返す（issue #43）")
+    func getGroupColor_returnsGrayForOutOfRangeColor() throws {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let group = Group(
+            groupID: "g-invalid-color", title: "Broken Group", color: 99, order: 0, created_at: Date())
+        try manager.saveItem(group)
+
+        let color = GroupViewModel.getGroupColor(groupID: "g-invalid-color")
+        #expect(color == .gray)
+
+        manager.clearAll()
+    }
+
     // MARK: - CRUD操作テスト
 
     @Test("fetchData - データを取得できる")


### PR DESCRIPTION
## 概要
`Group.color`はFirestore/Realmから読み込む際に範囲チェックされないため、0〜7の範囲外の値が入ると`GroupColor.allCases[Int(group.color)]`が配列の範囲外アクセスでクラッシュする不具合を修正した。同一の未ガードパターンが10箇所に重複していたため、`Group`に安全なアクセサ`groupColor`（範囲外は`.gray`にフォールバック）を新設し、全10箇所を置き換えた。

Closes #43

## 変更ファイル一覧
- `SportsNote_iOS/Model/Group.swift` - `groupColor`アクセサを新設（`GroupColor(rawValue: color) ?? .gray`）
- `SportsNote_iOS/Model/Manager/RealmManager.swift` - `getNoteBackgroundColor`内の1箇所を置換
- `SportsNote_iOS/ViewModel/GroupViewModel.swift` - `getGroupColor(groupID:)`内の1箇所を置換
- `SportsNote_iOS/View/Group/GroupView.swift` - 3箇所を置換
- `SportsNote_iOS/View/Group/Components/GroupForm.swift` - 1箇所を置換
- `SportsNote_iOS/View/Task/Components/GroupListSection.swift` - 4箇所を置換
- `SportsNote_iOSTests/Models/GroupTests.swift`（新規） - `Group.groupColor`の単体テスト（正常範囲・範囲外の両方）
- `SportsNote_iOSTests/Managers/RealmManagerTests.swift` - `getNoteBackgroundColor`の範囲外color回帰テストを追加
- `SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift` - `getGroupColor`の範囲外color回帰テストを追加

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test`: **TEST SUCCEEDED**（446件全成功、新規3件含む）
- クロスレビュー時に、独立したレビュアーが`groupColor`実装を意図的にガードなしへ巻き戻して再テストし、新規3テストが実際に`Fatal error: Index out of range`で失敗することを確認済み（検証力のあるテストであることを確認）

## issue本文の完了条件
- [x] 10箇所の未ガード`GroupColor.allCases[Int(group.color)]`呼び出しがすべて安全なアクセサ経由に置き換わっている（`GroupViewModel.swift:247`の`getColorForGroupAtIndex`は元々ガード済みのため対象外・変更なし）
- [x] `color`が範囲外の値（0〜7外）でもクラッシュせずフォールバック色で表示されることを確認できる単体テストがある（Model/ViewModel/RealmManagerの3層でカバー）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順（範囲外color値の同期→画面表示）でクラッシュが再現しないこと（`RealmManager.getNoteBackgroundColor`・`GroupViewModel.getGroupColor`の実際の呼び出し経路を通したテストで確認）

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitともに指摘0件で合格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)