### PR TITLE
Fix: CalendarViewのNotificationCenterオブザーバーがonDisappearで解除されず蓄積する問題を修正

### DIFF
--- a/SportsNote_iOS/View/Target/Components/CalendarView.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarView.swift
@@ -95,42 +95,29 @@ struct CalendarView: View {
 
             // 当月のノートがある日付を取得
             updateDatesWithNotes()
-
-            // 「今日」ボタンの通知を受け取る
-            NotificationCenter.default.addObserver(
-                forName: .moveToToday,
-                object: nil,
-                queue: .main
-            ) { _ in
-                Task { @MainActor in
-                    // 現在の月が今日の月と異なる場合は月を切り替える
-                    let today = Date()
-                    let calendar = Calendar.current
-                    let currentMonthValue = self.currentMonth.get(.month)
-                    let currentYearValue = self.currentMonth.get(.year)
-                    let todayMonthValue = today.get(.month)
-                    let todayYearValue = today.get(.year)
-
-                    if currentMonthValue != todayMonthValue || currentYearValue != todayYearValue {
-                        // アニメーションなしで今日の月に直接移動
-                        self.currentMonth =
-                            calendar.date(from: DateComponents(year: todayYearValue, month: todayMonthValue, day: 1))
-                            ?? today
-                        self.onMonthChanged(self.currentMonth)
-
-                        // ノートの更新
-                        self.updateDatesWithNotes()
-                    }
-                }
-            }
         }
-        .onDisappear {
-            // 通知の登録解除
-            NotificationCenter.default.removeObserver(
-                self,
-                name: .moveToToday,
-                object: nil
-            )
+        // 「今日」ボタンの通知を受け取る（Combineの.onReceiveはViewの生存期間に紐づいて
+        // 自動的に購読解除されるため、ブロック型NotificationCenter APIのような
+        // 手動でのトークン管理・解除（addObserver/removeObserver）が不要になる）
+        .onReceive(NotificationCenter.default.publisher(for: .moveToToday)) { _ in
+            // 現在の月が今日の月と異なる場合は月を切り替える
+            let today = Date()
+            let calendar = Calendar.current
+            let currentMonthValue = currentMonth.get(.month)
+            let currentYearValue = currentMonth.get(.year)
+            let todayMonthValue = today.get(.month)
+            let todayYearValue = today.get(.year)
+
+            if currentMonthValue != todayMonthValue || currentYearValue != todayYearValue {
+                // アニメーションなしで今日の月に直接移動
+                currentMonth =
+                    calendar.date(from: DateComponents(year: todayYearValue, month: todayMonthValue, day: 1))
+                    ?? today
+                onMonthChanged(currentMonth)
+
+                // ノートの更新
+                updateDatesWithNotes()
+            }
         }
     }
 


### PR DESCRIPTION
## 概要
`CalendarView.swift`の`onAppear`で登録していた`NotificationCenter`のブロック型オブザーバー（`addObserver(forName:object:queue:using:)`）は、戻り値のトークンを保持していなかったため、`onDisappear`の`removeObserver(self, name:object:)`呼び出しが常にno-opになっていた（`self`はブロック型APIのオブザーバー実体として登録されたことが一度もないため）。その結果、「目標」タブへの再訪のたびにオブザーバーが蓄積し、「今日」ボタンをタップすると蓄積回数分だけ月切り替え処理が重複実行される不具合があった。

## 対応内容
`onAppear`内の`addObserver`/`onDisappear`内の`removeObserver`を削除し、他のViewModelと同様のCombineパターンに統一した`.onReceive(NotificationCenter.default.publisher(for: .moveToToday))`修飾子に置き換え。SwiftUIがView自身の生存期間に紐づけて購読を自動管理するため、手動でのトークン管理・解除が不要になり、構造的にリークが再発しなくなる。

`@State`トークン方式（onAppearが複数回呼ばれるとトークンを上書きしてしまいリークが再発するリスクがある）ではなく`.onReceive`方式を採用。既存コードベースでも`SportsNote_iOSApp.swift`のMainTabViewで同じ`.onReceive`パターンの前例がある。

## 変更ファイル一覧
- `SportsNote_iOS/View/Target/Components/CalendarView.swift`

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED（警告0件、appintentsmetadataprocessorの無害な警告のみ）
- `xcodebuild test`: TEST SUCCEEDED（463件全成功）
- swift-format: 適用済み（差分なし）

## 完了条件チェックリスト
- [x] `CalendarView`の画面再訪（onAppear/onDisappear）を繰り返しても、`MoveToToday`通知に対するハンドラーが重複登録されないことを確認できる（`.onReceive`への置き換えにより、SwiftUIがView識別子ベースで購読を1つだけ管理する構造的な保証。手動のaddObserver/removeObserverコード自体を撤去したため再発しない）
- [x] 「今日」ボタンタップ時に月切り替え処理が1回だけ実行される
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
1ラウンド目で指摘なし、合格。

Closes #54