### PR TITLE
refactor: FirebaseManagerのgetAllXxx群のFirestoreデコード処理を共通化

### DIFF
--- a/SportsNote_iOS/Model/Manager/FirebaseManager.swift
+++ b/SportsNote_iOS/Model/Manager/FirebaseManager.swift
@@ -237,34 +237,7 @@ final class FirebaseManager {
      */
     func getAllGroup() async throws -> [Group] {
         let documents = try await getAllDocuments(collection: "Group")
-
-        return documents.compactMap { document -> Group? in
-            let data = document.data()
-            let group = Group()
-
-            guard let userID = data["userID"] as? String,
-                let groupID = data["groupID"] as? String,
-                let title = data["title"] as? String,
-                let color = data["color"] as? Int,
-                let order = data["order"] as? Int,
-                let isDeleted = data["isDeleted"] as? Bool,
-                let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
-                let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
-            else {
-                return nil
-            }
-
-            group.userID = userID
-            group.groupID = groupID
-            group.title = title
-            group.color = color
-            group.order = order
-            group.isDeleted = isDeleted
-            group.created_at = created_at
-            group.updated_at = updated_at
-
-            return group
-        }
+        return documents.compactMap { Group(firestoreData: $0.data()) }
     }
 
     /**
@@ -274,38 +247,7 @@ final class FirebaseManager {
      */
     func getAllTask() async throws -> [TaskData] {
         let documents = try await getAllDocuments(collection: "Task")
-
-        return documents.compactMap { document -> TaskData? in
-            let data = document.data()
-            let task = TaskData()
-
-            guard let userID = data["userID"] as? String,
-                let taskID = data["taskID"] as? String,
-                let groupID = data["groupID"] as? String,
-                let title = data["title"] as? String,
-                let cause = data["cause"] as? String,
-                let order = data["order"] as? Int,
-                let isComplete = data["isComplete"] as? Bool,
-                let isDeleted = data["isDeleted"] as? Bool,
-                let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
-                let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
-            else {
-                return nil
-            }
-
-            task.userID = userID
-            task.taskID = taskID
-            task.groupID = groupID
-            task.title = title
-            task.cause = cause
-            task.order = order
-            task.isComplete = isComplete
-            task.isDeleted = isDeleted
-            task.created_at = created_at
-            task.updated_at = updated_at
-
-            return task
-        }
+        return documents.compactMap { TaskData(firestoreData: $0.data()) }
     }
 
     /**
@@ -315,34 +257,7 @@ final class FirebaseManager {
      */
     func getAllMeasures() async throws -> [Measures] {
         let documents = try await getAllDocuments(collection: "Measures")
-
-        return documents.compactMap { document -> Measures? in
-            let data = document.data()
-            let measure = Measures()
-
-            guard let userID = data["userID"] as? String,
-                let measuresID = data["measuresID"] as? String,
-                let taskID = data["taskID"] as? String,
-                let title = data["title"] as? String,
-                let order = data["order"] as? Int,
-                let isDeleted = data["isDeleted"] as? Bool,
-                let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
-                let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
-            else {
-                return nil
-            }
-
-            measure.userID = userID
-            measure.measuresID = measuresID
-            measure.taskID = taskID
-            measure.title = title
-            measure.order = order
-            measure.isDeleted = isDeleted
-            measure.created_at = created_at
-            measure.updated_at = updated_at
-
-            return measure
-        }
+        return documents.compactMap { Measures(firestoreData: $0.data()) }
     }
 
     /**
@@ -352,34 +267,7 @@ final class FirebaseManager {
      */
     func getAllMemo() async throws -> [Memo] {
         let documents = try await getAllDocuments(collection: "Memo")
-
-        return documents.compactMap { document -> Memo? in
-            let data = document.data()
-            let memo = Memo()
-
-            guard let userID = data["userID"] as? String,
-                let memoID = data["memoID"] as? String,
-                let noteID = data["noteID"] as? String,
-                let measuresID = data["measuresID"] as? String,
-                let detail = data["detail"] as? String,
-                let isDeleted = data["isDeleted"] as? Bool,
-                let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
-                let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
-            else {
-                return nil
-            }
-
-            memo.userID = userID
-            memo.memoID = memoID
-            memo.noteID = noteID
-            memo.measuresID = measuresID
-            memo.detail = detail
-            memo.isDeleted = isDeleted
-            memo.created_at = created_at
-            memo.updated_at = updated_at
-
-            return memo
-        }
+        return documents.compactMap { Memo(firestoreData: $0.data()) }
     }
 
     /**
@@ -389,36 +277,7 @@ final class FirebaseManager {
      */
     func getAllTarget() async throws -> [Target] {
         let documents = try await getAllDocuments(collection: "Target")
-
-        return documents.compactMap { document -> Target? in
-            let data = document.data()
-            let target = Target()
-
-            guard let userID = data["userID"] as? String,
-                let targetID = data["targetID"] as? String,
-                let title = data["title"] as? String,
-                let year = data["year"] as? Int,
-                let month = data["month"] as? Int,
-                let isYearlyTarget = data["isYearlyTarget"] as? Bool,
-                let isDeleted = data["isDeleted"] as? Bool,
-                let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
-                let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
-            else {
-                return nil
-            }
-
-            target.userID = userID
-            target.targetID = targetID
-            target.title = title
-            target.year = year
-            target.month = month
-            target.isYearlyTarget = isYearlyTarget
-            target.isDeleted = isDeleted
-            target.created_at = created_at
-            target.updated_at = updated_at
-
-            return target
-        }
+        return documents.compactMap { Target(firestoreData: $0.data()) }
     }
 
     /**
@@ -428,52 +287,7 @@ final class FirebaseManager {
      */
     func getAllNote() async throws -> [Note] {
         let documents = try await getAllDocuments(collection: "Note")
-
-        return documents.compactMap { document -> Note? in
-            let data = document.data()
-            let note = Note()
-
-            guard let userID = data["userID"] as? String,
-                let noteID = data["noteID"] as? String,
-                let noteType = data["noteType"] as? Int,
-                let isDeleted = data["isDeleted"] as? Bool,
-                let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
-                let updated_at = (data["updated_at"] as? Timestamp)?.dateValue(),
-                let title = data["title"] as? String,
-                let date = (data["date"] as? Timestamp)?.dateValue(),
-                let weather = data["weather"] as? Int,
-                let temperature = data["temperature"] as? Int,
-                let condition = data["condition"] as? String,
-                let reflection = data["reflection"] as? String,
-                let purpose = data["purpose"] as? String,
-                let detail = data["detail"] as? String,
-                let target = data["target"] as? String,
-                let consciousness = data["consciousness"] as? String,
-                let result = data["result"] as? String
-            else {
-                return nil
-            }
-
-            note.userID = userID
-            note.noteID = noteID
-            note.noteType = noteType
-            note.isDeleted = isDeleted
-            note.created_at = created_at
-            note.updated_at = updated_at
-            note.title = title
-            note.date = date
-            note.weather = weather
-            note.temperature = temperature
-            note.condition = condition
-            note.reflection = reflection
-            note.purpose = purpose
-            note.detail = detail
-            note.target = target
-            note.consciousness = consciousness
-            note.result = result
-
-            return note
-        }
+        return documents.compactMap { Note(firestoreData: $0.data()) }
     }
 
     // MARK: - Update
@@ -628,5 +442,211 @@ final class FirebaseManager {
         ]
 
         try await updateDocument(collection: "Note", documentID: documentID, data: data)
+    }
+}
+
+// MARK: - Firestoreデコード
+
+extension Group {
+    /// Firestoreドキュメントのフィールド辞書からGroupを生成する
+    ///
+    /// - Parameter data: Firestoreドキュメントの`data()`
+    /// - Returns: 必須フィールドがすべて揃っている場合はGroup、欠落・型不一致がある場合はnil
+    convenience init?(firestoreData data: [String: Any]) {
+        guard let userID = data["userID"] as? String,
+            let groupID = data["groupID"] as? String,
+            let title = data["title"] as? String,
+            let color = data["color"] as? Int,
+            let order = data["order"] as? Int,
+            let isDeleted = data["isDeleted"] as? Bool,
+            let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
+            let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
+        else {
+            return nil
+        }
+
+        self.init()
+        self.userID = userID
+        self.groupID = groupID
+        self.title = title
+        self.color = color
+        self.order = order
+        self.isDeleted = isDeleted
+        self.created_at = created_at
+        self.updated_at = updated_at
+    }
+}
+
+extension TaskData {
+    /// Firestoreドキュメントのフィールド辞書からTaskDataを生成する
+    ///
+    /// - Parameter data: Firestoreドキュメントの`data()`
+    /// - Returns: 必須フィールドがすべて揃っている場合はTaskData、欠落・型不一致がある場合はnil
+    convenience init?(firestoreData data: [String: Any]) {
+        guard let userID = data["userID"] as? String,
+            let taskID = data["taskID"] as? String,
+            let groupID = data["groupID"] as? String,
+            let title = data["title"] as? String,
+            let cause = data["cause"] as? String,
+            let order = data["order"] as? Int,
+            let isComplete = data["isComplete"] as? Bool,
+            let isDeleted = data["isDeleted"] as? Bool,
+            let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
+            let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
+        else {
+            return nil
+        }
+
+        self.init()
+        self.userID = userID
+        self.taskID = taskID
+        self.groupID = groupID
+        self.title = title
+        self.cause = cause
+        self.order = order
+        self.isComplete = isComplete
+        self.isDeleted = isDeleted
+        self.created_at = created_at
+        self.updated_at = updated_at
+    }
+}
+
+extension Measures {
+    /// Firestoreドキュメントのフィールド辞書からMeasuresを生成する
+    ///
+    /// - Parameter data: Firestoreドキュメントの`data()`
+    /// - Returns: 必須フィールドがすべて揃っている場合はMeasures、欠落・型不一致がある場合はnil
+    convenience init?(firestoreData data: [String: Any]) {
+        guard let userID = data["userID"] as? String,
+            let measuresID = data["measuresID"] as? String,
+            let taskID = data["taskID"] as? String,
+            let title = data["title"] as? String,
+            let order = data["order"] as? Int,
+            let isDeleted = data["isDeleted"] as? Bool,
+            let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
+            let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
+        else {
+            return nil
+        }
+
+        self.init()
+        self.userID = userID
+        self.measuresID = measuresID
+        self.taskID = taskID
+        self.title = title
+        self.order = order
+        self.isDeleted = isDeleted
+        self.created_at = created_at
+        self.updated_at = updated_at
+    }
+}
+
+extension Memo {
+    /// Firestoreドキュメントのフィールド辞書からMemoを生成する
+    ///
+    /// - Parameter data: Firestoreドキュメントの`data()`
+    /// - Returns: 必須フィールドがすべて揃っている場合はMemo、欠落・型不一致がある場合はnil
+    convenience init?(firestoreData data: [String: Any]) {
+        guard let userID = data["userID"] as? String,
+            let memoID = data["memoID"] as? String,
+            let noteID = data["noteID"] as? String,
+            let measuresID = data["measuresID"] as? String,
+            let detail = data["detail"] as? String,
+            let isDeleted = data["isDeleted"] as? Bool,
+            let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
+            let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
+        else {
+            return nil
+        }
+
+        self.init()
+        self.userID = userID
+        self.memoID = memoID
+        self.noteID = noteID
+        self.measuresID = measuresID
+        self.detail = detail
+        self.isDeleted = isDeleted
+        self.created_at = created_at
+        self.updated_at = updated_at
+    }
+}
+
+extension Target {
+    /// Firestoreドキュメントのフィールド辞書からTargetを生成する
+    ///
+    /// - Parameter data: Firestoreドキュメントの`data()`
+    /// - Returns: 必須フィールドがすべて揃っている場合はTarget、欠落・型不一致がある場合はnil
+    convenience init?(firestoreData data: [String: Any]) {
+        guard let userID = data["userID"] as? String,
+            let targetID = data["targetID"] as? String,
+            let title = data["title"] as? String,
+            let year = data["year"] as? Int,
+            let month = data["month"] as? Int,
+            let isYearlyTarget = data["isYearlyTarget"] as? Bool,
+            let isDeleted = data["isDeleted"] as? Bool,
+            let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
+            let updated_at = (data["updated_at"] as? Timestamp)?.dateValue()
+        else {
+            return nil
+        }
+
+        self.init()
+        self.userID = userID
+        self.targetID = targetID
+        self.title = title
+        self.year = year
+        self.month = month
+        self.isYearlyTarget = isYearlyTarget
+        self.isDeleted = isDeleted
+        self.created_at = created_at
+        self.updated_at = updated_at
+    }
+}
+
+extension Note {
+    /// Firestoreドキュメントのフィールド辞書からNoteを生成する
+    ///
+    /// - Parameter data: Firestoreドキュメントの`data()`
+    /// - Returns: 必須フィールドがすべて揃っている場合はNote、欠落・型不一致がある場合はnil
+    convenience init?(firestoreData data: [String: Any]) {
+        guard let userID = data["userID"] as? String,
+            let noteID = data["noteID"] as? String,
+            let noteType = data["noteType"] as? Int,
+            let isDeleted = data["isDeleted"] as? Bool,
+            let created_at = (data["created_at"] as? Timestamp)?.dateValue(),
+            let updated_at = (data["updated_at"] as? Timestamp)?.dateValue(),
+            let title = data["title"] as? String,
+            let date = (data["date"] as? Timestamp)?.dateValue(),
+            let weather = data["weather"] as? Int,
+            let temperature = data["temperature"] as? Int,
+            let condition = data["condition"] as? String,
+            let reflection = data["reflection"] as? String,
+            let purpose = data["purpose"] as? String,
+            let detail = data["detail"] as? String,
+            let target = data["target"] as? String,
+            let consciousness = data["consciousness"] as? String,
+            let result = data["result"] as? String
+        else {
+            return nil
+        }
+
+        self.init()
+        self.userID = userID
+        self.noteID = noteID
+        self.noteType = noteType
+        self.isDeleted = isDeleted
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.title = title
+        self.date = date
+        self.weather = weather
+        self.temperature = temperature
+        self.condition = condition
+        self.reflection = reflection
+        self.purpose = purpose
+        self.detail = detail
+        self.target = target
+        self.consciousness = consciousness
+        self.result = result
     }
 }

--- a/SportsNote_iOSTests/Models/FirestoreDecodingTests.swift
+++ b/SportsNote_iOSTests/Models/FirestoreDecodingTests.swift
@@ -1,0 +1,245 @@
+//
+//  FirestoreDecodingTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/03.
+//
+
+import FirebaseFirestore
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// issue #110: FirebaseManagerのgetAllXxx群で重複していたFirestoreデコード処理を
+/// 各モデルの`convenience init?(firestoreData:)`に集約したことを検証するテスト
+@Suite("Firestore Decoding Tests")
+struct FirestoreDecodingTests {
+
+    // MARK: - Group
+
+    @Test("Group(firestoreData:) - 必須フィールドが揃っていれば生成できる")
+    func group_decodesWhenAllFieldsPresent() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "groupID": "group1",
+            "title": "テストグループ",
+            "color": 2,
+            "order": 3,
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+        ]
+
+        let group = Group(firestoreData: data)
+
+        #expect(group != nil)
+        #expect(group?.userID == "user1")
+        #expect(group?.groupID == "group1")
+        #expect(group?.title == "テストグループ")
+        #expect(group?.color == 2)
+        #expect(group?.order == 3)
+        #expect(group?.isDeleted == false)
+    }
+
+    @Test("Group(firestoreData:) - 必須フィールドが欠落していればnilを返す")
+    func group_returnsNilWhenFieldMissing() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "groupID": "group1",
+            "title": "テストグループ",
+            "color": 2,
+            // "order" 欠落
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+        ]
+
+        #expect(Group(firestoreData: data) == nil)
+    }
+
+    // MARK: - TaskData
+
+    @Test("TaskData(firestoreData:) - 必須フィールドが揃っていれば生成できる")
+    func taskData_decodesWhenAllFieldsPresent() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "taskID": "task1",
+            "groupID": "group1",
+            "title": "テスト課題",
+            "cause": "原因",
+            "order": 1,
+            "isComplete": false,
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+        ]
+
+        let task = TaskData(firestoreData: data)
+
+        #expect(task != nil)
+        #expect(task?.taskID == "task1")
+        #expect(task?.groupID == "group1")
+        #expect(task?.cause == "原因")
+    }
+
+    @Test("TaskData(firestoreData:) - 必須フィールドが欠落していればnilを返す")
+    func taskData_returnsNilWhenFieldMissing() {
+        let data: [String: Any] = [
+            "userID": "user1",
+            "taskID": "task1",
+        ]
+
+        #expect(TaskData(firestoreData: data) == nil)
+    }
+
+    // MARK: - Measures
+
+    @Test("Measures(firestoreData:) - 必須フィールドが揃っていれば生成できる")
+    func measures_decodesWhenAllFieldsPresent() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "measuresID": "measures1",
+            "taskID": "task1",
+            "title": "テスト対策",
+            "order": 0,
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+        ]
+
+        let measures = Measures(firestoreData: data)
+
+        #expect(measures != nil)
+        #expect(measures?.measuresID == "measures1")
+        #expect(measures?.taskID == "task1")
+    }
+
+    @Test("Measures(firestoreData:) - 必須フィールドが欠落していればnilを返す")
+    func measures_returnsNilWhenFieldMissing() {
+        let data: [String: Any] = [
+            "userID": "user1"
+        ]
+
+        #expect(Measures(firestoreData: data) == nil)
+    }
+
+    // MARK: - Memo
+
+    @Test("Memo(firestoreData:) - 必須フィールドが揃っていれば生成できる")
+    func memo_decodesWhenAllFieldsPresent() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "memoID": "memo1",
+            "noteID": "note1",
+            "measuresID": "measures1",
+            "detail": "詳細",
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+        ]
+
+        let memo = Memo(firestoreData: data)
+
+        #expect(memo != nil)
+        #expect(memo?.memoID == "memo1")
+        #expect(memo?.detail == "詳細")
+    }
+
+    @Test("Memo(firestoreData:) - 必須フィールドが欠落していればnilを返す")
+    func memo_returnsNilWhenFieldMissing() {
+        let data: [String: Any] = [
+            "userID": "user1"
+        ]
+
+        #expect(Memo(firestoreData: data) == nil)
+    }
+
+    // MARK: - Target
+
+    @Test("Target(firestoreData:) - 必須フィールドが揃っていれば生成できる")
+    func target_decodesWhenAllFieldsPresent() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "targetID": "target1",
+            "title": "テスト目標",
+            "year": 2026,
+            "month": 8,
+            "isYearlyTarget": true,
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+        ]
+
+        let target = Target(firestoreData: data)
+
+        #expect(target != nil)
+        #expect(target?.targetID == "target1")
+        #expect(target?.isYearlyTarget == true)
+    }
+
+    @Test("Target(firestoreData:) - 必須フィールドが欠落していればnilを返す")
+    func target_returnsNilWhenFieldMissing() {
+        let data: [String: Any] = [
+            "userID": "user1"
+        ]
+
+        #expect(Target(firestoreData: data) == nil)
+    }
+
+    // MARK: - Note
+
+    @Test("Note(firestoreData:) - 必須フィールドが揃っていれば生成できる")
+    func note_decodesWhenAllFieldsPresent() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "noteID": "note1",
+            "noteType": 1,
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+            "title": "",
+            "date": now,
+            "weather": 0,
+            "temperature": 20,
+            "condition": "晴れ",
+            "reflection": "振り返り",
+            "purpose": "目的",
+            "detail": "詳細",
+            "target": "目標",
+            "consciousness": "意識点",
+            "result": "結果",
+        ]
+
+        let note = Note(firestoreData: data)
+
+        #expect(note != nil)
+        #expect(note?.noteID == "note1")
+        #expect(note?.noteType == 1)
+        #expect(note?.condition == "晴れ")
+        #expect(note?.result == "結果")
+    }
+
+    @Test("Note(firestoreData:) - 必須フィールドが欠落していればnilを返す")
+    func note_returnsNilWhenFieldMissing() {
+        let now = Timestamp(date: Date())
+        let data: [String: Any] = [
+            "userID": "user1",
+            "noteID": "note1",
+            "noteType": 1,
+            "isDeleted": false,
+            "created_at": now,
+            "updated_at": now,
+                // "title" 以降のフィールドが欠落
+        ]
+
+        #expect(Note(firestoreData: data) == nil)
+    }
+}


### PR DESCRIPTION
## 概要
`FirebaseManager.swift`の`getAllGroup`/`getAllTask`/`getAllMeasures`/`getAllMemo`/`getAllTarget`/`getAllNote`（計6メソッド）が、いずれも「Firestoreドキュメントを`guard let ... as? Type`で必須フィールド検証し、モデルオブジェクトへ手動でフィールドをコピーする」という同一パターンを個別実装していた。各モデルの`convenience init?(firestoreData:)`にデコード処理を集約し、`getAllXxx`側は`compactMap { Xxx(firestoreData: $0.data()) }`に簡略化した。

Closes #110

## 設計判断（issue記載との差異）
issue本文の「各モデルに...を用意する」という文言は、モデルファイル本体（`Group.swift`等）を編集することを示唆しているようにも読めますが、issueの「変更対象ファイル」欄は`FirebaseManager.swift`のみを明記しています。この矛盾を解消するため、**モデルファイル自体は一切変更せず**、`FirebaseManager.swift`の末尾（クラス定義の外側）に各モデル型への`extension`として`convenience init?(firestoreData:)`を追加する設計を採用しました。Swiftのextensionは型定義ファイルとは別ファイルに書けるため技術的に問題なく、`SyncManager.swift`（`Syncable`プロトコル準拠のextensionをManagerファイル側に配置）という既存の前例パターンを踏襲しています。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/FirebaseManager.swift`（`getAllXxx`6メソッドの簡略化＋6モデル分の`convenience init?(firestoreData:)`追加）
- `SportsNote_iOSTests/Models/FirestoreDecodingTests.swift`（新規、12テスト）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED（警告0件）
- テスト: TEST SUCCEEDED（475件全成功、新規12件含む）

## 完了条件チェックリスト
- [x] 6つの`getAllXxx`メソッドが共通のデコード処理経由でモデルを生成するようになっていること
- [x] 各モデルのフィールド欠落判定（`guard let`相当のnilチェック）がデコード処理側に集約され、`getAllXxx`側から重複コードが除去されていること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
1ラウンド目でmust-fix/nitとも指摘なし。should-fix 2件のみのため合格扱い：
- `TaskData`/`Measures`/`Memo`/`Target`の「欠落フィールド」テストが単一フィールドのみを外す設計になっておらず、特定フィールドのガード漏れ検知精度が`Group`のテスト（`"order"`単独欠落）より低い
- 同様に一部モデルの正常系テストが全フィールド値を検証していない

いずれも将来同種のテストを書く際の改善余地として記録し、今回は修正を見送りました（issue #21・#48と同系統のパターンですが、`getAllXxx`が直接デコード処理を呼ぶ単純な配線のため実害は限定的と判断）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)