### PR TITLE
Fix: 起動直後のNetwork.isOnline()誤判定によりマイグレーション/同期がスキップされる問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/InitializationManager.swift
+++ b/SportsNote_iOS/Model/Manager/InitializationManager.swift
@@ -37,9 +37,15 @@ final class InitializationManager {
         }
 
         // ログイン済みの場合、アプリ起動時にデータ同期を実行
-        if !isFirstLaunch && isUserLoggedIn() && Network.isOnline() {
-            await migrateOldData()
-            await syncAllData()
+        // NWPathMonitorの初回コールバックが未到達のままNetwork.isOnline()を判定すると
+        // 実際はオンラインでもデフォルト値falseが返り同期がスキップされてしまうため、
+        // 判定前に初回パス確定を待ち合わせる
+        if !isFirstLaunch && isUserLoggedIn() {
+            await Network.waitForInitialPath()
+            if Network.isOnline() {
+                await migrateOldData()
+                await syncAllData()
+            }
         }
     }
 

--- a/SportsNote_iOS/Utils/Network.swift
+++ b/SportsNote_iOS/Utils/Network.swift
@@ -13,6 +13,9 @@ final class Network: Sendable {
     /// 現在のネットワーク接続状態（アトミックにアクセスするための値）
     private let _isConnected = AtomicValue<Bool>(initialValue: false)
 
+    /// NWPathMonitorの初回パス確定を待ち合わせるための状態
+    private let pathReadyState = NetworkPathReadyState()
+
     /// 現在のネットワーク接続状態（読み取り専用）
     var isConnected: Bool {
         return _isConnected.value
@@ -34,6 +37,7 @@ final class Network: Sendable {
             guard let self = self else { return }
             let isConnected = path.status == .satisfied
             self._isConnected.value = isConnected
+            self.pathReadyState.markReady()
         }
         monitor.start(queue: monitorQueue)
     }
@@ -47,6 +51,116 @@ final class Network: Sendable {
     /// - Returns: ネットワークが利用可能な場合はtrue
     static func isOnline() -> Bool {
         return shared.isConnected
+    }
+
+    /// NWPathMonitorの初回パス確定（初回コールバック到達）を待ち合わせる
+    /// アプリ起動直後など、`isOnline()`の判定がNWPathMonitorの初回コールバックより先に
+    /// 実行され、実際はオンラインでもデフォルト値`false`が返ってしまう問題を防ぐために使用する
+    /// - Parameter timeout: 最大待機秒数。コールバックが到達しない異常系での保険（デフォルト2秒）
+    static func waitForInitialPath(timeout: TimeInterval = 2.0) async {
+        await shared.pathReadyState.waitUntilReady(timeout: timeout)
+    }
+}
+
+/// `NWPathMonitor`の初回パス確定を待ち合わせるための状態管理クラス
+/// `NWPathMonitor`そのものには依存せず、`markReady()`/`waitUntilReady(timeout:)`のみで構成されるため、
+/// 単体テストでは`NWPathMonitor`を介さずにこのクラス単体を検証できる
+final class NetworkPathReadyState: @unchecked Sendable {
+    /// `CheckedContinuation`を一度だけresumeすることを保証するためのラッパー
+    /// `markReady()`とタイムアウト処理が競合しても二重resumeによるクラッシュを防ぐ
+    private final class ContinuationBox: @unchecked Sendable {
+        private let continuation: CheckedContinuation<Void, Never>
+        private let lock = NSLock()
+        private var didResume = false
+
+        init(_ continuation: CheckedContinuation<Void, Never>) {
+            self.continuation = continuation
+        }
+
+        func resumeOnce() {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didResume else { return }
+            didResume = true
+            continuation.resume()
+        }
+    }
+
+    private let lock = NSLock()
+    private var isReady = false
+    private var pendingBoxes: [ContinuationBox] = []
+
+    /// 初回パス確定を通知する（`NWPathMonitor`の`pathUpdateHandler`から呼ばれる想定）
+    /// 2回目以降の呼び出しでは何もしない
+    func markReady() {
+        let boxes: [ContinuationBox] = {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !isReady else { return [] }
+            isReady = true
+            let boxes = pendingBoxes
+            pendingBoxes.removeAll()
+            return boxes
+        }()
+
+        boxes.forEach { $0.resumeOnce() }
+    }
+
+    /// 初回パス確定を待ち合わせる。既に確定済みの場合は即座に返る
+    /// タイムアウトした場合も（コールバックが到達しない異常系向けの保険として）復帰する
+    /// - Parameter timeout: 最大待機秒数
+    func waitUntilReady(timeout: TimeInterval) async {
+        if currentIsReady() {
+            return
+        }
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let box = ContinuationBox(continuation)
+
+            if registerIfNotReady(box) {
+                // 登録前に既にready化されていた場合は即座にresumeする
+                box.resumeOnce()
+                return
+            }
+
+            DispatchQueue.global()
+                .asyncAfter(deadline: .now() + timeout) { [weak self] in
+                    guard let self = self else {
+                        box.resumeOnce()
+                        return
+                    }
+                    self.removePendingBox(box)
+                    box.resumeOnce()
+                }
+        }
+    }
+
+    /// 現在のready状態を返す（同期処理としてロックを閉じ込めるためのヘルパー）
+    private func currentIsReady() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isReady
+    }
+
+    /// 未readyであれば`box`を待機リストに登録する
+    /// - Returns: 登録時点で既にreadyだった場合はtrue（呼び出し元は即座にresumeする）
+    private func registerIfNotReady(_ box: ContinuationBox) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if isReady {
+            return true
+        }
+        pendingBoxes.append(box)
+        return false
+    }
+
+    /// 待機リストから`box`を取り除く（タイムアウト到達時に呼ばれる）
+    private func removePendingBox(_ box: ContinuationBox) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let index = pendingBoxes.firstIndex(where: { $0 === box }) {
+            pendingBoxes.remove(at: index)
+        }
     }
 }
 

--- a/SportsNote_iOSTests/Utils/NetworkPathReadyStateTests.swift
+++ b/SportsNote_iOSTests/Utils/NetworkPathReadyStateTests.swift
@@ -1,0 +1,95 @@
+//
+//  NetworkPathReadyStateTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/03.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// `NWPathMonitor`は実機・OS依存のため、`Network`クラスそのものではなく
+/// 初回パス確定の待ち合わせロジックを抽出した`NetworkPathReadyState`単体を検証する（issue #68）。
+@Suite("NetworkPathReadyState Tests")
+struct NetworkPathReadyStateTests {
+
+    @Test("markReady()を先に呼んでからwaitUntilReady()を呼ぶと即座に返る")
+    func waitUntilReady_alreadyReady_returnsImmediately() async {
+        let state = NetworkPathReadyState()
+        state.markReady()
+
+        let start = Date()
+        await state.waitUntilReady(timeout: 5.0)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 1.0)
+    }
+
+    @Test("waitUntilReady()呼び出し後に別Taskでmarkready()を呼ぶと待機が解除される")
+    func waitUntilReady_markReadyFromAnotherTask_resolvesBeforeTimeout() async {
+        let state = NetworkPathReadyState()
+
+        let start = Date()
+        async let waiter: Void = state.waitUntilReady(timeout: 5.0)
+
+        // waitUntilReady()の登録が先に走るよう少し待ってからmarkReady()を呼ぶ
+        try? await Task.sleep(nanoseconds: 50_000_000)  // 0.05秒
+        state.markReady()
+
+        await waiter
+        let elapsed = Date().timeIntervalSince(start)
+
+        // タイムアウト(5秒)よりも十分早く解除されること
+        #expect(elapsed < 2.0)
+    }
+
+    @Test("複数のTaskが同時にwaitUntilReady()しても1回のmarkReady()で全て解除される")
+    func waitUntilReady_multipleWaiters_allResolvedByOneMarkReady() async {
+        let state = NetworkPathReadyState()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    await state.waitUntilReady(timeout: 5.0)
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 50_000_000)  // 0.05秒
+                state.markReady()
+            }
+            await group.waitForAll()
+        }
+
+        // 全Taskが完了（=二重resumeでクラッシュせず正常終了）すればテスト成功
+        #expect(Bool(true))
+    }
+
+    @Test("markReady()が呼ばれない場合、指定timeout後にwaitUntilReady()が復帰する")
+    func waitUntilReady_neverMarkedReady_resolvesAfterTimeout() async {
+        let state = NetworkPathReadyState()
+
+        let start = Date()
+        await state.waitUntilReady(timeout: 0.2)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed >= 0.2)
+        #expect(elapsed < 2.0)
+    }
+
+    @Test("markReady()を複数回呼んでも安全（2回目以降は何もしない）")
+    func markReady_calledMultipleTimes_isSafe() async {
+        let state = NetworkPathReadyState()
+
+        state.markReady()
+        state.markReady()
+        state.markReady()
+
+        let start = Date()
+        await state.waitUntilReady(timeout: 5.0)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 1.0)
+    }
+}


### PR DESCRIPTION
## 概要
アプリ起動直後、`Network.isOnline()`が実際はオンラインであっても`false`を返しうるタイミング依存の不具合があり、ログイン済みユーザーの起動時マイグレーション・Firebase同期がスキップされる可能性がある問題を修正した。

`Network`クラスの`_isConnected`は`AtomicValue<Bool>(initialValue: false)`で初期化され、実際の接続状態は`NWPathMonitor`の`pathUpdateHandler`が非同期で初めて発火するまで確定しない。`InitializationManager.initializeApp()`の`Network.isOnline()`判定がこの初回コールバックより先に実行されると、実際はオンラインでもデフォルト値`false`が返り、`migrateOldData()`・`syncAllData()`がスキップされてしまう。

- `Network.swift`に`NetworkPathReadyState`を追加し、`NWPathMonitor`の初回パス確定を待ち合わせる`static func waitForInitialPath(timeout:)`を公開（デフォルトタイムアウト2秒。コールバック未到達の異常系向けの保険）
- `InitializationManager.initializeApp()`が`Network.isOnline()`を判定する前に`Network.waitForInitialPath()`を呼ぶよう変更（ログイン済みユーザーの場合のみ待機コストが発生し、初回起動・未ログイン時は従来通り待機なし）
- `NWPathMonitor`実機依存部分から切り離した`NetworkPathReadyState`単体を検証する新規テストを追加

## Closes
Closes #68

## 変更ファイル一覧
- `SportsNote_iOS/Utils/Network.swift`
- `SportsNote_iOS/Model/Manager/InitializationManager.swift`
- `SportsNote_iOSTests/Utils/NetworkPathReadyStateTests.swift`（新規）

## ビルド・テスト結果
- `xcodebuild build` → **BUILD SUCCEEDED**（警告なし）
- `xcodebuild test` → **TEST SUCCEEDED**（468件全成功、新規`NetworkPathReadyState Tests`5件含む）

## 完了条件チェックリスト
- [x] `Network`が初回パス確定を待ち合わせ可能なAPIを提供していること
- [x] `InitializationManager.initializeApp()`が初回パス確定後に`Network.isOnline()`を判定していること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で示したタイミング依存の誤判定が発生しないこと（初回コールバック待機により`isOnline()`がデフォルト値`false`を返す期間が排除されていること）

## クロスレビュー結果
1ラウンド目でmust-fix指摘なし。should-fix 1件（`InitializationManager.initializeApp()`が`Network.waitForInitialPath()`を`isOnline()`判定前に呼んでいるという呼び出し側の配線を自動検証するテストがない。`InitializationManager`はFirebase/Realmに密結合しテスト環境での実行が困難なため、過去issue #30・#35・#101と同様の理由で目視確認による合格扱いとした）のみのため合格。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>