### PR TITLE
refactor: getUnaddedTasksの重複実装をTaskViewModelに集約

### DIFF
--- a/SportsNote_iOS/View/Note/AddPracticeNoteView.swift
+++ b/SportsNote_iOS/View/Note/AddPracticeNoteView.swift
@@ -55,7 +55,7 @@ struct AddPracticeNoteView: View {
                 Section(header: Text(LocalizedStrings.taskReflection)) {
                     TaskListSection(
                         taskReflections: $taskReflections,
-                        unaddedTasks: getUnaddedTasks()
+                        unaddedTasks: taskViewModel.getUnaddedTasks(taskReflections: taskReflections)
                     )
                 }
 
@@ -97,12 +97,6 @@ struct AddPracticeNoteView: View {
             .dismissKeyboardOnTap()
             .allowsHitTesting(true)
         }
-    }
-
-    /// 未追加のタスクを取得
-    private func getUnaddedTasks() -> [TaskListData] {
-        let addedTaskIds = Set(taskReflections.keys.map { $0.taskID })
-        return taskViewModel.getUnaddedTasks(excludingTaskIds: addedTaskIds)
     }
 
     /// 保存処理

--- a/SportsNote_iOS/View/Note/PracticeNoteView.swift
+++ b/SportsNote_iOS/View/Note/PracticeNoteView.swift
@@ -62,10 +62,13 @@ struct PracticeNoteView: View {
 
                     // 取り組んだ課題
                     Section(header: Text(LocalizedStrings.taskReflection)) {
-                        TaskListSection(taskReflections: $taskReflections, unaddedTasks: getUnaddedTasks())
-                            .onChange(of: taskReflections) { _ in
-                                updateNote()
-                            }
+                        TaskListSection(
+                            taskReflections: $taskReflections,
+                            unaddedTasks: taskViewModel.getUnaddedTasks(taskReflections: taskReflections)
+                        )
+                        .onChange(of: taskReflections) { _ in
+                            updateNote()
+                        }
                     }
 
                     // 反省
@@ -136,12 +139,6 @@ struct PracticeNoteView: View {
         Task {
             _ = await taskViewModel.fetchData()
         }
-    }
-
-    /// 未追加のタスクを取得
-    private func getUnaddedTasks() -> [TaskListData] {
-        let addedTaskIds = Set(taskReflections.keys.map { $0.taskID })
-        return taskViewModel.getUnaddedTasks(excludingTaskIds: addedTaskIds)
     }
 
     // タスクのリフレクションをロードする

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -428,6 +428,14 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         }
     }
 
+    /// 未追加のタスクを取得（taskReflectionsから直接算出）
+    /// - Parameter taskReflections: ノートに追加済みの課題と感想のマップ
+    /// - Returns: 未追加タスクのリスト
+    func getUnaddedTasks(taskReflections: [TaskListData: String]) -> [TaskListData] {
+        let addedTaskIds = Set(taskReflections.keys.map { $0.taskID })
+        return getUnaddedTasks(excludingTaskIds: addedTaskIds)
+    }
+
     // MARK: - Measures委譲メソッド
 
     /// 最も優先度の高い（orderが低い）対策を取得（MeasuresViewModelへの委譲）

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -473,6 +473,69 @@ struct TaskViewModelTests {
         #expect(viewModel.filteredTaskListData.allSatisfy { $0.groupID == "group-1" })
     }
 
+    // MARK: - 未追加課題取得テスト（issue #86: getUnaddedTasksの重複解消）
+
+    @Test("未追加課題取得 - taskReflectionsに含まれる課題を除外する")
+    func getUnaddedTasks_excludesTasksInTaskReflections() async {
+        let viewModel = TaskViewModel()
+
+        let allTasks = (0..<3)
+            .map { i in
+                TaskListData(
+                    taskID: "task-\(i)",
+                    groupID: "group-1",
+                    groupColor: .red,
+                    title: "Task \(i)",
+                    measuresID: "measures-\(i)",
+                    measures: "Measures \(i)",
+                    memoID: nil,
+                    order: i,
+                    isComplete: false
+                )
+            }
+        viewModel.taskListData = allTasks
+
+        // task-0のみをtaskReflectionsに追加済みとする
+        let taskReflections: [TaskListData: String] = [allTasks[0]: "感想"]
+
+        let unaddedTasks = viewModel.getUnaddedTasks(taskReflections: taskReflections)
+
+        #expect(unaddedTasks.count == 2)
+        #expect(!unaddedTasks.contains { $0.taskID == "task-0" })
+        #expect(unaddedTasks.contains { $0.taskID == "task-1" })
+        #expect(unaddedTasks.contains { $0.taskID == "task-2" })
+    }
+
+    @Test("未追加課題取得 - excludingTaskIds版と同じ結果になる")
+    func getUnaddedTasks_matchesExcludingTaskIdsOverload() async {
+        let viewModel = TaskViewModel()
+
+        let allTasks = (0..<4)
+            .map { i in
+                TaskListData(
+                    taskID: "task-\(i)",
+                    groupID: "group-1",
+                    groupColor: .red,
+                    title: "Task \(i)",
+                    measuresID: "measures-\(i)",
+                    measures: "Measures \(i)",
+                    memoID: nil,
+                    order: i,
+                    isComplete: i == 3  // task-3は完了済み
+                )
+            }
+        viewModel.taskListData = allTasks
+
+        let taskReflections: [TaskListData: String] = [allTasks[1]: "感想"]
+        let excludingTaskIds: Set<String> = ["task-1"]
+
+        let resultFromTaskReflections = viewModel.getUnaddedTasks(taskReflections: taskReflections)
+        let resultFromExcludingIds = viewModel.getUnaddedTasks(excludingTaskIds: excludingTaskIds)
+
+        #expect(Set(resultFromTaskReflections.map { $0.taskID }) == Set(resultFromExcludingIds.map { $0.taskID }))
+        #expect(!resultFromTaskReflections.contains { $0.taskID == "task-3" })  // 完了済みは除外
+    }
+
     // MARK: - 完了/未完了の混在テスト
 
     @Test("完了/未完了 - 混在する課題リスト")


### PR DESCRIPTION
## 概要
`AddPracticeNoteView.swift`/`PracticeNoteView.swift`に1文字違わず重複していた`private func getUnaddedTasks()`を削除し、`TaskViewModel.getUnaddedTasks(taskReflections:)`に処理を統合した。

Closes #86

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/TaskViewModel.swift` - `getUnaddedTasks(taskReflections:)`オーバーロードを新設（既存の`getUnaddedTasks(excludingTaskIds:)`に委譲）
- `SportsNote_iOS/View/Note/AddPracticeNoteView.swift` - privateヘルパー削除、新メソッド呼び出しに変更
- `SportsNote_iOS/View/Note/PracticeNoteView.swift` - privateヘルパー削除、新メソッド呼び出しに変更
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift` - 新規テスト2件追加

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test`: **TEST SUCCEEDED**（444件全成功、新規2件含む）
- swift-format適用済み（再適用しても差分なし）

## issue本文の完了条件チェックリスト
- [x] `getUnaddedTasks()`の重複実装が解消され、共通ロジックが1箇所に集約されていること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 両画面で未追加課題の一覧表示が変更前と同じであることを確認できる（ロジックは移動のみで完全に等価）

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitともに指摘0件のため合格。