### PR TITLE
Fix: アカウント作成直後のuserID切替時にFirebase更新のドキュメントIDが不一致になる問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/FirebaseManager.swift
+++ b/SportsNote_iOS/Model/Manager/FirebaseManager.swift
@@ -20,6 +20,21 @@ final class FirebaseManager {
             key: UserDefaultsManager.Keys.userID, defaultValue: UUIDGenerator.generateID())
     }
 
+    /**
+     * ドキュメントIDを組み立てる（userIDとentityIDから）
+     *
+     * Firestoreに一切触れない純粋関数のため、Firebase未設定のテスト環境でも呼び出し可能。
+     * 更新系メソッドは、UserDefaults上の現在のuserID（`currentUserID()`）ではなく、
+     * エンティティ自身が保持するuserIDを渡すこと（`saveXxx`系と同じ基準に揃えるため）。
+     *
+     * @param userID ドキュメントIDに使用するuserID（エンティティ自身の値を渡す）
+     * @param entityID エンティティのID
+     * @return "userID_entityID"形式のドキュメントID
+     */
+    static func buildDocumentID(userID: String, entityID: String) -> String {
+        "\(userID)_\(entityID)"
+    }
+
     // MARK: - Create
 
     /**
@@ -508,8 +523,7 @@ final class FirebaseManager {
      * @param group グループデータ
      */
     func updateGroup(group: Group) async throws {
-        let userID = currentUserID()
-        let documentID = "\(userID)_\(group.groupID)"
+        let documentID = FirebaseManager.buildDocumentID(userID: group.userID, entityID: group.groupID)
 
         let data: [String: Any] = [
             "title": group.title,
@@ -528,8 +542,7 @@ final class FirebaseManager {
      * @param task 課題データ
      */
     func updateTask(task: TaskData) async throws {
-        let userID = currentUserID()
-        let documentID = "\(userID)_\(task.taskID)"
+        let documentID = FirebaseManager.buildDocumentID(userID: task.userID, entityID: task.taskID)
 
         let data: [String: Any] = [
             "groupID": task.groupID,
@@ -550,8 +563,7 @@ final class FirebaseManager {
      * @param measures 対策データ
      */
     func updateMeasures(measures: Measures) async throws {
-        let userID = currentUserID()
-        let documentID = "\(userID)_\(measures.measuresID)"
+        let documentID = FirebaseManager.buildDocumentID(userID: measures.userID, entityID: measures.measuresID)
 
         let data: [String: Any] = [
             "title": measures.title,
@@ -569,8 +581,7 @@ final class FirebaseManager {
      * @param memo メモデータ
      */
     func updateMemo(memo: Memo) async throws {
-        let userID = currentUserID()
-        let documentID = "\(userID)_\(memo.memoID)"
+        let documentID = FirebaseManager.buildDocumentID(userID: memo.userID, entityID: memo.memoID)
 
         let data: [String: Any] = [
             "detail": memo.detail,
@@ -587,8 +598,7 @@ final class FirebaseManager {
      * @param target 目標データ
      */
     func updateTarget(target: Target) async throws {
-        let userID = currentUserID()
-        let documentID = "\(userID)_\(target.targetID)"
+        let documentID = FirebaseManager.buildDocumentID(userID: target.userID, entityID: target.targetID)
 
         let data: [String: Any] = [
             "title": target.title,
@@ -608,8 +618,7 @@ final class FirebaseManager {
      * @param note ノートデータ
      */
     func updateNote(note: Note) async throws {
-        let userID = currentUserID()
-        let documentID = "\(userID)_\(note.noteID)"
+        let documentID = FirebaseManager.buildDocumentID(userID: note.userID, entityID: note.noteID)
 
         let data: [String: Any] = [
             "isDeleted": note.isDeleted,

--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -136,6 +136,14 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
         defer { isLoading = false }
 
         do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate, let existingGroup = try RealmManager.shared.getObjectById(id: entity.groupID, type: Group.self)
+            {
+                entity.userID = existingGroup.userID
+            }
+
             // Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -150,6 +150,15 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
         defer { isLoading = false }
 
         do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate,
+                let existingMeasures = try RealmManager.shared.getObjectById(id: entity.measuresID, type: Measures.self)
+            {
+                entity.userID = existingMeasures.userID
+            }
+
             // 1. Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -72,6 +72,13 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         defer { isLoading = false }
 
         do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate, let existingMemo = try RealmManager.shared.getObjectById(id: entity.memoID, type: Memo.self) {
+                entity.userID = existingMemo.userID
+            }
+
             // Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -137,6 +137,13 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         defer { isLoading = false }
 
         do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate, let existingNote = try realmManager.getObjectById(id: entity.noteID, type: Note.self) {
+                entity.userID = existingNote.userID
+            }
+
             // Realm操作はMainActorで実行
             try realmManager.saveItem(entity)
 

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -116,6 +116,15 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
         defer { isLoading = false }
 
         do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate,
+                let existingTarget = try RealmManager.shared.getObjectById(id: entity.targetID, type: Target.self)
+            {
+                entity.userID = existingTarget.userID
+            }
+
             // Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -264,6 +264,15 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         defer { isLoading = false }
 
         do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate,
+                let existingTask = try RealmManager.shared.getObjectById(id: entity.taskID, type: TaskData.self)
+            {
+                entity.userID = existingTask.userID
+            }
+
             // 1. Realm操作はMainActorで実行
             try RealmManager.shared.saveItem(entity)
 

--- a/SportsNote_iOSTests/Managers/FirebaseManagerDocumentIDTests.swift
+++ b/SportsNote_iOSTests/Managers/FirebaseManagerDocumentIDTests.swift
@@ -1,0 +1,79 @@
+//
+//  FirebaseManagerDocumentIDTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/04.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// `FirebaseManager`はFirebaseFirestoreに直接依存し、Firebase未設定のテスト環境では
+/// インスタンス化する（`.shared`にアクセスする等）だけでクラッシュするため、
+/// `FirebaseManager`のインスタンスには一切触れず、Firestoreに触れない
+/// `static func buildDocumentID(userID:entityID:)`のみを検証する（issue #74）。
+///
+/// issue #74は、更新系メソッド（`updateTask`等）がドキュメントID組み立てに
+/// 「現在のUserDefaults上のuserID」ではなく「エンティティ自身が保持するuserID」を
+/// 使用しなければならない、という規約違反（バグ）を修正するものである。
+/// 以下のテストは、アカウント作成直後にUserDefaults上のuserIDが新IDへ切り替わった後でも、
+/// Realm上にまだ旧IDのまま残っているエンティティに対しては、
+/// 旧ID基準のドキュメントID（Firestore上の実データと一致するID）が組み立てられることを検証する。
+@Suite("FirebaseManager buildDocumentID Tests")
+@MainActor
+struct FirebaseManagerDocumentIDTests {
+
+    private let oldUserID = "old-user-ABC"
+    private let newUserID = "new-user-XYZ"
+
+    @Test("buildDocumentIDはuserIDとentityIDから\"userID_entityID\"形式のIDを組み立てる")
+    func buildDocumentID_returnsUnderscoreJoinedID() {
+        let documentID = FirebaseManager.buildDocumentID(userID: "user1", entityID: "entity1")
+        #expect(documentID == "user1_entity1")
+    }
+
+    @Test(
+        "アカウント作成直後にuserIDが切り替わった状態でも、エンティティ自身の（旧）userIDを使ってドキュメントIDが組み立てられる",
+        arguments: [
+            ("task-1", "TaskData"),
+            ("group-1", "Group"),
+            ("measures-1", "Measures"),
+            ("memo-1", "Memo"),
+            ("target-1", "Target"),
+            ("note-1", "Note"),
+        ]
+    )
+    func buildDocumentID_usesEntityOwnUserID_notCurrentUserID(entityID: String, entityName: String) {
+        // Realm上のエンティティのuserIDはまだ旧IDのまま（updateAllUserIds完了前を想定）
+        let documentID = FirebaseManager.buildDocumentID(userID: oldUserID, entityID: entityID)
+
+        // Firestore上の実データと一致する「旧userID_entityID」が組み立てられること
+        #expect(documentID == "\(oldUserID)_\(entityID)")
+        // 現在UserDefaultsに切り替わっている新userIDを使った誤ったIDにはならないこと
+        #expect(documentID != "\(newUserID)_\(entityID)")
+    }
+
+    @Test("TaskDataエンティティ自身のuserIDプロパティを使ってドキュメントIDが組み立てられる")
+    func buildDocumentID_withTaskDataEntity_usesTaskUserID() {
+        let task = TaskData()
+        task.taskID = "task-abc"
+        task.userID = oldUserID
+
+        let documentID = FirebaseManager.buildDocumentID(userID: task.userID, entityID: task.taskID)
+
+        #expect(documentID == "\(oldUserID)_task-abc")
+    }
+
+    @Test("Groupエンティティ自身のuserIDプロパティを使ってドキュメントIDが組み立てられる")
+    func buildDocumentID_withGroupEntity_usesGroupUserID() {
+        let group = Group()
+        group.groupID = "group-abc"
+        group.userID = oldUserID
+
+        let documentID = FirebaseManager.buildDocumentID(userID: group.userID, entityID: group.groupID)
+
+        #expect(documentID == "\(oldUserID)_group-abc")
+    }
+}

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelUserIDPreservationTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelUserIDPreservationTests.swift
@@ -1,0 +1,75 @@
+//
+//  TaskViewModelUserIDPreservationTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/04.
+//
+
+import Foundation
+import RealmSwift
+import Testing
+
+@testable import SportsNote_iOS
+
+/// issue #74の再現シナリオ（アカウント作成直後のuserID切替タイミングでFirebase更新が
+/// ドキュメントID不一致により失敗する）を、`TaskViewModel.updateTask`経由で
+/// エンドツーエンドに近い形で検証する。
+///
+/// `TaskViewModel.updateTask`は内部で`createTaskData(basedOn:)`により`TaskData`を
+/// 再構築するが、`TaskData`の designated init はUserDefaults上の**現在の**userIDを
+/// 読み直すため、再構築されたエンティティのuserIDは常に「現在の」userIDになってしまう。
+/// `TaskViewModel.save(_:isUpdate:)`は、更新時にRealmへ永続化済みの（切替前の）userIDへ
+/// 明示的に戻す処理を持つべきであり、本テストはそれを検証する。
+@Suite("TaskViewModel userID保持 Tests", .serialized)
+@MainActor
+struct TaskViewModelUserIDPreservationTests {
+
+    init() {
+        RealmManager.shared.setupInMemoryRealm()
+    }
+
+    @Test(
+        "updateTask - アカウント作成直後にUserDefaultsのuserIDが切り替わっても、既存タスクのuserIDは切替前の値のまま保持される"
+    )
+    func updateTask_afterUserIDSwitch_preservesOriginalUserID() async throws {
+        let oldUserID = "old-user-ABC"
+        let newUserID = "new-user-XYZ"
+
+        // 1. 旧userIDの状態でタスクを作成する（匿名ユーザー相当）
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.userID, value: oldUserID)
+
+        let viewModel = TaskViewModel()
+        let createResult = await viewModel.saveNewTaskWithMeasures(
+            title: "Original Title", cause: "Original Cause", groupID: "group-1")
+
+        guard case .success(let createdTask) = createResult else {
+            Issue.record("タスクの作成に失敗した")
+            return
+        }
+        #expect(createdTask.userID == oldUserID)
+
+        // 2. アカウント作成により、UserDefaults上のuserIDだけが即座に新IDへ切り替わる
+        //    （updateAllUserIdsによるRealm全件書き換えはまだ完了していない状態を模す）
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.userID, value: newUserID)
+
+        // 3. その状態でユーザーが既存タスクを編集する
+        let updateResult = await viewModel.updateTask(
+            taskID: createdTask.taskID, title: "Updated Title", cause: "Updated Cause", groupID: "group-1")
+
+        guard case .success = updateResult else {
+            Issue.record("タスクの更新に失敗した")
+            return
+        }
+
+        // 4. Realmに永続化されたタスクのuserIDは、切替前の値のまま保持されている必要がある
+        //    （切替後の新userIDに上書きされてしまうと、Firebase更新時のドキュメントIDが
+        //      Firestore上の実データと一致しなくなる）
+        let persistedTask = try RealmManager.shared.getObjectById(id: createdTask.taskID, type: TaskData.self)
+        #expect(persistedTask?.userID == oldUserID)
+        #expect(persistedTask?.userID != newUserID)
+        #expect(persistedTask?.title == "Updated Title")
+
+        // 後始末
+        UserDefaultsManager.remove(key: UserDefaultsManager.Keys.userID)
+    }
+}


### PR DESCRIPTION
## 概要
`FirebaseManager`の更新系メソッド（`updateGroup`/`updateTask`/`updateMeasures`/`updateMemo`/`updateTarget`/`updateNote`）が、ドキュメントIDの組み立てに常に「現在のUserDefaults上のuserID」（`currentUserID()`）を使っていたため、アカウント作成直後にuserIDが切り替わるタイミングと更新処理が重なると、Firestore上の実データとは異なるドキュメントIDを更新しようとして失敗していました。

調査の過程で、根本原因がさらに一段深いところにあることが判明しました。各ViewModelの更新処理（`createTaskData`等）はエンティティを再構築する際に新しい`TaskData`等のオブジェクトを生成しますが、そのdesignated initが常に`UserDefaults.standard`から**現在の**userIDを読み直すため、`FirebaseManager`側だけを直しても、更新のたびにuserIDが現在値へ上書きされてしまい、issueの再現シナリオ自体は解消されませんでした（クロスレビュー1回目で発見）。そのため、各ViewModelの`save(_:isUpdate:)`にも修正を加えています。

## 変更内容
1. `SportsNote_iOS/Model/Manager/FirebaseManager.swift`
   - `static func buildDocumentID(userID:entityID:)`を追加（Firestoreに触れない純粋関数）
   - `updateGroup`/`updateTask`/`updateMeasures`/`updateMemo`/`updateTarget`/`updateNote`の6メソッドで、`currentUserID()`ではなくエンティティ自身の`userID`を使うよう統一（`saveXxx`系と同じ基準に揃えた）
2. `SportsNote_iOS/ViewModel/{Group,Measures,Memo,Note,Target,Task}ViewModel.swift`
   - 各`save(_:isUpdate:)`に、更新時はRealmに永続化済みのuserIDへ明示的に戻すガードを追加（エンティティ再構築時にUserDefaultsの現在値で上書きされてしまう問題への対処）

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/FirebaseManager.swift`
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`
- `SportsNote_iOS/ViewModel/MeasuresViewModel.swift`
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`
- `SportsNote_iOS/ViewModel/TargetViewModel.swift`
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOSTests/Managers/FirebaseManagerDocumentIDTests.swift`（新規）
- `SportsNote_iOSTests/ViewModels/TaskViewModelUserIDPreservationTests.swift`（新規）

## ビルド・テスト結果
- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild test`: TEST SUCCEEDED（468 tests in 21 suites、全件成功）
- 新規テスト`TaskViewModelUserIDPreservationTests`は、修正前のコードに対しては実際に失敗する（`persistedTask?.userID == "new-user-XYZ"`）ことを手動で確認済みです（回帰検出力の検証）。

## 完了条件チェックリスト
- [x] `updateGroup`/`updateTask`/`updateMeasures`/`updateMemo`/`updateTarget`/`updateNote`のドキュメントID組み立てが、いずれもエンティティ自身の`userID`を使用するように統一されていること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] アカウント作成直後にuserIDが切り替わった状態でも、既存データのFirebase更新が正しいドキュメントIDに対して行われることを検証するテストが追加されていること（`TaskViewModelUserIDPreservationTests`）

## クロスレビュー結果
2ラウンド実施。1ラウンド目でmust-fix（ViewModel側でのuserID再上書き問題）を検出・修正し、2ラウンド目で合格（must-fixなし）。

**残存should-fix（本PRのスコープ外として記録）**:
- `NoteViewModel.swift`396行目`updateTaskReflections`内の`try? realmManager.saveItem(memo)`は、`MemoViewModel.save(_:isUpdate:)`を経由しない別の直接保存経路のため、今回追加したuserID保持ガードの対象外になっています。ブロッキングではありませんが、将来的に同種の問題が起きうる箇所として認識しておく必要があります。

Closes #74