### PR TITLE
refactor: MoveToToday通知名をAppNotifications.swiftの定数パターンに統一

### DIFF
--- a/SportsNote_iOS/Utils/AppNotifications.swift
+++ b/SportsNote_iOS/Utils/AppNotifications.swift
@@ -10,4 +10,7 @@ extension Notification.Name {
 
     /// アプリを再初期化する必要がある際の通知
     static let shouldReinitializeApp = Notification.Name("shouldReinitializeApp")
+
+    /// 「今日」ボタンタップ時にカレンダーを今日の月へ移動させるための通知
+    static let moveToToday = Notification.Name("MoveToToday")
 }

--- a/SportsNote_iOS/View/Target/Components/CalendarView.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarView.swift
@@ -98,7 +98,7 @@ struct CalendarView: View {
 
             // 「今日」ボタンの通知を受け取る
             NotificationCenter.default.addObserver(
-                forName: NSNotification.Name("MoveToToday"),
+                forName: .moveToToday,
                 object: nil,
                 queue: .main
             ) { _ in
@@ -128,7 +128,7 @@ struct CalendarView: View {
             // 通知の登録解除
             NotificationCenter.default.removeObserver(
                 self,
-                name: NSNotification.Name("MoveToToday"),
+                name: .moveToToday,
                 object: nil
             )
         }

--- a/SportsNote_iOS/View/Target/Components/TodayButton.swift
+++ b/SportsNote_iOS/View/Target/Components/TodayButton.swift
@@ -20,7 +20,7 @@ struct TodayButton: View {
             targetViewModel.updateCurrentPeriod(year: selectedYear, month: selectedMonth)
 
             NotificationCenter.default.post(
-                name: NSNotification.Name("MoveToToday"),
+                name: .moveToToday,
                 object: nil
             )
 


### PR DESCRIPTION
## 概要
`TodayButton.swift`（post側）・`CalendarView.swift`（addObserver側・removeObserver側）の計3箇所に生文字列直書きされていた`NSNotification.Name("MoveToToday")`を、`AppNotifications.swift`の`Notification.Name`拡張に定義した`moveToToday`定数経由に統一した。

Closes #87

## 変更ファイル一覧
- `SportsNote_iOS/Utils/AppNotifications.swift` - `static let moveToToday = Notification.Name("MoveToToday")`を追加
- `SportsNote_iOS/View/Target/Components/TodayButton.swift` - post側の生文字列を`.moveToToday`に置換
- `SportsNote_iOS/View/Target/Components/CalendarView.swift` - addObserver側・removeObserver側の生文字列を`.moveToToday`に置換

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test`: **TEST SUCCEEDED**（442件全成功）
- swift-format適用済み（再適用しても差分なし）

## issue本文の完了条件チェックリスト
- [x] `"MoveToToday"`の生文字列参照が`AppNotifications.swift`の定数経由に統一されていること（`grep`で定義箇所以外の生文字列が0件であることを確認）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 「今日」ボタンタップでカレンダーが今日の日付に移動する挙動が変更前と同じであることを確認できる（`Notification.Name`の文字列値は変更前と完全一致のため、post/observeペアリングに影響なし）

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitともに指摘0件のため合格。