### PR TITLE
Fix: 課題振り返りメモの保存直後にFirebase同期が実行されない問題を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -19,6 +19,12 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     private let realmManager = RealmManager.shared
     private var cancellables = Set<AnyCancellable>()
 
+    #if DEBUG
+        /// テスト用: updateTaskReflectionsからのMemo Firebase同期呼び出しを記録する
+        /// （実Firebase通信を伴わずに呼び出しの発生・isUpdate判定を検証するため）
+        var memoSyncCallsForTesting: [(memoID: String, isUpdate: Bool)] = []
+    #endif
+
     init() {
         // 初期化のみ実行、データ取得はView側で明示的に実行
         setupNotifications()
@@ -387,10 +393,53 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             // 既存メモを更新する場合はcreated_atを維持し、新規作成時のみ現在時刻とする
             memo.created_at = existingCreatedAt ?? Date()
             try? realmManager.saveItem(memo)
+
+            // Firebase同期はバックグラウンドで実行
+            // existingCreatedAtが設定されている場合のみ既存メモの更新(isUpdate=true)、
+            // それ以外は新規作成(isUpdate=false)。memoIDの決定ロジックと同じ判定材料を再利用する
+            performMemoBackgroundSync(memo, isUpdate: existingCreatedAt != nil)
         }
 
         // メモを再読み込み
         loadMemos()
+    }
+
+    /// 課題振り返りメモ(Memo)をFirebaseに同期する
+    /// NoteViewModelのFirebaseSyncable.EntityTypeはNoteのため、
+    /// Memoの同期にはperformBackgroundSync(EntityType用)を使えず専用の同期処理を持つ
+    /// - Parameters:
+    ///   - memo: 同期するメモ
+    ///   - isUpdate: 更新かどうか
+    /// - Returns: 同期処理の結果
+    func syncMemoToFirebase(_ memo: Memo, isUpdate: Bool) async -> Result<Void, SportsNoteError> {
+        guard isOnlineAndLoggedIn else { return .success(()) }
+
+        do {
+            if isUpdate {
+                try await FirebaseManager.shared.updateMemo(memo: memo)
+            } else {
+                try await FirebaseManager.shared.saveMemo(memo: memo)
+            }
+            return .success(())
+        } catch {
+            return .failure(ErrorMapper.mapFirebaseError(error, context: "NoteViewModel-syncMemoToFirebase"))
+        }
+    }
+
+    /// 課題振り返りメモのFirebase同期をバックグラウンドで実行する
+    /// - Parameters:
+    ///   - memo: 同期するメモ
+    ///   - isUpdate: 更新かどうか
+    private func performMemoBackgroundSync(_ memo: Memo, isUpdate: Bool) {
+        #if DEBUG
+            memoSyncCallsForTesting.append((memoID: memo.memoID, isUpdate: isUpdate))
+        #endif
+        Task {
+            let result = await syncMemoToFirebase(memo, isUpdate: isUpdate)
+            if case .failure(let error) = result, currentError == nil {
+                showErrorAlert(error)
+            }
+        }
     }
 
     /// 大会ノートの保存処理

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -669,6 +669,139 @@ struct NoteViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - updateTaskReflections（課題振り返りメモ）のFirebase同期テスト
+
+    @Test("updateTaskReflections - 新規作成時、Memoの同期呼び出しがisUpdate=falseで発生する")
+    func updateTaskReflections_newMemo_triggersFirebaseSyncCall() async {
+        let viewModel = NoteViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let task = TaskListData(
+            taskID: "task-sync-1",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-sync-1",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "新規の振り返り"]
+        )
+
+        #expect(viewModel.memoSyncCallsForTesting.count == 1)
+        #expect(viewModel.memoSyncCallsForTesting.first?.isUpdate == false)
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - task.memoIDによる既存メモ編集時、Memoの同期呼び出しがisUpdate=trueで発生する")
+    func updateTaskReflections_existingMemoWithMemoID_triggersFirebaseSyncCallAsUpdate() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let existingMemo = Memo(
+            memoID: "memo-sync-fixed-1",
+            measuresID: "measures-sync-2",
+            noteID: "note-sync-1",
+            detail: "旧振り返り",
+            created_at: Date().addingTimeInterval(-3600)
+        )
+        try? manager.saveItem(existingMemo)
+
+        let viewModel = NoteViewModel()
+        let task = TaskListData(
+            taskID: "task-sync-2",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-sync-2",
+            measures: "Test Measures",
+            memoID: "memo-sync-fixed-1",
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-sync-1",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "更新後の振り返り"]
+        )
+
+        #expect(viewModel.memoSyncCallsForTesting.count == 1)
+        #expect(viewModel.memoSyncCallsForTesting.first?.memoID == "memo-sync-fixed-1")
+        #expect(viewModel.memoSyncCallsForTesting.first?.isUpdate == true)
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - noteID+measuresID検索で既存メモが見つかる場合もMemoの同期呼び出しがisUpdate=trueで発生する")
+    func updateTaskReflections_existingMemoFoundBySearch_triggersFirebaseSyncCallAsUpdate() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let existingMemo = Memo(
+            memoID: "memo-sync-fixed-2",
+            measuresID: "measures-sync-3",
+            noteID: "note-sync-2",
+            detail: "旧振り返り",
+            created_at: Date().addingTimeInterval(-3600)
+        )
+        try? manager.saveItem(existingMemo)
+
+        let viewModel = NoteViewModel()
+        // memoIDを持たないTaskListDataで渡す（noteID+measuresIDでの検索分岐を通す）
+        let task = TaskListData(
+            taskID: "task-sync-3",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-sync-3",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-sync-2",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "更新後の振り返り(検索経由)"]
+        )
+
+        #expect(viewModel.memoSyncCallsForTesting.count == 1)
+        #expect(viewModel.memoSyncCallsForTesting.first?.memoID == "memo-sync-fixed-2")
+        #expect(viewModel.memoSyncCallsForTesting.first?.isUpdate == true)
+
+        manager.clearAll()
+    }
+
+    @Test("syncMemoToFirebase - オフライン/テスト環境では同期をスキップして成功を返す", arguments: [false, true])
+    func syncMemoToFirebase_offline_returnsSuccessWithoutThrowing(isUpdate: Bool) async {
+        let viewModel = NoteViewModel()
+        let memo = Memo(
+            memoID: "memo-direct-sync",
+            measuresID: "measures-direct",
+            noteID: "note-direct",
+            detail: "detail",
+            created_at: Date()
+        )
+
+        let result = await viewModel.syncMemoToFirebase(memo, isUpdate: isUpdate)
+
+        if case .failure(let error) = result {
+            Issue.record("テスト用インメモリRealm使用時は同期がスキップされ成功を返すはず: \(error)")
+        }
+    }
+
     @Test("saveTournamentNote - 大会ノートを保存できる")
     func saveTournamentNote_savesCorrectly() async {
         let viewModel = NoteViewModel()


### PR DESCRIPTION
## 概要
`NoteViewModel.updateTaskReflections`は、他の全ての保存系メソッド（Group/Task/Measures/Memo/Target/NoteViewModelの各`save`実装）と異なり、ローカルRealm保存後にFirebase同期を一切呼んでいなかったため、課題振り返りメモの追加・編集内容が、次回のアプリ起動・ログイン・ログアウト（`syncAllData()`が実行されるタイミング）まで他端末に反映されない不具合を修正しました。

`NoteViewModel`に`Memo`専用の`syncMemoToFirebase(_:isUpdate:)`／`performMemoBackgroundSync(_:isUpdate:)`を新設し、`updateTaskReflections`内でRealm保存直後に呼び出すようにしました。`isUpdate`判定は既存のmemoID決定ロジックが既に持っている変数（`existingCreatedAt`）をそのまま再利用しており、新たな判定ロジックは追加していません。

Closes #57

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`: `syncMemoToFirebase`/`performMemoBackgroundSync`を新設し、`updateTaskReflections`から呼び出すよう変更。`#if DEBUG`限定のテスト用呼び出し記録プロパティ`memoSyncCallsForTesting`を追加。
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`: Firebase同期呼び出しの発生・isUpdate判定を検証するテストを5件追加。

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED（警告0件）
- `xcodebuild test` → TEST SUCCEEDED（467 tests in 19 suites all passed、既存テストに回帰なし）

## 完了条件チェックリスト
- [x] 課題振り返りメモの保存直後にFirebase同期が実行されることを確認できる単体テストがある（`memoSyncCallsForTesting`を使い、実Firebase通信なしに配線の発生とisUpdate判定を検証する3テスト＋`syncMemoToFirebase`単体のオフライン挙動テスト2ケースを追加）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] オフライン時・オンライン復帰時など既存の同期動作に回帰がないこと（`isOnlineAndLoggedIn`ガードは他のViewModelと同じパターンを踏襲、`SyncManager.syncAllData()`自体は変更なし）

## クロスレビュー結果
独立コンテキストのレビュアーによるクロスレビューを実施し、1ラウンド目でmust-fix/should-fix/nitいずれも指摘なしで合格しました。レビュアーは独立してビルド・全テストを再実行し、加えて`performMemoBackgroundSync`の呼び出しを一時的にコメントアウトするロールバック実験により、新規追加した配線テストが期待通り失敗することを確認し、テストの検証力を実証しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)