### PR TITLE
Refactor: migrateLoginStateIfNeededのUserDefaults直接アクセスをUserDefaultsManager経由に統一

### DIFF
--- a/SportsNote_iOS/Model/Manager/InitializationManager.swift
+++ b/SportsNote_iOS/Model/Manager/InitializationManager.swift
@@ -133,11 +133,9 @@ final class InitializationManager {
     /// これらが存在する場合は isLogin = true をセットする
     private func migrateLoginStateIfNeeded() {
         let isLogin = UserDefaultsManager.get(key: UserDefaultsManager.Keys.isLogin, defaultValue: false)
-        if !isLogin,
-            let address = UserDefaults.standard.string(forKey: "address"),
-            let password = UserDefaults.standard.string(forKey: "password"),
-            !address.isEmpty, !password.isEmpty
-        {
+        let address = UserDefaultsManager.get(key: UserDefaultsManager.Keys.address, defaultValue: "")
+        let password = UserDefaultsManager.get(key: UserDefaultsManager.Keys.password, defaultValue: "")
+        if !isLogin, !address.isEmpty, !password.isEmpty {
             UserDefaultsManager.set(key: UserDefaultsManager.Keys.isLogin, value: true)
         }
     }


### PR DESCRIPTION
## 概要
`InitializationManager.migrateLoginStateIfNeeded()`が、同一メソッド内の他の箇所（`isLogin`の取得）では`UserDefaultsManager`経由でアクセスしているにもかかわらず、`address`/`password`の取得だけ`UserDefaults.standard`に直接アクセスしていた。`UserDefaultsManager.get(key:defaultValue:)`経由の呼び出しに統一した。

Closes #77

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/InitializationManager.swift` - `migrateLoginStateIfNeeded()`の`address`/`password`取得を`UserDefaults.standard.string(forKey:)`から`UserDefaultsManager.get(key:defaultValue:)`経由に置換

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**
- `xcodebuild test`: **TEST SUCCEEDED**（442件全成功）
- swift-format適用済み（再適用しても差分なし）

## issue本文の完了条件
- [x] `migrateLoginStateIfNeeded()`が`address`/`password`の取得に`UserDefaultsManager`経由のAPIを使用していること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitともに指摘0件で合格。レビュアーが独立に`address`/`password`キーへの書き込み経路（`LoginViewModel.swift`のみ、いずれも`String`型）を確認し、新旧実装の意味論的等価性（キー不在・空文字・正常値の3パターン）を検証済み。ビルド・テストも独立に再実行し申告内容と一致することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)