### PR TITLE
Refactor: MenuView.swiftのDEBUG専用テストメニュー文字列をLocalizedStrings経由に統一

### DIFF
--- a/SportsNote_iOS/Resource/LocalizedString.swift
+++ b/SportsNote_iOS/Resource/LocalizedString.swift
@@ -171,6 +171,16 @@ struct LocalizedStrings {
     static let checkTermsOfService = "checkTermsOfService".localized
     static let agree = "agree".localized
 
+    // MARK: Debug
+    static let debugSectionTitle = "debugSectionTitle".localized
+    static let debugCreateTestData = "debugCreateTestData".localized
+    static let debugCreateTestDataSubtitle = "debugCreateTestDataSubtitle".localized
+    static let debugCreateOldFormatData = "debugCreateOldFormatData".localized
+    static let debugCreateOldFormatDataSubtitle = "debugCreateOldFormatDataSubtitle".localized
+    static let debugLoginRequired = "debugLoginRequired".localized
+    static let debugResetMigrationFlag = "debugResetMigrationFlag".localized
+    static let debugResetMigrationFlagSubtitle = "debugResetMigrationFlagSubtitle".localized
+
     // MARK: Mail
     static let pleaseEnterInquiry = "pleaseEnterInquiry".localized
     static let doNotDeleteBelow = "doNotDeleteBelow".localized

--- a/SportsNote_iOS/Resource/en.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/en.lproj/Localizable.strings
@@ -170,6 +170,16 @@
 "checkTermsOfService" = "Check Terms of Service";
 "agree" = "Agree";
 
+// MARK: Debug
+"debugSectionTitle" = "Test (Debug)";
+"debugCreateTestData" = "Create Test Data";
+"debugCreateTestDataSubtitle" = "Add new-format data to Realm";
+"debugCreateOldFormatData" = "Upload Legacy Data to Firebase";
+"debugCreateOldFormatDataSubtitle" = "For migration verification";
+"debugLoginRequired" = "Login required";
+"debugResetMigrationFlag" = "Reset Migration Flag";
+"debugResetMigrationFlagSubtitle" = "Allow migration to run again";
+
 // MARK: Login/Auth
 "login" = "Login";
 "logout" = "Logout";

--- a/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
@@ -170,6 +170,16 @@
 "checkTermsOfService" = "利用規約を確認";
 "agree" = "同意";
 
+// MARK: Debug
+"debugSectionTitle" = "テスト（開発用）";
+"debugCreateTestData" = "テストデータを作成";
+"debugCreateTestDataSubtitle" = "新形式データをRealmに追加";
+"debugCreateOldFormatData" = "旧データをFirebaseに投入";
+"debugCreateOldFormatDataSubtitle" = "マイグレーション検証用";
+"debugLoginRequired" = "ログインが必要です";
+"debugResetMigrationFlag" = "マイグレーションフラグをリセット";
+"debugResetMigrationFlagSubtitle" = "再マイグレーションを許可";
+
 // MARK: Login/Auth
 "login" = "ログイン";
 "logout" = "ログアウト";

--- a/SportsNote_iOS/View/Setting/MenuView.swift
+++ b/SportsNote_iOS/View/Setting/MenuView.swift
@@ -89,43 +89,45 @@ struct MenuView: View {
         ]
 
         #if DEBUG
-        let isLogin = UserDefaultsManager.get(key: UserDefaultsManager.Keys.isLogin, defaultValue: false)
-        sections.append(
-            SectionData(
-                title: "テスト（開発用）",
-                items: [
-                    ItemData(
-                        title: "テストデータを作成",
-                        subTitle: "新形式データをRealmに追加",
-                        iconRes: "plus.circle",
-                        onClick: {
-                            Task {
-                                try? await TestDataManager.shared.createTestData()
+            let isLogin = UserDefaultsManager.get(key: UserDefaultsManager.Keys.isLogin, defaultValue: false)
+            sections.append(
+                SectionData(
+                    title: LocalizedStrings.debugSectionTitle,
+                    items: [
+                        ItemData(
+                            title: LocalizedStrings.debugCreateTestData,
+                            subTitle: LocalizedStrings.debugCreateTestDataSubtitle,
+                            iconRes: "plus.circle",
+                            onClick: {
+                                Task {
+                                    try? await TestDataManager.shared.createTestData()
+                                }
                             }
-                        }
-                    ),
-                    ItemData(
-                        title: "旧データをFirebaseに投入",
-                        subTitle: isLogin ? "マイグレーション検証用" : "ログインが必要です",
-                        iconRes: "arrow.up.doc",
-                        isEnabled: isLogin,
-                        onClick: {
-                            Task {
-                                try? await TestDataManager.shared.createOldFormatTestData()
+                        ),
+                        ItemData(
+                            title: LocalizedStrings.debugCreateOldFormatData,
+                            subTitle: isLogin
+                                ? LocalizedStrings.debugCreateOldFormatDataSubtitle
+                                : LocalizedStrings.debugLoginRequired,
+                            iconRes: "arrow.up.doc",
+                            isEnabled: isLogin,
+                            onClick: {
+                                Task {
+                                    try? await TestDataManager.shared.createOldFormatTestData()
+                                }
                             }
-                        }
-                    ),
-                    ItemData(
-                        title: "マイグレーションフラグをリセット",
-                        subTitle: "再マイグレーションを許可",
-                        iconRes: "arrow.counterclockwise",
-                        onClick: {
-                            UserDefaultsManager.remove(key: UserDefaultsManager.Keys.migrationV1Completed)
-                        }
-                    ),
-                ]
+                        ),
+                        ItemData(
+                            title: LocalizedStrings.debugResetMigrationFlag,
+                            subTitle: LocalizedStrings.debugResetMigrationFlagSubtitle,
+                            iconRes: "arrow.counterclockwise",
+                            onClick: {
+                                UserDefaultsManager.remove(key: UserDefaultsManager.Keys.migrationV1Completed)
+                            }
+                        ),
+                    ]
+                )
             )
-        )
         #endif
 
         return sections


### PR DESCRIPTION
## 概要
`MenuView.swift`の`#if DEBUG`ブロック内（開発用テストメニュー）で、セクションタイトル・項目タイトル・サブタイトルの計8箇所が`LocalizedStrings`を経由せず日本語文字列を直書きしていた問題を修正する。

Closes #102

## 変更内容
- `ja.lproj`/`en.lproj`の`Localizable.strings`に8キー（`debugSectionTitle`等）を追加
- `LocalizedString.swift`に`// MARK: Debug`セクションを新設し対応する`static let`を追加
- `MenuView.swift`の`#if DEBUG`ブロック内8箇所を`LocalizedStrings`経由の参照に置き換え

## 変更ファイル一覧
- `SportsNote_iOS/View/Setting/MenuView.swift`
- `SportsNote_iOS/Resource/LocalizedString.swift`
- `SportsNote_iOS/Resource/ja.lproj/Localizable.strings`
- `SportsNote_iOS/Resource/en.lproj/Localizable.strings`

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test` → TEST SUCCEEDED（463件全成功）

## 完了条件チェックリスト
- [x] `MenuView.swift`の`#if DEBUG`ブロック内8箇所が`LocalizedStrings`経由の参照に置き換わっていること
- [x] `ja.lproj/Localizable.strings`・`en.lproj/Localizable.strings`双方に対応するキーが追加されていること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立コンテキストのサブエージェントによるクロスレビューを実施（ビルド・テストの独立再実行込み）。must-fix/should-fix/nitいずれも指摘なしで合格（1ラウンド）。ja.lproj側の追加値が元の日本語リテラルと完全一致していることも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)