### PR TITLE
refactor: CalendarView関連3ファイルでDate.get(_:)拡張を使うよう統一

### DIFF
--- a/SportsNote_iOS/View/Target/Components/CalendarSection.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarSection.swift
@@ -43,9 +43,8 @@ struct CalendarSection: View {
                 initialDate: currentMonth,
                 onDateSelected: onDateSelected,
                 onMonthChanged: { newDate in
-                    let calendar = Calendar.current
-                    let year = calendar.component(.year, from: newDate)
-                    let month = calendar.component(.month, from: newDate)
+                    let year = newDate.get(.year)
+                    let month = newDate.get(.month)
 
                     // 年月が変わったら表示される月と目標を更新
                     if year != currentDisplayedYearMonth.year || month != currentDisplayedYearMonth.month {

--- a/SportsNote_iOS/View/Target/Components/CalendarView.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarView.swift
@@ -106,10 +106,10 @@ struct CalendarView: View {
                     // 現在の月が今日の月と異なる場合は月を切り替える
                     let today = Date()
                     let calendar = Calendar.current
-                    let currentMonthValue = calendar.component(.month, from: self.currentMonth)
-                    let currentYearValue = calendar.component(.year, from: self.currentMonth)
-                    let todayMonthValue = calendar.component(.month, from: today)
-                    let todayYearValue = calendar.component(.year, from: today)
+                    let currentMonthValue = self.currentMonth.get(.month)
+                    let currentYearValue = self.currentMonth.get(.year)
+                    let todayMonthValue = today.get(.month)
+                    let todayYearValue = today.get(.year)
 
                     if currentMonthValue != todayMonthValue || currentYearValue != todayYearValue {
                         // アニメーションなしで今日の月に直接移動
@@ -170,8 +170,8 @@ struct CalendarView: View {
 
         // 表示している月の初日と末日を取得
         let calendar = Calendar.current
-        let year = calendar.component(.year, from: currentMonth)
-        let month = calendar.component(.month, from: currentMonth)
+        let year = currentMonth.get(.year)
+        let month = currentMonth.get(.month)
 
         if let startDate = calendar.date(from: DateComponents(year: year, month: month, day: 1)),
             let endDate = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startDate)

--- a/SportsNote_iOS/View/Target/Components/TodayButton.swift
+++ b/SportsNote_iOS/View/Target/Components/TodayButton.swift
@@ -11,9 +11,8 @@ struct TodayButton: View {
     var body: some View {
         Button {
             let today = Date()
-            let calendar = Calendar.current
-            selectedYear = calendar.component(.year, from: today)
-            selectedMonth = calendar.component(.month, from: today)
+            selectedYear = today.get(.year)
+            selectedMonth = today.get(.month)
             selectedDate = today
 
             // ViewModelの年月も更新


### PR DESCRIPTION
## 概要
`Date`拡張の`get(_:)`メソッド（`Calendar.current.component()`のラッパー）が存在し`CalendarView.swift`内の一部箇所では実際に使われているにもかかわらず、カレンダー関連の複数箇所で`Calendar.current.component()`が直接呼び出され続け、同一ファイル内・同一機能グループ内で書き方が混在していたため統一した。

- `TodayButton.swift`: 1箇所
- `CalendarSection.swift`: 1箇所
- `CalendarView.swift`: 2箇所

いずれも`Calendar.current.component(.year/.month, from: X)`を`X.get(.year)`/`X.get(.month)`に置換。`TodayButton.swift`・`CalendarSection.swift`は不要になった`calendar`ローカル変数を削除、`CalendarView.swift`の2箇所は`calendar`変数が他のCalendar操作（`date(from:)`等）で使われ続けるため変数自体は残した。

Closes #95

## 変更ファイル一覧
- `SportsNote_iOS/View/Target/Components/TodayButton.swift`
- `SportsNote_iOS/View/Target/Components/CalendarSection.swift`
- `SportsNote_iOS/View/Target/Components/CalendarView.swift`

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED（警告0件）
- `xcodebuild test` → TEST SUCCEEDED（全テスト成功）

## 完了条件チェックリスト
- [x] 対象4箇所すべてが`Date.get(_:)`拡張を使う形に置き換えられていること
- [x] 置き換え後も年・月の算出結果が変更前と完全に一致すること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
1ラウンド目で指摘0件（must-fix/should-fix/nitともになし）。レビュアーが独立に置換箇所の意味論的等価性、grepによるスコープ外箇所（`extractDates()`内の`calendar.component(.weekday, from:)`等）への無影響、ビルド・テスト再実行結果の一致、swift-format適用結果を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)