### PR TITLE
Fix: FirebaseManager.updateDocumentのみエラーマッピング(ErrorMapper.mapFirebaseError)が欠落している問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/FirebaseManager.swift
+++ b/SportsNote_iOS/Model/Manager/FirebaseManager.swift
@@ -484,21 +484,26 @@ final class FirebaseManager {
      * @param collection コレクション名
      * @param documentID ドキュメントID
      * @param data 更新するデータ
+     * @throws SportsNoteError Firebase更新に失敗した場合
      */
     private func updateDocument(
         collection: String,
         documentID: String,
         data: [String: Any]
     ) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            db.collection(collection).document(documentID)
-                .updateData(data) { error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: ())
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                db.collection(collection).document(documentID)
+                    .updateData(data) { error in
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume(returning: ())
+                        }
                     }
-                }
+            }
+        } catch let error {
+            throw ErrorMapper.mapFirebaseError(error, context: "updateDocument-\(collection)-\(documentID)")
         }
     }
 


### PR DESCRIPTION
## 概要
`FirebaseManager.swift`の`saveDocument`・`getAllDocuments`は`do/catch`で`ErrorMapper.mapFirebaseError`によるエラー変換を行っているが、同様の共通private関数である`updateDocument`のみ`do/catch`がなく、Firebaseから返る生のエラーをそのまま送出していた。`saveDocument`と同じパターンで`updateDocument`をラップし、エラーハンドリングの対称性を確保した。

Closes #101

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/FirebaseManager.swift`（`updateDocument`のみ、do/catch追加）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED（警告0件）
- テスト: TEST SUCCEEDED（463件全成功）
- 新規テストは追加していません。理由: `updateDocument`はprivateメソッドで`FirebaseManager`はプロトコル抽象化されていないシングルトンのためモック不可、かつテスト実行時は`FirebaseSyncable.isOnlineAndLoggedIn`が`#if DEBUG`ブロックでテスト用Realm設定時に常に`false`を返す設計のため、既存のViewModelテスト経由でもこの呼び出し経路自体に到達しません。同一パターンの`saveDocument`/`getAllDocuments`についても専用テストは存在しません（issue #30・#35・#36で確立済みの既知の制約）。

## 完了条件チェックリスト
- [x] `updateDocument`が`saveDocument`と同様に`do/catch`で`ErrorMapper.mapFirebaseError`による変換を行うこと
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] `updateGroup`等6メソッド経由でFirebase更新が失敗した場合に、`SportsNoteError`（マッピング後のエラー）が送出されること

## クロスレビュー結果
1ラウンド目でmust-fix/should-fix/nitとも指摘なし、合格。レビュアーが`saveDocument`とのパターン一致・6呼び出し元の網羅性・テスト非追加判断の妥当性を独立に検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)