### PR TITLE
Fix: MigrationManagerがmeasuresPriorityを無視しMeasures.orderが不定になる問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/MeasuresOrderResolver.swift
+++ b/SportsNote_iOS/Model/Manager/MeasuresOrderResolver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// 旧アプリの measuresData（対策タイトルをキーとするDictionary）から、
+/// Measures.order を決定的に採番するための対策タイトル順序を算出する
+///
+/// Swift Dictionary の列挙順は不定なため、旧データの "measuresPriority" フィールド
+/// （ユーザーが指定した最優先対策のタイトル）を order=0 として先頭に固定し、
+/// 残りは `sorted()` で決定的にソートする（issue #71）
+///
+/// `MigrationManager`（Firebase依存でテスト環境ではインスタンス化できない）から独立した
+/// 純粋関数とすることで、Firebase未設定のテスト環境でも単体テスト可能にする
+/// （`MigrationStepRunner`と同じ設計方針）
+enum MeasuresOrderResolver {
+
+    /// - Parameters:
+    ///   - measuresTitles: measuresData のキー一覧（対策タイトル、重複なし）
+    ///   - measuresPriority: 旧データの "measuresPriority" フィールド値（最優先対策のタイトル）
+    /// - Returns: order=0から順に採番すべき対策タイトルの配列。
+    ///   measuresPriorityがmeasuresTitlesに一致するものを含む場合は先頭に配置し、
+    ///   残り（一致しない場合は全件）は sorted() による決定的な順序とする
+    static func resolveOrder(measuresTitles: [String], measuresPriority: String?) -> [String] {
+        let sortedTitles = measuresTitles.sorted()
+
+        guard let priority = measuresPriority, sortedTitles.contains(priority) else {
+            return sortedTitles
+        }
+
+        return [priority] + sortedTitles.filter { $0 != priority }
+    }
+}

--- a/SportsNote_iOS/Model/Manager/MigrationManager.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationManager.swift
@@ -204,8 +204,17 @@ final class MigrationManager {
         // measuresData から Measures + Memo を生成
         guard let measuresData = data["measuresData"] as? [String: [[String: Int]]] else { return }
 
-        var measuresOrder = 0
-        for (measuresTitle, effectivenessArray) in measuresData {
+        // measuresPriority（旧データの最優先対策タイトル）を order=0 に固定し、
+        // 残りは決定的な順序（sorted）で採番する（Dictionary列挙順の不定性に依存しないため。issue #71）
+        let measuresPriority = data["measuresPriority"] as? String
+        let orderedTitles = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: Array(measuresData.keys),
+            measuresPriority: measuresPriority
+        )
+
+        for (measuresOrder, measuresTitle) in orderedTitles.enumerated() {
+            guard let effectivenessArray = measuresData[measuresTitle] else { continue }
+
             let measures = Measures()
             measures.measuresID = UUIDGenerator.generateID()
             measures.userID = userID
@@ -218,7 +227,6 @@ final class MigrationManager {
 
             try RealmManager.shared.saveItem(measures)
             try await FirebaseManager.shared.saveMeasures(measures: measures)
-            measuresOrder += 1
 
             // 有効性コメントを Memo に変換
             // effectivenessArray: [ ["コメント文字列": ノートID(Int)], ... ]

--- a/SportsNote_iOSTests/Managers/MeasuresOrderResolverTests.swift
+++ b/SportsNote_iOSTests/Managers/MeasuresOrderResolverTests.swift
@@ -1,0 +1,88 @@
+//
+//  MeasuresOrderResolverTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/04.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// `MeasuresOrderResolver`は Realm/UserDefaults/NotificationCenter/シングルトンのいずれにも
+/// 依存しない純粋関数のため、`.serialized`は不要（issue #71）
+@Suite("MeasuresOrderResolver Tests")
+struct MeasuresOrderResolverTests {
+
+    @Test("measuresPriorityと一致するタイトルが先頭(order=0相当)に配置される")
+    func resolveOrder_priorityMatches_placesPriorityFirst() {
+        let result = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: ["B対策", "A対策", "C対策"],
+            measuresPriority: "C対策"
+        )
+        #expect(result == ["C対策", "A対策", "B対策"])
+    }
+
+    @Test("measuresPriorityがnilの場合はsorted()順になる")
+    func resolveOrder_priorityNil_fallsBackToSorted() {
+        let result = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: ["B対策", "A対策"],
+            measuresPriority: nil
+        )
+        #expect(result == ["A対策", "B対策"])
+    }
+
+    @Test("measuresPriorityが一致しない場合もsorted()にフォールバックする")
+    func resolveOrder_priorityNotFound_fallsBackToSorted() {
+        let result = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: ["B対策", "A対策"],
+            measuresPriority: "存在しない対策"
+        )
+        #expect(result == ["A対策", "B対策"])
+    }
+
+    @Test("measuresTitlesが空の場合は空配列を返す")
+    func resolveOrder_emptyTitles_returnsEmpty() {
+        let result = MeasuresOrderResolver.resolveOrder(measuresTitles: [], measuresPriority: "何か")
+        #expect(result.isEmpty)
+    }
+
+    @Test("measuresTitlesが1件のみでmeasuresPriorityと一致する場合はその1件を返す")
+    func resolveOrder_singleTitleMatchesPriority_returnsSingleTitle() {
+        let result = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: ["唯一の対策"],
+            measuresPriority: "唯一の対策"
+        )
+        #expect(result == ["唯一の対策"])
+    }
+
+    @Test(
+        "入力の並び順（Dictionary列挙順を模した順序）に関わらず結果が一定になる",
+        arguments: [
+            ["A対策", "B対策", "C対策"],
+            ["C対策", "A対策", "B対策"],
+            ["B対策", "C対策", "A対策"],
+        ]
+    )
+    func resolveOrder_inputOrderVaries_resultIsDeterministic(shuffledTitles: [String]) {
+        let result = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: shuffledTitles,
+            measuresPriority: "C対策"
+        )
+        #expect(result == ["C対策", "A対策", "B対策"])
+    }
+
+    @Test("旧データ実例に近い日本語タイトルでもsorted()フォールバックが決定的に機能する")
+    func resolveOrder_realisticJapaneseTitles_fallsBackDeterministically() {
+        let titles = [
+            "[旧データ] 反応ドリルを毎日5分",
+            "[旧データ] 毎日100本トスの練習",
+        ]
+        let result = MeasuresOrderResolver.resolveOrder(
+            measuresTitles: titles,
+            measuresPriority: "[旧データ] 毎日100本トスの練習"
+        )
+        #expect(result == ["[旧データ] 毎日100本トスの練習", "[旧データ] 反応ドリルを毎日5分"])
+    }
+}


### PR DESCRIPTION
## 概要
旧アプリからのタスク移行処理（`MigrationManager.migrateTask`）が、旧データの`measuresPriority`フィールド（ユーザーが指定した最優先対策）を一切読み取らず、`Measures.order`をSwift `Dictionary`の不定な列挙順で採番していた問題を修正しました。

- `migrateTask(data:)`内で`data["measuresPriority"] as? String`を読み取るようにした
- 採番順序の決定ロジックを`MeasuresOrderResolver.resolveOrder(measuresTitles:measuresPriority:)`という純粋関数に切り出し、`measuresPriority`と一致するタイトルを`order=0`に固定、残りは`sorted()`による決定的な順序でフォールバックするようにした
- `MigrationManager`はFirebase Firestoreに直接依存しテスト環境でインスタンス化するとクラッシュするため（既存の`MigrationStepRunner`と同じ制約）、採番ロジックをFirebase非依存の`MeasuresOrderResolver`として切り出すことで単体テスト可能にした

Closes #71

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/MeasuresOrderResolver.swift`（新規）: measuresPriorityに基づく採番順序を決定する純粋関数
- `SportsNote_iOS/Model/Manager/MigrationManager.swift`（修正）: `migrateTask`内で`MeasuresOrderResolver`を使うよう変更
- `SportsNote_iOSTests/Managers/MeasuresOrderResolverTests.swift`（新規）: `MeasuresOrderResolver`の単体テスト7ケース（Swift Testing）

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild test`: 470件全成功（新規`MeasuresOrderResolverTests`7ケース含む）
- `swift-format`実行済み

## 完了条件チェックリスト
- [x] `migrateTask(data:)`が`measuresPriority`フィールドを読み取り、一致する対策の`order`を0に設定すること
- [x] `measuresPriority`と一致する対策が存在しない場合でも、決定的な順序（`sorted()`等）でフォールバックし、Dictionary列挙順に依存しないこと
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] `MigrationManager`のマイグレーション処理に対し、`measuresPriority`が正しく最優先として反映されることを検証する新規テストが追加され成功すること

## クロスレビュー結果
独立コンテキストのAgentによるクロスレビューを実施し、指摘なしで合格しました（完了条件の充足・意味的整合性・ビルド/テスト成功・swift-format準拠・過去指摘パターンとの照合を確認済み）。

🤖 Generated with sportsnote-ios-maintainer autonomous workflow