### PR TITLE
Fix: TargetViewでノート編集後にRefreshSelectedDateNotes通知の購読者が存在せず一覧が更新されない問題を修正

### DIFF
--- a/SportsNote_iOS/Utils/AppNotifications.swift
+++ b/SportsNote_iOS/Utils/AppNotifications.swift
@@ -10,4 +10,7 @@ extension Notification.Name {
 
     /// 「今日」ボタンタップ時にカレンダーを今日の月へ移動させるための通知
     static let moveToToday = Notification.Name("MoveToToday")
+
+    /// ノート編集画面から戻った際に選択中日付のノート一覧を再取得するための通知
+    static let refreshSelectedDateNotes = Notification.Name("RefreshSelectedDateNotes")
 }

--- a/SportsNote_iOS/View/Target/Components/NoteListSection.swift
+++ b/SportsNote_iOS/View/Target/Components/NoteListSection.swift
@@ -55,7 +55,7 @@ struct NoteListSection: View {
                 .onDisappear {
                     // 詳細画面から戻ったときに日付で再フィルタリング
                     NotificationCenter.default.post(
-                        name: NSNotification.Name("RefreshSelectedDateNotes"),
+                        name: .refreshSelectedDateNotes,
                         object: nil,
                         userInfo: ["date": date]
                     )
@@ -65,7 +65,7 @@ struct NoteListSection: View {
                 .onDisappear {
                     // 詳細画面から戻ったときに日付で再フィルタリング
                     NotificationCenter.default.post(
-                        name: NSNotification.Name("RefreshSelectedDateNotes"),
+                        name: .refreshSelectedDateNotes,
                         object: nil,
                         userInfo: ["date": date]
                     )
@@ -75,7 +75,7 @@ struct NoteListSection: View {
                 .onDisappear {
                     // 詳細画面から戻ったときに日付で再フィルタリング
                     NotificationCenter.default.post(
-                        name: NSNotification.Name("RefreshSelectedDateNotes"),
+                        name: .refreshSelectedDateNotes,
                         object: nil,
                         userInfo: ["date": date]
                     )

--- a/SportsNote_iOS/View/Target/TargetView.swift
+++ b/SportsNote_iOS/View/Target/TargetView.swift
@@ -11,6 +11,7 @@ struct TargetView: View {
     @State private var selectedMonth = Date().get(.month)
     @State private var selectedDate: Date?
     @StateObject var viewModel = TargetViewModel()
+    @State private var refreshSelectedDateNotesObserver: NSObjectProtocol?
 
     var body: some View {
         TabTopView(
@@ -106,6 +107,25 @@ struct TargetView: View {
                         noteViewModel.showingErrorAlert = true
                     }
                 }
+            }
+
+            // ノート編集画面から戻った際に選択中日付のノート一覧を再取得する
+            refreshSelectedDateNotesObserver = NotificationCenter.default.addObserver(
+                forName: .refreshSelectedDateNotes,
+                object: nil,
+                queue: .main
+            ) { notification in
+                guard let date = notification.userInfo?["date"] as? Date else { return }
+                Task { @MainActor in
+                    noteViewModel.updateNotesByDate(date)
+                }
+            }
+        }
+        .onDisappear {
+            // 通知の登録解除
+            if let refreshSelectedDateNotesObserver {
+                NotificationCenter.default.removeObserver(refreshSelectedDateNotesObserver)
+                self.refreshSelectedDateNotesObserver = nil
             }
         }
         .onChange(of: selectedYear) { newYear in


### PR DESCRIPTION
## 概要
目標画面（TargetView）でノートを編集して戻っても、日付選択に紐づくノート一覧が編集前の内容のまま表示され続ける不具合を修正しました。

`NoteListSection.noteDestination(for:)`の`.onDisappear`で`RefreshSelectedDateNotes`通知をpostしていましたが、この通知を購読している箇所がリポジトリ内に存在せず、`TargetView`のノート一覧が再取得されていませんでした。

## 変更内容
- `SportsNote_iOS/Utils/AppNotifications.swift`: `Notification.Name`拡張に`refreshSelectedDateNotes`を新規定数化（既存の`didClearAllData`/`moveToToday`と同じパターン）
- `SportsNote_iOS/View/Target/Components/NoteListSection.swift`: 3箇所（`.free`/`.practice`/`.tournament`）のpost処理を定数経由に置き換え
- `SportsNote_iOS/View/Target/TargetView.swift`: `onAppear`で`RefreshSelectedDateNotes`通知を購読し、`userInfo`の`date`を使って`noteViewModel.updateNotesByDate(date)`を呼び出す処理を追加。`onDisappear`で解除。オブザーバートークン（`NSObjectProtocol`）を`@State`で保持し、`removeObserver(token)`で確実に解除する方式を採用（`CalendarView`の`.moveToToday`購読が使っている`removeObserver(self, name:object:)`は、クロージャ版`addObserver`で登録したオブザーバーに対しては実質的に解除されない既知の落とし穴があるため、今回は正しい解除方式を採用）

## 変更ファイル一覧
- `SportsNote_iOS/Utils/AppNotifications.swift`
- `SportsNote_iOS/View/Target/Components/NoteListSection.swift`
- `SportsNote_iOS/View/Target/TargetView.swift`

## ビルド・テスト結果
- `xcodebuild build` → **BUILD SUCCEEDED**
- `xcodebuild test` → **463 tests in 19 suites, all passed**（既存件数のまま、回帰なし）
- View層（TargetView/NoteListSection/CalendarView等）はリポジトリ内に自動テストの前例が存在せず、onAppear/onDisappearクロージャ内ロジックをXCTest/Swift Testingから直接検証する手段がないため、新規テストは追加していません（`CalendarView`の`.moveToToday`購読も同様に未テスト）。

## 完了条件
- [x] `TargetView`が`"RefreshSelectedDateNotes"`通知を購読し、該当日付のノート一覧が再取得される
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順（ノート編集→画面遷移で戻る）で一覧が最新内容に更新されることを確認できる（コードトレースによる検証: `TargetView.onAppear`で登録した購読が、`NoteListSection`のonDisappear post時に`userInfo["date"]`をそのまま`noteViewModel.updateNotesByDate`へ渡す配線を確認。TargetViewのonAppear/onDisappearはタブ表示状態に紐づくため、ノート編集画面への遷移・復帰中も購読が維持される）

## クロスレビュー結果
独立コンテキストのレビュアーによるクロスレビューを実施（1ラウンドで合格、must-fixなし）。

- should-fix: `RefreshSelectedDateNotes`購読はView層（`TargetView`）で手動`NotificationCenter.addObserver`/`removeObserver`を配線する実装にしたが、`NoteViewModel`自身が既に`setupNotifications()`でCombineベースの`.publisher(for: .didClearAllData).sink{}`購読パターンを持っており、そちらへの追加の方がより少ない差分で既存パターンとも整合していた可能性がある（動作自体は正しく機能するため合格扱い。issue本文が変更対象ファイルとして`TargetView.swift`を明記していたため、スコープを踏襲）
- nit: `userInfo: ["date": date]`の生文字列キーが定数化されていない（`Notification.Name`自体は今回定数化済み）