### PR TITLE
Fix: 課題振り返りメモの編集でMemo.created_atが上書きされる問題を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -357,6 +357,7 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             if reflectionText.isEmpty { continue }
 
             let memo = Memo()
+            var existingCreatedAt: Date?
 
             // memoIDの決定ロジック:
             // 1. task.memoIDがあればそれを使用(既存メモ編集)
@@ -365,12 +366,16 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             // 4. なければ新規ID生成(新規作成)
             if let existingMemoID = task.memoID {
                 memo.memoID = existingMemoID
+                // 既存メモをRealmから取得し、created_atを引き継ぐ
+                existingCreatedAt = (try? realmManager.getObjectById(id: existingMemoID, type: Memo.self))?.created_at
             } else {
                 let existingMemos = realmManager.getMemosByNoteID(noteID: noteID)
                 if let existingMemo = existingMemos.first(where: {
                     $0.measuresID == task.measuresID
                 }) {
                     memo.memoID = existingMemo.memoID  // 既存IDを使用
+                    // 検索でヒットした既存メモのcreated_atを引き継ぐ
+                    existingCreatedAt = existingMemo.created_at
                 } else {
                     memo.memoID = UUIDGenerator.generateID()  // 新規生成
                 }
@@ -379,6 +384,8 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             memo.measuresID = task.measuresID
             memo.noteID = noteID
             memo.detail = reflectionText
+            // 既存メモを更新する場合はcreated_atを維持し、新規作成時のみ現在時刻とする
+            memo.created_at = existingCreatedAt ?? Date()
             try? realmManager.saveItem(memo)
         }
 

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -6,26 +6,26 @@
 //
 
 import Foundation
-import Testing
 import RealmSwift
+import Testing
 
 @testable import SportsNote_iOS
 
 @Suite("NoteViewModel Tests", .serialized)
 @MainActor
 struct NoteViewModelTests {
-    
+
     init() async throws {
         // インメモリRealmの設定
         RealmManager.shared.setupInMemoryRealm()
     }
-    
+
     // MARK: - 初期化テスト
-    
+
     @Test("初期化 - プロパティが正しく初期化される")
     func initialization_propertiesAreInitializedCorrectly() async {
         let viewModel = NoteViewModel()
-        
+
         #expect(viewModel.notes.isEmpty)
         #expect(viewModel.selectedNote == nil)
         #expect(viewModel.practiceNotes.isEmpty)
@@ -36,34 +36,37 @@ struct NoteViewModelTests {
         #expect(viewModel.currentError == nil)
         #expect(viewModel.showingErrorAlert == false)
     }
-    
+
     // MARK: - NoteType列挙型テスト
-    
+
     @Test("NoteType - 全てのケースが定義されている")
     func noteType_allCasesAreDefined() async {
         let allTypes: [NoteType] = [.free, .practice, .tournament]
         #expect(NoteType.allCases.count == allTypes.count)
     }
-    
+
     @Test("NoteType - rawValueが連続している", arguments: 0..<3)
     func noteType_rawValuesAreSequential(rawValue: Int) async {
         #expect(NoteType(rawValue: rawValue) != nil)
     }
-    
-    @Test("NoteType - 各タイプにアイコンが設定されている",
-          arguments: NoteType.allCases)
+
+    @Test(
+        "NoteType - 各タイプにアイコンが設定されている",
+        arguments: NoteType.allCases)
     func noteType_eachTypeHasIcon(noteType: NoteType) async {
         #expect(!noteType.icon.isEmpty)
     }
-    
-    @Test("NoteType - 各タイプにタイトルが設定されている",
-          arguments: NoteType.allCases)
+
+    @Test(
+        "NoteType - 各タイプにタイトルが設定されている",
+        arguments: NoteType.allCases)
     func noteType_eachTypeHasTitle(noteType: NoteType) async {
         #expect(!noteType.title.isEmpty)
     }
-    
-    @Test("NoteType - アイコン名が有効なSFSymbol形式",
-          arguments: NoteType.allCases)
+
+    @Test(
+        "NoteType - アイコン名が有効なSFSymbol形式",
+        arguments: NoteType.allCases)
     func noteType_iconNamesAreValid(noteType: NoteType) async {
         // SF Symbolsの命名規則に従っているか確認
         let icon = noteType.icon
@@ -71,112 +74,116 @@ struct NoteViewModelTests {
         // ドットまたはアンダースコアを含む可能性がある
         #expect(icon.contains(".") || icon.contains("_") || icon.count > 0)
     }
-    
+
     // MARK: - Weather列挙型テスト
-    
+
     @Test("Weather - 全てのケースが定義されている")
     func weather_allCasesAreDefined() async {
         let allWeathers: [Weather] = [.sunny, .cloudy, .rainy]
         #expect(Weather.allCases.count == allWeathers.count)
     }
-    
+
     @Test("Weather - rawValueが連続している", arguments: 0..<3)
     func weather_rawValuesAreSequential(rawValue: Int) async {
         #expect(Weather(rawValue: rawValue) != nil)
     }
-    
-    @Test("Weather - 各天気にタイトルが設定されている",
-          arguments: Weather.allCases)
+
+    @Test(
+        "Weather - 各天気にタイトルが設定されている",
+        arguments: Weather.allCases)
     func weather_eachWeatherHasTitle(weather: Weather) async {
         #expect(!weather.title.isEmpty)
     }
-    
-    @Test("Weather - 各天気にアイコンが設定されている",
-          arguments: Weather.allCases)
+
+    @Test(
+        "Weather - 各天気にアイコンが設定されている",
+        arguments: Weather.allCases)
     func weather_eachWeatherHasIcon(weather: Weather) async {
         #expect(!weather.icon.isEmpty)
     }
-    
+
     // MARK: - Note作成テスト
-    
+
     @Test("Note作成 - デフォルトイニシャライザ")
     func noteCreation_defaultInitializer() async {
         let note = Note()
-        
+
         #expect(!note.noteID.isEmpty)
         #expect(note.noteType == NoteType.free.rawValue)
         #expect(note.isDeleted == false)
         #expect(note.title == "")
         #expect(note.weather == Weather.sunny.rawValue)
     }
-    
+
     @Test("Note作成 - フリーノートイニシャライザ")
     func noteCreation_freeNoteInitializer() async {
         let note = Note(title: "テストタイトル")
-        
+
         #expect(note.noteType == NoteType.free.rawValue)
         #expect(note.title == "テストタイトル")
     }
-    
+
     @Test("Note作成 - 練習ノートイニシャライザ")
     func noteCreation_practiceNoteInitializer() async {
         let note = Note(purpose: "目的", detail: "詳細")
-        
+
         #expect(note.noteType == NoteType.practice.rawValue)
         #expect(note.purpose == "目的")
         #expect(note.detail == "詳細")
     }
-    
+
     @Test("Note作成 - 大会ノートイニシャライザ")
     func noteCreation_tournamentNoteInitializer() async {
         let note = Note(target: "目標", consciousness: "意識点", result: "結果")
-        
+
         #expect(note.noteType == NoteType.tournament.rawValue)
         #expect(note.target == "目標")
         #expect(note.consciousness == "意識点")
         #expect(note.result == "結果")
     }
-    
+
     // MARK: - 温度テスト
-    
-    @Test("温度 - 様々な温度値", 
-          arguments: [-10, 0, 10, 20, 30, 40])
+
+    @Test(
+        "温度 - 様々な温度値",
+        arguments: [-10, 0, 10, 20, 30, 40])
     func temperature_variousValues(temp: Int) async {
         let note = Note()
         note.temperature = temp
-        
+
         #expect(note.temperature == temp)
     }
-    
-    @Test("温度 - 極端な温度値",
-          arguments: [-50, -100, 50, 100])
+
+    @Test(
+        "温度 - 極端な温度値",
+        arguments: [-50, -100, 50, 100])
     func temperature_extremeValues(temp: Int) async {
         let note = Note()
         note.temperature = temp
-        
+
         #expect(note.temperature == temp)
     }
-    
+
     // MARK: - 通知処理テスト
-    
+
     @Test("通知処理 - didClearAllData通知でクリアされる")
     func notification_clearsOnDidClearAllData() async {
         let viewModel = NoteViewModel()
-        
+
         // データを追加
         let testNote = Note(title: "Test")
         viewModel.notes = [testNote]
         viewModel.selectedNote = testNote
-        
+
         #expect(!viewModel.notes.isEmpty)
         #expect(viewModel.selectedNote != nil)
-        
+
         // 通知を送信
         NotificationCenter.default.post(name: .didClearAllData, object: nil)
-        
+
         // 非同期処理を待つ
-        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1秒
-        
+        try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1秒
+
         #expect(viewModel.notes.isEmpty)
         #expect(viewModel.selectedNote == nil)
         #expect(viewModel.practiceNotes.isEmpty)
@@ -184,154 +191,155 @@ struct NoteViewModelTests {
         #expect(viewModel.freeNotes.isEmpty)
         #expect(viewModel.memos.isEmpty)
     }
-    
+
     // MARK: - Note noteTypeプロパティテスト
-    
+
     @Test("noteType - フリーノートの型確認")
     func noteType_freeNote() async {
         let note = Note(title: "Free")
-        
+
         #expect(note.noteType == NoteType.free.rawValue)
         #expect(NoteType(rawValue: note.noteType) == .free)
     }
-    
+
     @Test("noteType - 練習ノートの型確認")
     func noteType_practiceNote() async {
         let note = Note(purpose: "Purpose", detail: "Detail")
-        
+
         #expect(note.noteType == NoteType.practice.rawValue)
         #expect(NoteType(rawValue: note.noteType) == .practice)
     }
-    
+
     @Test("noteType - 大会ノートの型確認")
     func noteType_tournamentNote() async {
         let note = Note(target: "Target", consciousness: "Consciousness", result: "Result")
-        
+
         #expect(note.noteType == NoteType.tournament.rawValue)
         #expect(NoteType(rawValue: note.noteType) == .tournament)
     }
-    
+
     // MARK: - 境界値テスト
-    
+
     @Test("境界値 - 空のタイトル")
     func boundaryCase_emptyTitle() async {
         let note = Note(title: "")
-        
+
         #expect(note.title == "")
     }
-    
+
     @Test("境界値 - 非常に長いタイトル")
     func boundaryCase_veryLongTitle() async {
         let longTitle = String(repeating: "あ", count: 1000)
         let note = Note(title: longTitle)
-        
+
         #expect(note.title == longTitle)
         #expect(note.title.count == 1000)
     }
-    
-    @Test("境界値 - 特殊文字を含むタイトル",
-          arguments: [
+
+    @Test(
+        "境界値 - 特殊文字を含むタイトル",
+        arguments: [
             "タイトル🎾",
             "Title\nWith\nNewlines",
             "Title\t\tWith\tTabs",
-            "Title & Special <> Characters"
-          ])
+            "Title & Special <> Characters",
+        ])
     func boundaryCase_specialCharactersInTitle(title: String) async {
         let note = Note(title: title)
-        
+
         #expect(note.title == title)
     }
-    
+
     @Test("境界値 - 大量のノート", arguments: [10, 50, 100])
     func boundaryCase_largeNotesList(count: Int) async {
         let viewModel = NoteViewModel()
-        
+
         var notes: [Note] = []
         for i in 0..<count {
             let note = Note(title: "Note \(i)")
             notes.append(note)
         }
-        
+
         viewModel.notes = notes
-        
+
         #expect(viewModel.notes.count == count)
     }
-    
+
     // MARK: - エラーハンドリングテスト
-    
+
     @Test("エラーハンドリング - isLoadingの初期状態")
     func errorHandling_isLoadingInitialState() async {
         let viewModel = NoteViewModel()
         #expect(viewModel.isLoading == false)
     }
-    
+
     @Test("エラーハンドリング - currentErrorの初期状態")
     func errorHandling_currentErrorInitialState() async {
         let viewModel = NoteViewModel()
         #expect(viewModel.currentError == nil)
     }
-    
+
     @Test("エラーハンドリング - showingErrorAlertの初期状態")
     func errorHandling_showingErrorAlertInitialState() async {
         let viewModel = NoteViewModel()
         #expect(viewModel.showingErrorAlert == false)
     }
-    
+
     // MARK: - NoteType.content メソッドテスト
-    
+
     @Test("NoteType.content - フリーノートの内容取得")
     func noteTypeContent_freeNote() async {
         let note = Note(title: "Free")
         note.detail = "Free note detail"
-        
+
         let content = NoteType.free.content(from: note)
-        
+
         #expect(content == "Free note detail")
     }
-    
+
     @Test("NoteType.content - 練習ノートの内容取得（詳細あり）")
     func noteTypeContent_practiceNoteWithDetail() async {
         let note = Note(purpose: "Purpose", detail: "Detail")
-        
+
         let content = NoteType.practice.content(from: note)
-        
+
         #expect(content == "Detail")
     }
-    
+
     @Test("NoteType.content - 練習ノートの内容取得（詳細なし）")
     func noteTypeContent_practiceNoteWithoutDetail() async {
         let note = Note(purpose: "Purpose", detail: "")
-        
+
         let content = NoteType.practice.content(from: note)
-        
+
         #expect(content == "Purpose")
     }
-    
+
     @Test("NoteType.content - 大会ノートの内容取得（結果あり）")
     func noteTypeContent_tournamentNoteWithResult() async {
         let note = Note(target: "Target", consciousness: "Consciousness", result: "Result")
-        
+
         let content = NoteType.tournament.content(from: note)
-        
+
         #expect(content == "Result")
     }
-    
+
     @Test("NoteType.content - 大会ノートの内容取得（結果なし）")
     func noteTypeContent_tournamentNoteWithoutResult() async {
         let note = Note(target: "Target", consciousness: "Consciousness", result: "")
-        
+
         let content = NoteType.tournament.content(from: note)
-        
+
         #expect(content == "Target")
     }
     // MARK: - CRUD操作テスト
-    
+
     @Test("fetchData - データを取得できる")
     func fetchData_retrievesData() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         // テストデータ作成（フリーノート以外を使用）
         let note1 = Note(purpose: "Purpose 1", detail: "Detail 1")
         note1.noteType = NoteType.practice.rawValue
@@ -339,159 +347,159 @@ struct NoteViewModelTests {
         note2.noteType = NoteType.tournament.rawValue
         try? manager.saveItem(note1)
         try? manager.saveItem(note2)
-        
+
         // データ取得
         _ = await viewModel.fetchData()
-        
+
         #expect(viewModel.notes.count == 2)
         #expect(viewModel.notes.contains(where: { $0.noteID == note1.noteID }))
         #expect(viewModel.notes.contains(where: { $0.noteID == note2.noteID }))
-        
+
         manager.clearAll()
     }
-    
-    
+
+
     @Test("delete - ノートを削除できる")
     func delete_deletesNote() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         // テストデータ（フリーノート以外でないと削除できない仕様があるため練習ノートにする）
         let note = Note(purpose: "Purpose", detail: "Detail")
         note.noteType = NoteType.practice.rawValue
         try? manager.saveItem(note)
-        
+
         // ViewModelにロード
         _ = await viewModel.fetchData()
         #expect(viewModel.notes.count == 1)
-        
+
         // 削除
         let result = await viewModel.delete(id: note.noteID)
-        
+
         // 成功確認
         if case .failure(let error) = result {
             Issue.record("Delete failed: \(error)")
         }
-        
+
         #expect(viewModel.notes.isEmpty)
-        
+
         // Realmでの論理削除確認
         let deletedNote = manager.getRawObjectById(id: note.noteID, type: Note.self)
         #expect(deletedNote?.isDeleted == true)
-        
+
         manager.clearAll()
     }
-    
+
     @Test("delete - フリーノートは削除できない")
     func delete_cannotDeleteFreeNote() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         // フリーノート作成
         let note = Note(title: "Free Note")
         note.noteType = NoteType.free.rawValue
         try? manager.saveItem(note)
-        
+
         // ViewModelにロード
         _ = await viewModel.fetchData()
-        
+
         // 削除試行
         let result = await viewModel.delete(id: note.noteID)
-        
+
         // 失敗確認
         if case .success = result {
             Issue.record("Should fail to delete free note")
         }
-        
+
         // データが残っていること
         #expect(viewModel.notes.count == 1)
         let existingNote = try? manager.getObjectById(id: note.noteID, type: Note.self)
         #expect(existingNote != nil)
-        
+
         manager.clearAll()
     }
-    
+
     // MARK: - 検索・フィルタリングテスト
-    
+
     @Test("searchNotes - クエリで検索できる")
     func searchNotes_filtersByQuery() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         // データ作成
         let note1 = Note(title: "Swift")
-        note1.noteType = NoteType.free.rawValue // フリーノートは常にヒットする仕様
-        
+        note1.noteType = NoteType.free.rawValue  // フリーノートは常にヒットする仕様
+
         let note2 = Note(purpose: "Coding", detail: "Swift Testing")
         note2.noteType = NoteType.practice.rawValue
-        
+
         let note3 = Note(target: "Win", consciousness: "Focus", result: "Good")
         note3.noteType = NoteType.tournament.rawValue
-        
+
         try? manager.saveItem(note1)
         try? manager.saveItem(note2)
         try? manager.saveItem(note3)
-        
+
         // "Testing"で検索 -> note1(Free)とnote2(Practice)がヒット
         viewModel.searchNotes(query: "Testing")
-        
+
         #expect(viewModel.notes.count == 2)
         #expect(viewModel.notes.contains(where: { $0.noteID == note1.noteID }))
         #expect(viewModel.notes.contains(where: { $0.noteID == note2.noteID }))
-        
+
         manager.clearAll()
     }
-    
+
     @Test("filterNotesByDate - 日付でフィルタリングできる")
     func filterNotesByDate_filtersByDate() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         let today = Date()
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
-        
+
         let noteToday = Note(purpose: "Today", detail: "")
         noteToday.date = today
         noteToday.noteType = NoteType.practice.rawValue
-        
+
         let noteYesterday = Note(purpose: "Yesterday", detail: "")
         noteYesterday.date = yesterday
         noteYesterday.noteType = NoteType.practice.rawValue
-        
+
         try? manager.saveItem(noteToday)
         try? manager.saveItem(noteYesterday)
-        
+
         // 今日のノートを取得
         let filtered = viewModel.filterNotesByDate(today)
-        
+
         #expect(filtered.count == 1)
         #expect(filtered.first?.noteID == noteToday.noteID)
-        
+
         manager.clearAll()
     }
-    
+
     // MARK: - 各種ノート作成メソッドテスト
-    
+
     @Test("savePracticeNote - 練習ノートを保存できる")
     func savePracticeNote_savesCorrectly() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         viewModel.savePracticeNoteWithReflections(
             purpose: "Practice Purpose",
             detail: "Practice Detail",
             weather: .rainy,
             temperature: 25
         )
-        
+
         // 保存完了を待機（ポーリング）
         var notes: [Note] = []
-        for _ in 0..<50 { // 最大5秒待機
+        for _ in 0..<50 {  // 最大5秒待機
             await Task.yield()
             if let fetched = try? manager.getDataList(clazz: Note.self), !fetched.isEmpty {
                 notes = fetched
@@ -503,34 +511,179 @@ struct NoteViewModelTests {
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
-        
+
         let note = notes.first
-        
+
         #expect(note != nil)
         #expect(note?.noteType == NoteType.practice.rawValue)
         #expect(note?.purpose == "Practice Purpose")
         #expect(note?.detail == "Practice Detail")
         #expect(note?.weather == Weather.rainy.rawValue)
         #expect(note?.temperature == 25)
-        
+
         manager.clearAll()
     }
-    
+
+    // MARK: - updateTaskReflections（課題振り返りメモ）のcreated_atテスト
+
+    @Test("updateTaskReflections - 新規作成時はcreated_atに現在時刻が設定される")
+    func updateTaskReflections_newMemo_setsCurrentCreatedAt() async {
+        let viewModel = NoteViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let beforeSave = Date()
+        let task = TaskListData(
+            taskID: "task-1",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-1",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "初回の振り返り"]
+        )
+
+        // Memoの保存はrealmManager.saveItemによる同期処理のため、この時点で既に反映されている
+        let memos = (try? manager.getDataList(clazz: Memo.self)) ?? []
+        let memo = memos.first
+
+        #expect(memo != nil)
+        #expect(memo?.detail == "初回の振り返り")
+        // 新規作成時はcreated_atに現在時刻が設定される
+        if let createdAt = memo?.created_at {
+            #expect(createdAt >= beforeSave.addingTimeInterval(-1))
+            #expect(createdAt <= Date().addingTimeInterval(1))
+        } else {
+            Issue.record("新規作成されたMemoのcreated_atが取得できませんでした")
+        }
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - task.memoIDがある場合、既存メモのcreated_atが維持される")
+    func updateTaskReflections_existingMemoWithMemoID_preservesCreatedAt() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 既存メモをRealmに直接投入（過去のcreated_atを持つ）
+        let fixedCreatedAt = Date().addingTimeInterval(-86400)
+        let existingMemo = Memo(
+            memoID: "memo-fixed-1",
+            measuresID: "measures-1",
+            noteID: "note-1",
+            detail: "初回の振り返り",
+            created_at: fixedCreatedAt
+        )
+        try? manager.saveItem(existingMemo)
+
+        let viewModel = NoteViewModel()
+        let task = TaskListData(
+            taskID: "task-1",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-1",
+            measures: "Test Measures",
+            memoID: "memo-fixed-1",
+            order: 0,
+            isComplete: false
+        )
+
+        // 既存メモを編集（task.memoIDあり）
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-1",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "編集後の振り返り"]
+        )
+
+        let updatedMemo = try? manager.getObjectById(id: "memo-fixed-1", type: Memo.self)
+
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.detail == "編集後の振り返り")
+        // created_atが編集前の値のまま維持されていること（誤差を許容して比較）
+        if let updatedCreatedAt = updatedMemo?.created_at {
+            #expect(abs(updatedCreatedAt.timeIntervalSince(fixedCreatedAt)) < 0.5)
+        } else {
+            Issue.record("更新後のMemoのcreated_atが取得できませんでした")
+        }
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - task.memoIDがなくnoteID+measuresIDで既存メモが見つかる場合もcreated_atが維持される")
+    func updateTaskReflections_existingMemoFoundBySearch_preservesCreatedAt() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 既存メモをRealmに直接投入（過去のcreated_atを持つ）
+        let fixedCreatedAt = Date().addingTimeInterval(-3600)
+        let existingMemo = Memo(
+            memoID: "memo-fixed-2",
+            measuresID: "measures-2",
+            noteID: "note-2",
+            detail: "初回の振り返り",
+            created_at: fixedCreatedAt
+        )
+        try? manager.saveItem(existingMemo)
+
+        let viewModel = NoteViewModel()
+        // memoIDを持たないTaskListDataで渡す（noteID+measuresIDでの検索分岐を通す）
+        let task = TaskListData(
+            taskID: "task-2",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-2",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-2",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "編集後の振り返り(検索経由)"]
+        )
+
+        let updatedMemo = try? manager.getObjectById(id: "memo-fixed-2", type: Memo.self)
+
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.detail == "編集後の振り返り(検索経由)")
+        if let updatedCreatedAt = updatedMemo?.created_at {
+            #expect(abs(updatedCreatedAt.timeIntervalSince(fixedCreatedAt)) < 0.5)
+        } else {
+            Issue.record("更新後のMemoのcreated_atが取得できませんでした")
+        }
+
+        manager.clearAll()
+    }
+
     @Test("saveTournamentNote - 大会ノートを保存できる")
     func saveTournamentNote_savesCorrectly() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         viewModel.saveTournamentNote(
             target: "Tournament Target",
             consciousness: "Consciousness",
             result: "Result"
         )
-        
+
         // 保存完了を待機（ポーリング）
         var notes: [Note] = []
-        for _ in 0..<50 { // 最大5秒待機
+        for _ in 0..<50 {  // 最大5秒待機
             await Task.yield()
             if let fetched = try? manager.getDataList(clazz: Note.self), !fetched.isEmpty {
                 notes = fetched
@@ -542,32 +695,32 @@ struct NoteViewModelTests {
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
-        
+
         let note = notes.first
-        
+
         #expect(note != nil)
         #expect(note?.noteType == NoteType.tournament.rawValue)
         #expect(note?.target == "Tournament Target")
         #expect(note?.consciousness == "Consciousness")
         #expect(note?.result == "Result")
-        
+
         manager.clearAll()
     }
-    
+
     @Test("saveFreeNote - フリーノートを保存できる")
     func saveFreeNote_savesCorrectly() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         viewModel.saveFreeNote(
             title: "Free Title",
             detail: "Free Detail"
         )
-        
+
         // 保存完了を待機（ポーリング）
         var notes: [Note] = []
-        for _ in 0..<50 { // 最大5秒待機
+        for _ in 0..<50 {  // 最大5秒待機
             await Task.yield()
             if let fetched = try? manager.getDataList(clazz: Note.self), !fetched.isEmpty {
                 notes = fetched
@@ -579,48 +732,48 @@ struct NoteViewModelTests {
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
-        
+
         let note = notes.first
-        
+
         #expect(note != nil)
         #expect(note?.noteType == NoteType.free.rawValue)
         #expect(note?.title == "Free Title")
         #expect(note?.detail == "Free Detail")
-        
+
         manager.clearAll()
     }
-    
+
     @Test("fetchNotesExcludingFree - フリーノートを除外して取得できる")
     func fetchNotesExcludingFree_excludesFreeNotes() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
         manager.clearAll()
-        
+
         let freeNote = Note(title: "Free")
         freeNote.noteType = NoteType.free.rawValue
-        
+
         let practiceNote = Note(purpose: "Practice", detail: "")
         practiceNote.noteType = NoteType.practice.rawValue
-        
+
         try? manager.saveItem(freeNote)
         try? manager.saveItem(practiceNote)
-        
+
         _ = await viewModel.fetchNotesExcludingFree()
-        
+
         #expect(viewModel.notes.count == 1)
         #expect(viewModel.notes.first?.noteType == NoteType.practice.rawValue)
-        
+
         manager.clearAll()
     }
 }
 
 extension NoteViewModelTests {
-    
+
     /// テスト用のNoteを作成（フリーノート）
     static func createTestFreeNote(title: String = "Test Note") -> Note {
         return Note(title: title)
     }
-    
+
     /// テスト用のNoteを作成（練習ノート）
     static func createTestPracticeNote(
         purpose: String = "Test Purpose",
@@ -628,7 +781,7 @@ extension NoteViewModelTests {
     ) -> Note {
         return Note(purpose: purpose, detail: detail)
     }
-    
+
     /// テスト用のNoteを作成（大会ノート）
     static func createTestTournamentNote(
         target: String = "Test Target",


### PR DESCRIPTION
## 概要
`NoteViewModel.updateTaskReflections`が既存の課題振り返りメモを更新する際、常に新規`Memo()`インスタンス（デフォルトinitで`created_at`が現在時刻に初期化される）を生成してIDのみ既存に合わせて保存していたため、既存メモを編集するたびに`created_at`が「今」に上書きされ、Realm/Firestore間で`created_at`が永続的に食い違う問題を修正しました。

`saveNote`が既に採用している「既存オブジェクトを`RealmManager.getObjectById`で取得し、`created_at`等を明示的に引き継ぐ」パターンを`updateTaskReflections`にも適用しています。

Closes #44

## 変更内容
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`: `updateTaskReflections`内の2つの分岐（`task.memoID`がある場合／`noteID`+`measuresID`で検索して見つかった場合）それぞれで、既存Memoの`created_at`を取得・引き継ぎ、新規作成時のみ`Date()`を設定するよう修正
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`: 新規テスト3件を追加（新規作成時にcreated_atが現在時刻になること、task.memoIDあり分岐でcreated_at維持、noteID+measuresID検索分岐でcreated_at維持）。あわせてswift-format再適用による既存コードの整形差分（import順・複数行`@Test`引数の改行位置）を含む

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`

## ビルド・テスト結果
- `xcodebuild build` → **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test` → **TEST SUCCEEDED**（445件全成功、新規3件含む）

## 完了条件チェックリスト
- [x] 既存メモの編集で`created_at`が変化しないことを確認できる単体テストがある（新規作成時は現在時刻が設定されることも確認する）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順（既存の振り返りコメント編集）で`created_at`が変化しないこと

## クロスレビュー結果
独立コンテキストのレビューエージェントによる1ラウンド目のレビューで指摘0件、合格。以下を確認済み:
- 2つの分岐それぞれで既存`created_at`の引き継ぎロジックが正しいこと
- スコープ外とした`FirebaseManager.updateMemo`・`MemoViewModel.saveMemo`に変更が及んでいないこと
- 追加テスト3件について、修正前のロジックに巻き戻すと実際に失敗することを実験で確認済み（テストの検証力を担保）
- ビルド・テストの再実行結果が申告と一致
- swift-format再適用でdiffが発生しないこと（冪等性確認済み）