### PR TITLE
Fix: migrate成功後にmarkOldXxxDeletedだけ失敗するとTask/Target/Noteが重複作成される問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/MigrationStepRunner.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationStepRunner.swift
@@ -7,6 +7,12 @@ import Foundation
 /// 旧データを保持したまま処理を継続させる（issue #35: 必須フィールド欠損によるデータ恒久消失の防止）。
 /// `MigrationError`以外のエラー（Firestore通信エラー等）はそのままrethrowし、
 /// 既存の異常系挙動（`migrateAll()`全体の中断）を変えない。
+///
+/// また、`migrate`が成功した直後に`markDeleted`だけが失敗した場合、旧ドキュメントの
+/// `isDeleted`が更新されないため次回のマイグレーション再実行で同一旧ドキュメントが再取得され、
+/// `migrate`が再実行されて新規レコードが重複作成されてしまう（issue #30）。これを防ぐため、
+/// `entity`+`documentID`単位で「migrate成功済みか」をUserDefaults経由で永続的に記録し、
+/// 既にmigrate済みの場合は`migrate`をスキップして`markDeleted`のみ再試行する。
 @MainActor
 struct MigrationStepRunner {
 
@@ -19,8 +25,8 @@ struct MigrationStepRunner {
 
     /// 1件の旧データについて、変換→旧データ削除を実行する
     /// - Parameters:
-    ///   - entity: ログ出力用のエンティティ名（例: "Task"）
-    ///   - documentID: ログ出力用の旧ドキュメントID
+    ///   - entity: ログ出力用・べき等性ガードのキー用のエンティティ名（例: "Task"）
+    ///   - documentID: ログ出力用・べき等性ガードのキー用の旧ドキュメントID
     ///   - migrate: 変換処理（`MigrationError.invalidData`をthrowした場合はスキップ扱いとする）
     ///   - markDeleted: 変換成功時にのみ実行する旧データ削除処理
     /// - Throws: `migrate`/`markDeleted`が`MigrationError`以外のエラーをthrowした場合、そのまま伝播する
@@ -30,12 +36,41 @@ struct MigrationStepRunner {
         migrate: () async throws -> Void,
         markDeleted: () async throws -> Void
     ) async throws {
-        do {
-            try await migrate()
-        } catch let error as MigrationError {
-            logger("旧\(entity)データの変換に失敗したため、旧データを保持します: documentID=\(documentID), error=\(error)")
-            return
+        if isAlreadyMigrated(entity: entity, documentID: documentID) {
+            // 前回の実行でmigrateは成功済み（markDeletedのみ失敗）のため、
+            // migrateを再実行せずmarkDeletedのみ再試行する（issue #30: 重複作成防止）
+            logger("旧\(entity)データは変換済みのためスキップし、旧データ削除のみ再試行します: documentID=\(documentID)")
+        } else {
+            do {
+                try await migrate()
+            } catch let error as MigrationError {
+                logger("旧\(entity)データの変換に失敗したため、旧データを保持します: documentID=\(documentID), error=\(error)")
+                return
+            }
+            markAsMigrated(entity: entity, documentID: documentID)
         }
+
         try await markDeleted()
+
+        // markDeletedまで成功したら、旧ドキュメントは再取得されなくなるためガード記録は不要になる
+        clearMigrated(entity: entity, documentID: documentID)
+    }
+
+    // MARK: - べき等性ガード（migrate成功後のmarkDeleted失敗による重複作成防止）
+
+    private func guardKey(entity: String, documentID: String) -> String {
+        "migratedOldDoc_\(entity)_\(documentID)"
+    }
+
+    private func isAlreadyMigrated(entity: String, documentID: String) -> Bool {
+        UserDefaultsManager.get(key: guardKey(entity: entity, documentID: documentID), defaultValue: false)
+    }
+
+    private func markAsMigrated(entity: String, documentID: String) {
+        UserDefaultsManager.set(key: guardKey(entity: entity, documentID: documentID), value: true)
+    }
+
+    private func clearMigrated(entity: String, documentID: String) {
+        UserDefaultsManager.remove(key: guardKey(entity: entity, documentID: documentID))
     }
 }

--- a/SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift
+++ b/SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift
@@ -13,12 +13,20 @@ import Testing
 /// `MigrationManager`はFirebaseFirestoreに直接依存し、Firebase未設定のテスト環境では
 /// インスタンス化するとクラッシュするため、`MigrationManager`/`FirebaseManager`には一切触れず
 /// `MigrationStepRunner`単体をスタブクロージャで検証する（issue #35）。
-@Suite("MigrationStepRunner Tests")
+///
+/// issue #30対応（migrate成功後にmarkDeletedだけ失敗した場合の重複作成防止）のガードは
+/// UserDefaultsを介して永続化されるため、本Suiteは`@Suite(.serialized)`で同期実行し、
+/// 各テストの前後で`UserDefaultsManager.clearAll()`によりガード状態をクリーンな状態に保つ。
+@Suite("MigrationStepRunner Tests", .serialized)
 @MainActor
 struct MigrationStepRunnerTests {
 
     private enum StubError: Error {
         case network
+    }
+
+    init() {
+        UserDefaultsManager.clearAll()
     }
 
     @Test("migrate/markDeletedが共に成功する場合、両方が1回ずつ呼ばれる")
@@ -39,6 +47,105 @@ struct MigrationStepRunnerTests {
         #expect(migrateCallCount == 1)
         #expect(markDeletedCallCount == 1)
         #expect(loggedMessages.isEmpty)
+    }
+
+    @Test("migrate成功後にmarkDeletedだけ失敗して再実行しても、migrateは再実行されない（issue #30の再現・修正確認）")
+    func run_markDeletedFailsThenRetried_doesNotDuplicateMigrate() async throws {
+        var migrateCallCount = 0
+        var markDeletedCallCount = 0
+        var shouldMarkDeletedFail = true
+
+        let runner = MigrationStepRunner()
+
+        // 1回目: migrateは成功するが、markDeletedがネットワーク断等で失敗する
+        await #expect(throws: StubError.self) {
+            try await runner.run(
+                entity: "Task",
+                documentID: "doc-dup",
+                migrate: { migrateCallCount += 1 },
+                markDeleted: {
+                    markDeletedCallCount += 1
+                    if shouldMarkDeletedFail { throw StubError.network }
+                }
+            )
+        }
+        #expect(migrateCallCount == 1)
+        #expect(markDeletedCallCount == 1)
+
+        // 2回目（次回起動時の再実行を模す）: 旧ドキュメントのisDeletedが更新されていないため
+        // 同一documentIDで再度runが呼ばれるが、migrateは再実行されず、markDeletedのみ再試行される
+        shouldMarkDeletedFail = false
+        try await runner.run(
+            entity: "Task",
+            documentID: "doc-dup",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: { markDeletedCallCount += 1 }
+        )
+
+        #expect(migrateCallCount == 1)  // 修正前は2（重複作成）になってしまっていた箇所
+        #expect(markDeletedCallCount == 2)
+    }
+
+    @Test("markDeletedが成功して完了すると、ガード記録がクリアされ以降は独立した新規ドキュメントとして扱われる")
+    func run_markDeletedSucceeds_clearsGuardState() async throws {
+        var migrateCallCount = 0
+
+        let runner = MigrationStepRunner()
+
+        try await runner.run(
+            entity: "Task",
+            documentID: "doc-clear",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: {}
+        )
+        #expect(migrateCallCount == 1)
+
+        // markDeletedまで成功しているため、同じdocumentIDで再度runを呼んでもガードは残っておらず
+        // （実運用ではisDeleted=trueにより再取得されないため到達しないが）migrateは通常通り実行される
+        try await runner.run(
+            entity: "Task",
+            documentID: "doc-clear",
+            migrate: { migrateCallCount += 1 },
+            markDeleted: {}
+        )
+        #expect(migrateCallCount == 2)
+    }
+
+    @Test("entityが異なれば同じdocumentIDでも独立してガードされる")
+    func run_differentEntitiesSameDocumentID_areGuardedIndependently() async throws {
+        var taskMigrateCallCount = 0
+        var targetMigrateCallCount = 0
+
+        let runner = MigrationStepRunner()
+
+        // Task側: migrate成功・markDeleted失敗でガードが立つ
+        await #expect(throws: StubError.self) {
+            try await runner.run(
+                entity: "Task",
+                documentID: "shared-doc-id",
+                migrate: { taskMigrateCallCount += 1 },
+                markDeleted: { throw StubError.network }
+            )
+        }
+        #expect(taskMigrateCallCount == 1)
+
+        // Target側: 同じdocumentIDだがentityが異なるため、Task側のガードの影響を受けず通常通り実行される
+        try await runner.run(
+            entity: "Target",
+            documentID: "shared-doc-id",
+            migrate: { targetMigrateCallCount += 1 },
+            markDeleted: {}
+        )
+        #expect(targetMigrateCallCount == 1)
+
+        // Task側を再実行: ガードが効いてmigrateはスキップされる
+        try await runner.run(
+            entity: "Task",
+            documentID: "shared-doc-id",
+            migrate: { taskMigrateCallCount += 1 },
+            markDeleted: {}
+        )
+        #expect(taskMigrateCallCount == 1)
     }
 
     @Test(


### PR DESCRIPTION
## 概要
旧アプリ（UIKit版）データのマイグレーション処理（`MigrationManager.migrateAll()`）で、新形式データの保存後に旧データの削除フラグ更新（`markOldXxxDeleted`）だけが失敗すると、次回起動時に同一データが重複して再作成される問題を修正した。

### 原因
- `migrateAll()`は各旧ドキュメントに対し「新形式への変換・保存（`migrateXxx`）」→「旧ドキュメントの削除フラグ更新（`markOldXxxDeleted`）」を順に実行する
- `migrateTask`/`migrateTarget`は呼び出しごとに`UUIDGenerator.generateID()`で新規UUIDを採番するため、`markOldXxxDeleted`だけがネットワーク断等で失敗して`migrateAll()`が例外throwすると、`migrationV1Completed`フラグが立たないまま終了する
- 次回起動時、旧ドキュメントの`isDeleted`が更新されていないため同一ドキュメントが再取得され、`migrateXxx`が再実行されて新しいUUIDで重複レコードが作成される

## 対応内容
issue本文は`MigrationManager.swift`を変更対象として挙げていたが、調査の結果、`migrateAll()`内のTask/Target/FreeNote/Noteの4ループはすべて共通の実行役`MigrationStepRunner.run(entity:documentID:migrate:markDeleted:)`（issue #35で導入）経由になっていたため、**`MigrationManager.swift`は無変更**とし、`MigrationStepRunner`側にべき等性ガードを追加する形で対応した。

- `MigrationStepRunner.run`に、`entity`+`documentID`をキーとしたUserDefaultsベースのべき等性ガードを追加
  - `migrate`成功後にガードフラグを立てる（`markAsMigrated`）
  - 次回同じ`entity`+`documentID`で`run`が呼ばれた際、フラグが立っていれば`migrate`をスキップし、`markDeleted`のみ再試行する
  - `markDeleted`まで成功したらガードフラグをクリアする（`clearMigrated`）ため、UserDefaultsにゴミが残り続けることはない
- `MigrationManager`は`Firestore.firestore()`をプロパティに持ちFirebase未設定のテスト環境ではインスタンス化するとクラッシュするため、既存パターン（issue #35で確立した「Firebase非依存ロジックを`MigrationStepRunner`に切り出してスタブテストする」方針）を踏襲し、テスト容易性を確保した

### 過去の対応試行について
本issueには過去に別アプローチ（`MigrationDedupeGuard`という新規独立structを追加する実装、PR #34）が試みられたが、マージされずCloseされている（当時は`MigrationStepRunner`がまだmainに存在しない時期）。今回はそのPRの実装を参照せず、`MigrationStepRunner`導入後の現在のmainを起点に、既存の同一責務の型を拡張する設計で独立に対応した。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/MigrationStepRunner.swift`: べき等性ガードロジックを追加
- `SportsNote_iOSTests/Managers/MigrationStepRunnerTests.swift`: 再現・修正確認テストを追加、`@Suite(.serialized)`化

## ビルド・テスト結果
- swift-format: 正常完了
- ビルド: BUILD SUCCEEDED（警告0件）
- テスト: TEST SUCCEEDED（466件全成功、既存テストの回帰なし）

## 完了条件チェックリスト
- [x] `migrateXxx`成功後に`markOldXxxDeleted`が失敗しても、次回のマイグレーション再実行で同一データが重複作成されないことを確認できる（`MigrationStepRunner`のべき等性ガードで保証）
- [x] 上記シナリオを再現する単体テストを追加し、修正後にテストが成功する（`run_markDeletedFailsThenRetried_doesNotDuplicateMigrate`）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（466件全成功）
- [x] 再現手順で問題が再現しないこと（クロスレビュアーがガード条件を一時的に無効化して新規テストが失敗することを確認済み。実運用のFirestoreネットワーク断再現は困難なためユニットテストで担保）

## クロスレビュー結果
1ラウンド目でmust-fix指摘なし、should-fix 1件のみのため合格扱い:
- **should-fix**: `MigrationStepRunnerTests.swift`の`@Suite(.serialized)`＋`init()`内`UserDefaultsManager.clearAll()`は、Swift Testingのstructにteardownがないためテスト後片付けができず、`.serialized`もスイート間の並行実行までは防げない（issue #11・#15で既に指摘済みの既知制約の継続であり、今回新規に持ち込んだ問題ではない）

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)