### PR TITLE
Fix: TaskSelectionViewの課題一覧が追加済み課題を除外できていない問題を修正

### DIFF
--- a/SportsNote_iOS/View/Note/Components/TaskSelectionView.swift
+++ b/SportsNote_iOS/View/Note/Components/TaskSelectionView.swift
@@ -8,7 +8,7 @@ struct TaskSelectionView: View {
     var onTaskSelected: (TaskListData) -> Void
     var addedTaskIds: Set<String>
     private var incompleteTasks: [TaskListData] {
-        return taskViewModel.getUnaddedTasks(excludingTaskIds: [])
+        return taskViewModel.getUnaddedTasks(excludingTaskIds: addedTaskIds)
     }
 
     var body: some View {


### PR DESCRIPTION
## 概要
`TaskSelectionView.incompleteTasks`が呼び出し元から渡された`addedTaskIds`を使わず、常に空集合で`getUnaddedTasks`を呼んでいたため、既に追加済みの課題が一覧から除外されずに残ってしまう不具合を修正しました。

`TaskSelectionView.swift`11行目の`getUnaddedTasks(excludingTaskIds: [])`を`getUnaddedTasks(excludingTaskIds: addedTaskIds)`に変更する1行修正です。

Closes #63

## 変更ファイル一覧
- `SportsNote_iOS/View/Note/Components/TaskSelectionView.swift`（1行修正）

## ビルド・テスト結果
- `xcodebuild build` → **BUILD SUCCEEDED**
- `xcodebuild test` → **463 tests in 19 suites, all passed**（既存件数のまま回帰なし）

## 完了条件チェックリスト
- [x] `TaskSelectionView`が`addedTaskIds`をリスト絞り込みに使用するようになること
- [x] 追加済みの課題が課題選択画面の一覧に表示されなくなること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立コンテキストのレビュアー（Agentツール, general-purpose）による1ラウンドレビューで合格。must-fix指摘なし。

- should-fix（対応不要、将来的なクリーンアップ候補として記録）: `TaskSelectionView.swift:32-46` — 本修正により`incompleteTasks`が常に`addedTaskIds`を含まなくなった結果、同ファイル内の「追加済み」ラベル表示・`.disabled(...)`・グレー背景分岐が実行時に到達不可能なデッドコードになった。issue本文で「グレーアウトUI方針自体の変更はスコープ外」と明記されているため今回は対応せず、将来的な別issueでの検討候補として記録。

🤖 Generated with [Claude Code](https://claude.com/claude-code)