### PR TITLE
Fix: ログイン時マイグレーションでGroup未作成時にtask.groupIDが空文字になる問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/MigrationManager.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationManager.swift
@@ -163,6 +163,32 @@ final class MigrationManager {
 
     // MARK: - 変換・Realm + Firebase 保存
 
+    /// 未分類グループのIDを取得する。Realmにグループが1件も存在しない場合は新規作成して保存する
+    /// - Note: RealmManager経由のローカルDB操作のみで完結しFirebaseに依存しないため`static func`として定義する。
+    ///   Swiftのstatic funcはインスタンスの`init()`（`Firestore.firestore()`呼び出し）を経由しないため、
+    ///   Firebase未設定のテスト環境でも`MigrationManager.shared`をインスタンス化せずに直接検証できる（issue #73）。
+    /// - Parameter userID: 新規作成時にGroupへ設定するuserID（呼び出し元で解決済みの値を渡す）
+    /// - Returns: 既存または新規作成した未分類グループのgroupID
+    /// - Throws: RealmManagerの取得・保存に失敗した場合
+    static func resolveUncategorizedGroupID(userID: String) throws -> String {
+        let groups = try RealmManager.shared.getDataList(clazz: Group.self)
+        if let existing = groups.first {
+            return existing.groupID
+        }
+
+        // InitializationManager.createUncategorizedGroup() と同等のロジック
+        let group = Group()
+        group.groupID = UUIDGenerator.generateID()
+        group.title = LocalizedStrings.uncategorized
+        group.color = GroupColor.gray.rawValue
+        group.userID = userID
+        group.created_at = Date()
+        group.updated_at = Date()
+
+        try RealmManager.shared.saveItem(group)
+        return group.groupID
+    }
+
     /// 旧課題データを TaskData + Measures + Memo に変換して保存
     /// measuresData: [対策タイトル: [[有効性コメント: ノートID(Int)]]]
     private func migrateTask(documentID: String, data: [String: Any]) async throws {
@@ -190,13 +216,8 @@ final class MigrationManager {
         task.updated_at = now
 
         // 未分類グループに割り当て（旧データにグループ概念なし）
-        if let groups = try? RealmManager.shared.getDataList(clazz: Group.self),
-            let uncategorized = groups.first
-        {
-            task.groupID = uncategorized.groupID
-        } else {
-            task.groupID = ""
-        }
+        // Group が0件の場合でも空文字にフォールバックせず、その場で未分類グループを作成する（issue #73）
+        task.groupID = try MigrationManager.resolveUncategorizedGroupID(userID: userID)
 
         try RealmManager.shared.saveItem(task)
         try await FirebaseManager.shared.saveTask(task: task)

--- a/SportsNote_iOSTests/Managers/MigrationManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/MigrationManagerTests.swift
@@ -1,0 +1,78 @@
+//
+//  MigrationManagerTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/04.
+//
+
+import Foundation
+import RealmSwift
+import Testing
+
+@testable import SportsNote_iOS
+
+/// `MigrationManager`はFirebaseFirestoreに直接依存し、Firebase未設定のテスト環境では
+/// インスタンス化するとクラッシュするため、`MigrationManager.shared`や`MigrationManager()`には
+/// 一切触れず、Firebaseに依存しない`resolveUncategorizedGroupID(userID:)`（static func）のみを
+/// 検証する（issue #35のMigrationStepRunnerと同じ回避パターン、issue #73）。
+@Suite("MigrationManager resolveUncategorizedGroupID Tests", .serialized)
+@MainActor
+struct MigrationManagerTests {
+
+    init() async throws {
+        RealmManager.shared.setupInMemoryRealm()
+        RealmManager.shared.clearAll()
+    }
+
+    @Test("Groupが0件の場合、未分類グループを新規作成してそのIDを返す")
+    func resolveUncategorizedGroupID_noGroups_createsUncategorizedGroup() async throws {
+        let groupID = try MigrationManager.resolveUncategorizedGroupID(userID: "user-1")
+
+        #expect(!groupID.isEmpty)
+
+        let groups = try RealmManager.shared.getDataList(clazz: Group.self)
+        #expect(groups.count == 1)
+        #expect(groups.first?.groupID == groupID)
+        #expect(groups.first?.title == LocalizedStrings.uncategorized)
+        #expect(groups.first?.color == GroupColor.gray.rawValue)
+        #expect(groups.first?.userID == "user-1")
+    }
+
+    @Test("Groupが既に存在する場合、新規作成せず既存グループの先頭のIDを返す")
+    func resolveUncategorizedGroupID_groupsExist_reusesExistingGroup() async throws {
+        let existing = Group(
+            groupID: "existing-group",
+            title: "既存",
+            color: GroupColor.blue.rawValue,
+            order: 0,
+            created_at: Date()
+        )
+        try RealmManager.shared.saveItem(existing)
+
+        let groupID = try MigrationManager.resolveUncategorizedGroupID(userID: "user-1")
+
+        #expect(groupID == "existing-group")
+
+        let groups = try RealmManager.shared.getDataList(clazz: Group.self)
+        // 新規作成されていないこと
+        #expect(groups.count == 1)
+    }
+
+    @Test(
+        "Groupが0件の状態から複数タスクを移行しても、未分類グループは1件だけ作成され全タスクが同じグループIDを共有する"
+    )
+    func resolveUncategorizedGroupID_calledMultipleTimesFromZero_reusesCreatedGroup() async throws {
+        // migrateAll() が oldTaskDocs をループしながら本メソッドを都度呼び出す状況を再現
+        // （ログイン直後・Group0件の状態でのマイグレーション実行という再現手順の核心部分）
+        let firstGroupID = try MigrationManager.resolveUncategorizedGroupID(userID: "user-1")
+        let secondGroupID = try MigrationManager.resolveUncategorizedGroupID(userID: "user-1")
+        let thirdGroupID = try MigrationManager.resolveUncategorizedGroupID(userID: "user-1")
+
+        #expect(!firstGroupID.isEmpty)
+        #expect(firstGroupID == secondGroupID)
+        #expect(secondGroupID == thirdGroupID)
+
+        let groups = try RealmManager.shared.getDataList(clazz: Group.self)
+        #expect(groups.count == 1)
+    }
+}


### PR DESCRIPTION
## 概要
ログイン時の旧データマイグレーションで、Realm上にGroupが1件も存在しないタイミングで`MigrationManager.migrateTask(data:)`が実行されると、移行後の課題（Task）の`groupID`が空文字のまま永続化され、どのグループにも属さない孤立タスクになる問題を修正しました。

`InitializationManager.createUncategorizedGroup()`と同等のロジックを持つ`static func resolveUncategorizedGroupID(userID:)`を`MigrationManager`に追加し、Realmにグループが0件の場合はその場で未分類グループを作成してIDを返すようにしました。Firebaseに依存しないRealm操作のみのロジックのため`static func`として切り出し、`MigrationManager`のシングルトン（`Firestore.firestore()`をinitで保持）をインスタンス化せずにテスト可能にしています（issue #35の`MigrationStepRunner`と同じ回避パターン）。

`migrateTarget`/`migrateFreeNote`/`migrateNote`も確認しましたが、いずれも`groupID`を扱わないため修正不要と判断しています。

Closes #73

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/MigrationManager.swift`: `resolveUncategorizedGroupID(userID:)`を追加し、`migrateTask`のグループ0件時フォールバックを置き換え
- `SportsNote_iOSTests/Managers/MigrationManagerTests.swift`（新規）: `resolveUncategorizedGroupID`の3パターン（Group0件で新規作成／Group既存で再利用／複数回呼び出しで重複作成されない）を検証

## ビルド・テスト結果
- `xcodebuild ... build` → BUILD SUCCEEDED
- `xcodebuild ... test`（全テスト） → 466 tests in 20 suites, すべてpassed
- `xcodebuild ... test -only-testing:SportsNote_iOSTests/MigrationManagerTests` → 新規3テストすべてpassed
- swift-format適用済み

## 完了条件チェックリスト
- [x] `migrateTask(data:)`実行時にGroupが0件でも、`task.groupID`が空文字にならず有効な未分類グループのIDが設定されること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順（ログイン直後・Group0件の状態でのマイグレーション実行）で課題が孤立せず未分類グループに割り当てられることを検証するテストが追加されていること

## クロスレビュー結果
独立コンテキストのレビュアー（`general-purpose`サブエージェント）による1ラウンド目のクロスレビューで合格。must-fix/should-fix/nitいずれの指摘もありませんでした。レビュアーはビルド・全テストの独立実行に加え、旧バグ相当の実装へ一時的にロールバックして新規テストが期待通り失敗することを確認する検証も実施し、テストの検証力を実証しています。

## 挙動変更の注記
従来はRealm取得失敗時に`try?`で握りつぶし`groupID = ""`にフォールバックしていましたが、修正後はグループ確保処理の失敗が`migrateTask`から素の`Error`としてthrowされます（`MigrationError`ではないため`MigrationStepRunner.run`ではrethrowされ`migrateAll()`が中断し、次回起動時に再試行されます）。「サイレントなデータ破損」より安全側に倒す意図的な仕様変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)