### PR TITLE
Fix: JapaneseHolidayCheckerが「国民の休日」を判定できない問題を修正

### DIFF
--- a/SportsNote_iOS/Utils/JapaneseHolidayChecker.swift
+++ b/SportsNote_iOS/Utils/JapaneseHolidayChecker.swift
@@ -30,6 +30,11 @@ class JapaneseHolidayChecker {
             return true
         }
 
+        // 国民の休日（祝日と祝日に挟まれた平日）をチェック
+        if isCitizensHoliday(date) {
+            return true
+        }
+
         return false
     }
 
@@ -143,6 +148,36 @@ class JapaneseHolidayChecker {
         }
 
         return false
+    }
+
+    // 国民の休日（祝日法第3条3項: 前日・翌日がともに祝日である平日を休日とする）
+    private static func isCitizensHoliday(_ date: Date) -> Bool {
+        let weekday = jpCalendar.component(.weekday, from: date)
+
+        // 日曜日は対象外（既に休日であり、振替休日制度と役割が重複するため）
+        if weekday == 1 {
+            return false
+        }
+
+        guard let yesterday = jpCalendar.date(byAdding: .day, value: -1, to: date),
+            let tomorrow = jpCalendar.date(byAdding: .day, value: 1, to: date)
+        else {
+            return false
+        }
+
+        return isNamedHoliday(yesterday) && isNamedHoliday(tomorrow)
+    }
+
+    // 「国民の休日」の前日・翌日判定に用いる祝日集合（固定祝日・ハッピーマンデー・春分秋分のみ。
+    // 振替休日は祝日法上の「祝日」に含まれないため対象外とする）
+    private static func isNamedHoliday(_ date: Date) -> Bool {
+        let year = jpCalendar.component(.year, from: date)
+        let month = jpCalendar.component(.month, from: date)
+        let day = jpCalendar.component(.day, from: date)
+
+        return isFixedHoliday(month: month, day: day)
+            || isHappyMondayHoliday(year: year, month: month, day: day)
+            || isEquinoxDay(year: year, month: month, day: day)
     }
 
     // 年月日からDate型を生成するヘルパーメソッド

--- a/SportsNote_iOSTests/Utils/JapaneseHolidayCheckerTests.swift
+++ b/SportsNote_iOSTests/Utils/JapaneseHolidayCheckerTests.swift
@@ -191,6 +191,55 @@ struct JapaneseHolidayCheckerTests {
         #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
     }
 
+    // MARK: - 国民の休日テスト
+
+    @Test(
+        "国民の休日 - 敬老の日と秋分の日に挟まれた平日",
+        arguments: [2009, 2015, 2026]
+    )
+    func citizensHoliday_betweenRespectForTheAgedDayAndAutumnEquinox(year: Int) {
+        // 敬老の日（9月第3月曜）が21日、秋分の日が23日になる年は
+        // 間の22日（火曜）が「国民の休日」として休日になる
+        let date = createDate(year: year, month: 9, day: 22)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("国民の休日 - 前日（敬老の日）自体は引き続き祝日と判定される")
+    func citizensHoliday_dayBeforeIsStillHoliday() {
+        let date = createDate(year: 2026, month: 9, day: 21)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("国民の休日 - 翌日（秋分の日）自体は引き続き祝日と判定される")
+    func citizensHoliday_dayAfterIsStillHoliday() {
+        let date = createDate(year: 2026, month: 9, day: 23)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("国民の休日 - 前日のみ祝日で翌日は非祝日の場合はfalse")
+    func citizensHoliday_onlyPreviousDayIsHoliday() {
+        // 2026年9月23日（秋分の日）の翌日24日は前日(23日)は祝日だが翌々日(25日)は非祝日
+        let date = createDate(year: 2026, month: 9, day: 24)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("国民の休日 - 振替休日は前日・翌日判定の祝日集合に含まれない")
+    func citizensHoliday_substituteHolidayNotCountedAsNamedHoliday() {
+        // 2025年2月23日（天皇誕生日）は日曜日のため24日(月)が振替休日。
+        // 25日(火)は前日(24日)が振替休日のみで「祝日法上の祝日」ではないため
+        // 国民の休日にはならない
+        let date = createDate(year: 2025, month: 2, day: 25)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("国民の休日 - ゴールデンウィーク中でも前日・翌日が両方祝日でない日はfalse")
+    func citizensHoliday_goldenWeekGapDaysRemainNonHoliday() {
+        let may1 = createDate(year: 2025, month: 5, day: 1)
+        let may2 = createDate(year: 2025, month: 5, day: 2)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(may1))
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(may2))
+    }
+
     // MARK: - 異常系テスト（祝日ではない日）
 
     @Test("非祝日 - 通常の平日")


### PR DESCRIPTION
## 概要
`JapaneseHolidayChecker.isJapaneseHoliday`に「国民の休日」（祝日と祝日に挟まれた平日を休日とする、祝日法第3条3項）の判定ロジックを追加した。

前日・翌日がともに「振替休日を除く」名付き祝日（固定祝日・ハッピーマンデー・春分秋分のいずれか）であり、かつ当日が日曜日でない場合に`true`を返す`isCitizensHoliday`を新設し、`isJapaneseHoliday`から呼び出す。振替休日を前日・翌日判定の祝日集合に含めない理由（法的根拠・循環判定回避）はコード内コメントに明記。

具体例: 2026年は敬老の日(9/21,月)・秋分の日(9/23,水)に挟まれた9/22(火)が「国民の休日」に該当し、`isJapaneseHoliday(2026-09-22)`が`true`を返すようになる。これにより`CalendarView.swift`の祝日色分け（赤色表示）が`doc/spec/14_target.md`の仕様どおりに機能する。

Closes #48

## 変更ファイル一覧
- `SportsNote_iOS/Utils/JapaneseHolidayChecker.swift`: `isCitizensHoliday`・`isNamedHoliday`を追加
- `SportsNote_iOSTests/Utils/JapaneseHolidayCheckerTests.swift`: 国民の休日に関するテストケース6件を追加（パラメータ化1件含む）

## ビルド・テスト結果
- `xcodebuild build`: **BUILD SUCCEEDED**（警告0件）
- `xcodebuild test`: **TEST SUCCEEDED**（469件全成功。JapaneseHolidayCheckerTestsは53件全成功）

## 完了条件チェックリスト
- [x] `2026-09-22`（敬老の日と秋分の日に挟まれた平日）を`JapaneseHolidayChecker.isJapaneseHoliday`に渡すと`true`が返る単体テストが追加され成功する
- [x] 既存の`JapaneseHolidayCheckerTests.swift`のテストケースがすべて引き続き成功する（固定祝日・ハッピーマンデー・春分秋分・振替休日の判定に影響なし）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立コンテキストのレビュアーによるクロスレビューを実施（1ラウンドで合格）。

- must-fix: なし
- should-fix 1件: `citizensHoliday_substituteHolidayNotCountedAsNamedHoliday`テストが、意図した「振替休日を国民の休日の前日・翌日判定に含めない」設計を実質的に検証できていない（レビュアーが`isNamedHoliday`に振替休日を混入させるロールバック実験を行っても既存テストが全てPASSしたまま変化しないことを確認）。追加調査として1980〜2100年の全日付をPythonで全探索したが、「振替休日の前後2日以内に別の名付き祝日が存在する」組み合わせは0件であり、実カレンダー日付だけでこの分岐を差分検出するテストは現状構成不可能なことを確認した。実装ロジック自体は祝日法の条文どおり正しいため、should-fixとして記録のみ行い修正は見送り。

詳細は `references/review-insights.md`（2026-08-01 issue #48）に記録済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)