### PR TITLE
Fix: mapFirebaseErrorがNSURLErrorDomainのネットワークエラーを分類できない問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Error/SportsNoteError.swift
+++ b/SportsNote_iOS/Model/Error/SportsNoteError.swift
@@ -168,35 +168,15 @@ struct ErrorMapper {
     ///   - context: エラーが発生したコンテキスト情報
     /// - Returns: 変換されたSportsNoteError
     static func mapFirebaseError(_ error: Error, context: String = "") -> SportsNoteError {
-        // FirebaseのNSError処理
-        if let nsError = error as NSError? {
-            // Firestore エラーコード
-            switch nsError.code {
-            case 7:  // PERMISSION_DENIED
-                return .firebasePermissionDenied
-            case 5:  // NOT_FOUND
-                return .firebaseDocumentNotFound
-            case 14:  // UNAVAILABLE
-                return .firebaseNetworkError
-            case 8:  // RESOURCE_EXHAUSTED
-                return .firebaseQuotaExceeded
-            case 16:  // UNAUTHENTICATED
-                return .firebaseAuthenticationFailed
-            case 13:  // INTERNAL
-                return .firebaseServerError
-            case 4:  // DEADLINE_EXCEEDED
-                return .networkTimeout
-            default:
-                // 予期しないFirebaseエラー
-                if nsError.code >= 1000 {
-                    return .criticalError(error, context: "Firebase-\(context)")
-                }
-                return .unexpectedError(error)
-            }
+        guard let nsError = error as NSError? else {
+            // 完全に不明なエラー
+            return .unknownError("Firebase Error: \(error.localizedDescription)")
         }
 
-        // ネットワーク関連のエラーチェック
-        if let nsError = error as NSError?, nsError.domain == NSURLErrorDomain {
+        // ネットワーク関連のエラーチェック（Firestore固有コードより先に判定する。
+        // NSURLErrorDomainのコード（-1000番台）とFirestoreのコード（0〜16程度）は
+        // 値域が重ならないため、判定順序を入れ替えても既存のFirestore分類には影響しない）
+        if nsError.domain == NSURLErrorDomain {
             switch nsError.code {
             case NSURLErrorNotConnectedToInternet:
                 return .networkUnavailable
@@ -207,8 +187,29 @@ struct ErrorMapper {
             }
         }
 
-        // 完全に不明なエラー
-        return .unknownError("Firebase Error: \(error.localizedDescription)")
+        // Firestore エラーコード
+        switch nsError.code {
+        case 7:  // PERMISSION_DENIED
+            return .firebasePermissionDenied
+        case 5:  // NOT_FOUND
+            return .firebaseDocumentNotFound
+        case 14:  // UNAVAILABLE
+            return .firebaseNetworkError
+        case 8:  // RESOURCE_EXHAUSTED
+            return .firebaseQuotaExceeded
+        case 16:  // UNAUTHENTICATED
+            return .firebaseAuthenticationFailed
+        case 13:  // INTERNAL
+            return .firebaseServerError
+        case 4:  // DEADLINE_EXCEEDED
+            return .networkTimeout
+        default:
+            // 予期しないFirebaseエラー
+            if nsError.code >= 1000 {
+                return .criticalError(error, context: "Firebase-\(context)")
+            }
+            return .unexpectedError(error)
+        }
     }
 
     /// システムエラーを統一的にマッピング

--- a/SportsNote_iOSTests/Models/SportsNoteErrorTests.swift
+++ b/SportsNote_iOSTests/Models/SportsNoteErrorTests.swift
@@ -1,0 +1,113 @@
+//
+//  SportsNoteErrorTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/01.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("ErrorMapper.mapFirebaseError Tests")
+struct SportsNoteErrorTests {
+
+    // MARK: - NSURLErrorDomain（issue #53: ネットワークエラー分類）
+
+    @Test("mapFirebaseError - 未接続エラーはnetworkUnavailableに分類される")
+    func mapFirebaseError_notConnectedToInternet_returnsNetworkUnavailable() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        let result = ErrorMapper.mapFirebaseError(error)
+
+        guard case .networkUnavailable = result else {
+            Issue.record("Expected .networkUnavailable but got \(result)")
+            return
+        }
+    }
+
+    @Test("mapFirebaseError - タイムアウトエラーはnetworkTimeoutに分類される")
+    func mapFirebaseError_timedOut_returnsNetworkTimeout() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        let result = ErrorMapper.mapFirebaseError(error)
+
+        guard case .networkTimeout = result else {
+            Issue.record("Expected .networkTimeout but got \(result)")
+            return
+        }
+    }
+
+    @Test(
+        "mapFirebaseError - その他のNSURLErrorDomainコードはfirebaseNetworkErrorに分類される",
+        arguments: [
+            NSURLErrorNetworkConnectionLost, NSURLErrorCannotConnectToHost, NSURLErrorDNSLookupFailed,
+        ])
+    func mapFirebaseError_otherURLErrors_returnsFirebaseNetworkError(code: Int) {
+        let error = NSError(domain: NSURLErrorDomain, code: code)
+        let result = ErrorMapper.mapFirebaseError(error)
+
+        guard case .firebaseNetworkError = result else {
+            Issue.record("Expected .firebaseNetworkError but got \(result)")
+            return
+        }
+    }
+
+    // MARK: - Firestore固有コード（回帰防止: 既存分類の維持確認）
+
+    @Test(
+        "mapFirebaseError - Firestore固有コードは従来通り分類される",
+        arguments: [
+            (7, "firebasePermissionDenied"),
+            (5, "firebaseDocumentNotFound"),
+            (14, "firebaseNetworkError"),
+            (8, "firebaseQuotaExceeded"),
+            (16, "firebaseAuthenticationFailed"),
+            (13, "firebaseServerError"),
+            (4, "networkTimeout"),
+        ])
+    func mapFirebaseError_firestoreCodes_returnsExpectedCase(code: Int, expected: String) {
+        // FirestoreのNSErrorはdomainがNSURLErrorDomain以外（実際はFIRFirestoreErrorDomain相当）であることを模擬
+        let error = NSError(domain: "FIRFirestoreErrorDomain", code: code)
+        let result = ErrorMapper.mapFirebaseError(error)
+
+        #expect(describeCase(result) == expected)
+    }
+
+    // MARK: - 未知・予期しないエラー
+
+    @Test("mapFirebaseError - 1000以上の未知コードはcriticalErrorに分類される")
+    func mapFirebaseError_unknownHighCode_returnsCriticalError() {
+        let error = NSError(domain: "SomeOtherDomain", code: 1234)
+        let result = ErrorMapper.mapFirebaseError(error, context: "test")
+
+        guard case .criticalError = result else {
+            Issue.record("Expected .criticalError but got \(result)")
+            return
+        }
+    }
+
+    @Test("mapFirebaseError - 未知の低コードはunexpectedErrorに分類される")
+    func mapFirebaseError_unknownLowCode_returnsUnexpectedError() {
+        let error = NSError(domain: "SomeOtherDomain", code: 999)
+        let result = ErrorMapper.mapFirebaseError(error)
+
+        guard case .unexpectedError = result else {
+            Issue.record("Expected .unexpectedError but got \(result)")
+            return
+        }
+    }
+}
+
+/// SportsNoteErrorがEquatable未準拠（一部caseがError型を保持するため自動合成不可）のためのcase比較用ヘルパー
+private func describeCase(_ error: SportsNoteError) -> String {
+    switch error {
+    case .firebasePermissionDenied: return "firebasePermissionDenied"
+    case .firebaseDocumentNotFound: return "firebaseDocumentNotFound"
+    case .firebaseNetworkError: return "firebaseNetworkError"
+    case .firebaseQuotaExceeded: return "firebaseQuotaExceeded"
+    case .firebaseAuthenticationFailed: return "firebaseAuthenticationFailed"
+    case .firebaseServerError: return "firebaseServerError"
+    case .networkTimeout: return "networkTimeout"
+    default: return "other"
+    }
+}


### PR DESCRIPTION
## 概要
`ErrorMapper.mapFirebaseError`（`SportsNote_iOS/Model/Error/SportsNoteError.swift`）で、Firestore固有コードのswitchが`NSURLErrorDomain`判定より先に評価されていたため、Swiftの`Error as NSError?`が常にブリッジに成功する仕様上、`NSURLErrorDomain`専用分岐（`.networkUnavailable`/`.networkTimeout`）と`.unknownError`フォールバックが恒久的に到達不能なデッドコードになっていた。

オフライン状態やタイムアウト発生時（`URLError.notConnectedToInternet`＝コード-1009等）に本来`.networkUnavailable`/`.networkTimeout`になるべきエラーが`.unexpectedError`に分類され、`View/Common/ErrorAlertModifier.swift`でユーザーに表示されるアラートが汎用的な内容になり、実際の原因（オフライン/タイムアウト）に気づけない問題を修正した。

Closes #53

## 変更内容
- `NSURLErrorDomain`のチェックをFirestore固有コード（7,5,14,8,16,13,4等）のswitchより先に行うよう順序を入れ替え
- `NSURLErrorDomain`のコード値（-1000番台）とFirestoreのコード値（0〜16程度）は値域が重ならないため、順序入れ替えによる既存分類への影響なし

## 変更ファイル
- `SportsNote_iOS/Model/Error/SportsNoteError.swift`（`ErrorMapper.mapFirebaseError`のみ変更）
- `SportsNote_iOSTests/Models/SportsNoteErrorTests.swift`（新規作成、Swift Testing使用）

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED（警告0件）
- `xcodebuild test`: TEST SUCCEEDED（469 tests / 20 suites全成功、新規追加`SportsNoteErrorTests`スイート含む）

## 完了条件
- [x] `NSURLErrorNotConnectedToInternet`を持つエラーが`mapFirebaseError`経由で`.networkUnavailable`に、`NSURLErrorTimedOut`を持つエラーが`.networkTimeout`に正しく分類されることを新規単体テストで確認
- [x] 上記以外のFirestore固有エラーコード（7,5,14,8,16,13,4等）の分類が従来通り維持されている（回帰テストで確認）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
1ラウンドでmust-fix指摘なし、合格。

- should-fix 1件: `guard let nsError = error as NSError? else { return .unknownError(...) }`のelse節は、Swiftの仕様上どんな`Error`も`as NSError?`で必ずブリッジに成功するため恒久的に到達不能なデッドコードのまま残る。issue本文は「`.unknownError`フォールバックが実際に機能することを確認する」としているが、これはSwiftの言語仕様上原理的に満たせない要求のため、位置を変えても解消されない。完了条件チェックリスト自体はすべて満たしており、新規テストも到達不能branchへの検証力のないテストを書いていない点は適切なため、修正は行わず合格扱いとした。
- レビュアーはロールバック実験（修正前構造に戻す）により、新規追加した5テストケース（NSURLErrorDomain関連）が期待通り失敗し、Firestore固有コード関連テストは変わらずPASSすることを確認済み（検証力のあるテストであることを実証）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)