### PR TITLE
Refactor: 未使用のdidLogout通知定義とNotePageView.readOnlyRowを削除

### DIFF
--- a/SportsNote_iOS/Utils/AppNotifications.swift
+++ b/SportsNote_iOS/Utils/AppNotifications.swift
@@ -2,9 +2,6 @@ import Foundation
 
 /// アプリケーション内で使用する通知名の定義
 extension Notification.Name {
-    /// ログアウト時にViewModelをクリーンアップするための通知
-    static let didLogout = Notification.Name("didLogout")
-
     /// データがクリアされた際の通知
     static let didClearAllData = Notification.Name("didClearAllData")
 

--- a/SportsNote_iOS/View/Note/NotePageView.swift
+++ b/SportsNote_iOS/View/Note/NotePageView.swift
@@ -51,7 +51,7 @@ struct NotePageView: View {
     private var noteTypeNavigationTitle: some View {
         let indicatorColor = Color(
             currentNote.map { viewModel.getNoteIndicatorColor(noteID: $0.noteID, noteType: currentNoteType) }
-            ?? UIColor.systemBlue
+                ?? UIColor.systemBlue
         )
         return HStack(spacing: 6) {
             Image(systemName: currentNoteType.icon)
@@ -69,24 +69,24 @@ struct NotePageView: View {
     var body: some View {
         contentView
             .ignoresSafeArea(edges: .bottom)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .tabBar)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                noteTypeNavigationTitle
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden, for: .tabBar)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    noteTypeNavigationTitle
+                }
             }
-        }
-        .task {
-            let result = await viewModel.fetchNotesExcludingFree()
-            if case .success = result, let first = viewModel.notes.first {
-                currentNoteID = first.noteID
+            .task {
+                let result = await viewModel.fetchNotesExcludingFree()
+                if case .success = result, let first = viewModel.notes.first {
+                    currentNoteID = first.noteID
+                }
+                _ = await taskViewModel.fetchData()
             }
-            _ = await taskViewModel.fetchData()
-        }
-        .errorAlert(
-            currentError: $viewModel.currentError,
-            showingAlert: $viewModel.showingErrorAlert
-        )
+            .errorAlert(
+                currentError: $viewModel.currentError,
+                showingAlert: $viewModel.showingErrorAlert
+            )
     }
 }
 
@@ -277,18 +277,5 @@ struct NotePageContentView: View {
                 .background(Color(.systemBackground))
                 .cornerRadius(10)
         }
-    }
-
-    /// 読み取り専用の行（キー: 値）
-    private func readOnlyRow(title: String, value: String) -> some View {
-        HStack {
-            Text(title)
-                .foregroundColor(.primary)
-            Spacer()
-            Text(value)
-                .foregroundColor(.secondary)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 }


### PR DESCRIPTION
## 概要
呼び出し箇所が存在しない未使用コード（デッドコード）を2箇所削除した。

Closes #79

## 変更ファイル一覧
- `SportsNote_iOS/Utils/AppNotifications.swift` - 呼び出し・observe箇所が0件の`didLogout`通知定義を削除
- `SportsNote_iOS/View/Note/NotePageView.swift` - 呼び出し箇所が0件の`readOnlyRow(title:value:)`メソッド定義を削除（削除に伴いswift-formatを再適用し、`body`プロパティのmodifier chainインデントも是正）

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（未解決参照エラーなし）
- `xcodebuild test`: **TEST SUCCEEDED**（442件全成功）
- swift-format適用済み（再適用しても差分なし）

## issue本文の完了条件
- [x] `AppNotifications.swift`から`didLogout`の定義が削除されていること
- [x] `NotePageView.swift`から`readOnlyRow`の定義が削除されていること
- [x] ビルド成功（BUILD SUCCEEDED、削除による未解決参照エラーが発生しないこと）
- [x] 既存テストがすべて成功

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitともに指摘0件で合格。レビュアーが独立にリポジトリ全体を`grep`し両シンボルの参照が完全に消えていること、`body`プロパティのmodifier chain（swift-format起因のインデント変更のみ）の意味的等価性、ビルド・テストの再実行結果が申告と一致することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)