### PR TITLE
Fix: ログアウト/アカウント削除が未完了のFirebaseバックグラウンド同期を待たずにRealmを全削除する問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/BackgroundSyncTracker.swift
+++ b/SportsNote_iOS/Model/Manager/BackgroundSyncTracker.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// `FirebaseSyncable.performBackgroundSync`が起動したバックグラウンドFirebase同期Taskを追跡し、
+/// ログアウト/アカウント削除等でRealmを全削除する前に、起動済みの同期処理の完了を待機できるようにするためのシングルトン。
+///
+/// NOTE: `performBackgroundSync`のFire-and-forget起動パターン自体は変更しない。
+/// 起動済みTaskハンドルを本トラッカーに登録するだけの最小限の追加とする（Issue #84対応）。
+@MainActor
+final class BackgroundSyncTracker {
+
+    static let shared = BackgroundSyncTracker()
+
+    private init() {}
+
+    private var trackedTasks: [UUID: Task<Void, Never>] = [:]
+
+    /// バックグラウンド同期Taskを追跡対象に登録する
+    /// Task完了時には自動的に追跡対象から取り除かれる（メモリリーク防止）
+    /// - Parameter task: 追跡対象のTaskハンドル
+    func track(_ task: Task<Void, Never>) {
+        let id = UUID()
+        trackedTasks[id] = task
+
+        Task { [weak self] in
+            _ = await task.value
+            self?.trackedTasks.removeValue(forKey: id)
+        }
+    }
+
+    /// 呼び出し時点で追跡中の全Taskの完了を待機する
+    /// （待機開始後に新規登録されたTaskは対象外。Realm全削除の直前に呼ぶことを想定）
+    func waitForAll() async {
+        let tasks = Array(trackedTasks.values)
+        for task in tasks {
+            _ = await task.value
+        }
+    }
+
+    #if DEBUG
+        /// テスト用: 現在追跡中のTask数
+        var trackedCountForTesting: Int { trackedTasks.count }
+    #endif
+}

--- a/SportsNote_iOS/Model/Manager/InitializationManager.swift
+++ b/SportsNote_iOS/Model/Manager/InitializationManager.swift
@@ -88,6 +88,10 @@ final class InitializationManager {
 
     /// データを全削除
     func deleteAllData() async {
+        // 進行中のバックグラウンドFirebase同期の完了を待ってからRealmを全削除する
+        // （未実行/実行中の同期Taskがinvalidate済みRealmオブジェクトへアクセスしてクラッシュ・
+        //   同期データが消失するのを防ぐ。Issue #84対応）
+        await BackgroundSyncTracker.shared.waitForAll()
         RealmManager.shared.clearAll()
         UserDefaultsManager.clearAll()
     }

--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -102,11 +102,13 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
             try RealmManager.shared.updateGroupOrder(groups: reorderedGroups)
             groups = reorderedGroups
             // Firebase 同期（各グループを order 更新で同期）
-            Task {
+            // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）
+            let syncTask = Task<Void, Never> {
                 for group in reorderedGroups {
                     _ = await syncEntityToFirebase(group, isUpdate: true)
                 }
             }
+            BackgroundSyncTracker.shared.track(syncTask)
             return .success(())
         } catch {
             let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-moveGroup")

--- a/SportsNote_iOS/ViewModel/Protocols/FirebaseSyncable.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/FirebaseSyncable.swift
@@ -44,11 +44,13 @@ extension FirebaseSyncable where Self: BaseViewModelProtocol {
     ///   - entity: 同期するエンティティ
     ///   - isUpdate: 更新かどうか（デフォルトはfalse）
     func performBackgroundSync(_ entity: EntityType, isUpdate: Bool = false) {
-        Task {
+        let task = Task {
             let result = await syncEntityToFirebase(entity, isUpdate: isUpdate)
             if case .failure(let error) = result, currentError == nil {
                 showErrorAlert(error)
             }
         }
+        // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）
+        BackgroundSyncTracker.shared.track(task)
     }
 }

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -495,11 +495,13 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             try RealmManager.shared.updateTaskOrder(tasks: reorderedTasks)
 
             // Firebase同期（バックグラウンド）
-            Task {
+            // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）
+            let syncTask = Task<Void, Never> {
                 for task in reorderedTasks {
                     _ = await syncEntityToFirebase(task, isUpdate: true)
                 }
             }
+            BackgroundSyncTracker.shared.track(syncTask)
 
             return .success(())
         } catch {

--- a/SportsNote_iOSTests/Managers/BackgroundSyncTrackerTests.swift
+++ b/SportsNote_iOSTests/Managers/BackgroundSyncTrackerTests.swift
@@ -1,0 +1,79 @@
+//
+//  BackgroundSyncTrackerTests.swift
+//  SportsNote_iOSTests
+//
+//  issue #84: ログアウト/アカウント削除時に進行中のバックグラウンドFirebase同期を
+//  待たずにRealmを全削除してしまう問題の回帰テスト
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("BackgroundSyncTracker Tests", .serialized)
+@MainActor
+struct BackgroundSyncTrackerTests {
+
+    @Test("waitForAll - 追跡中のTaskが完了するまで待機する")
+    func waitForAll_waitsUntilTrackedTaskCompletes() async {
+        actor Flag {
+            var value = false
+            func set() { value = true }
+        }
+        let flag = Flag()
+
+        let task = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1秒
+            await flag.set()
+        }
+        BackgroundSyncTracker.shared.track(task)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        #expect(await flag.value == true)
+    }
+
+    @Test("waitForAll - 複数の追跡Taskすべての完了を待機する")
+    func waitForAll_waitsForMultipleTasks() async {
+        actor Counter {
+            var count = 0
+            func increment() { count += 1 }
+        }
+        let counter = Counter()
+
+        for i in 1...5 {
+            let task = Task<Void, Never> {
+                try? await Task.sleep(nanoseconds: UInt64(10_000_000 * i))
+                await counter.increment()
+            }
+            BackgroundSyncTracker.shared.track(task)
+        }
+
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        #expect(await counter.count == 5)
+    }
+
+    @Test("waitForAll - 追跡Taskが無い場合は即座に完了する")
+    func waitForAll_returnsImmediatelyWhenNoTasksTracked() async {
+        // 前テストの登録が自動クリーンアップされている前提で、極端に時間がかかっていないことを確認する
+        let start = Date()
+        await BackgroundSyncTracker.shared.waitForAll()
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 1.0)
+    }
+
+    @Test("track - Task完了後は自動的に追跡対象から除去される")
+    func track_removesCompletedTaskAutomatically() async {
+        let task = Task<Void, Never> {}
+        BackgroundSyncTracker.shared.track(task)
+        _ = await task.value
+
+        // 除去は登録側のTaskで非同期に行われるため、反映されるまで少し待つ
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+    }
+}

--- a/SportsNote_iOSTests/Managers/InitializationManagerDeleteAllDataTests.swift
+++ b/SportsNote_iOSTests/Managers/InitializationManagerDeleteAllDataTests.swift
@@ -1,0 +1,64 @@
+//
+//  InitializationManagerDeleteAllDataTests.swift
+//  SportsNote_iOSTests
+//
+//  issue #84: ログアウト/アカウント削除時に進行中のバックグラウンドFirebase同期を
+//  待たずにRealmを全削除してしまう問題の回帰テスト
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("InitializationManager deleteAllData Tests", .serialized)
+@MainActor
+struct InitializationManagerDeleteAllDataTests {
+
+    init() async throws {
+        RealmManager.shared.setupInMemoryRealm()
+    }
+
+    @Test("deleteAllData - 追跡中のバックグラウンド同期Taskの完了を待ってからRealmを全削除する")
+    func deleteAllData_waitsForTrackedSyncBeforeClearingRealm() async {
+        actor Order {
+            var events: [String] = []
+            func record(_ e: String) { events.append(e) }
+        }
+        let order = Order()
+
+        // Realmに1件保存しておく
+        let group = Group(groupID: "test-group", title: "test", color: 0, order: 0, created_at: Date())
+        try? RealmManager.shared.saveItem(group)
+
+        // performBackgroundSyncが起動する「未完了の同期Task」を模して追跡登録する
+        let task = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1秒後に完了
+            await order.record("sync_completed")
+        }
+        BackgroundSyncTracker.shared.track(task)
+
+        await InitializationManager.shared.deleteAllData()
+        await order.record("delete_all_data_returned")
+
+        let events = await order.events
+        // "sync_completed" が "delete_all_data_returned" より先に記録されている
+        // ＝ Realm全削除前に同期Taskの完了を待てていることを検証
+        #expect(events == ["sync_completed", "delete_all_data_returned"])
+
+        // Realmが実際に空になっていることも確認
+        let groups = (try? RealmManager.shared.getDataList(clazz: Group.self)) ?? []
+        #expect(groups.isEmpty)
+    }
+
+    @Test("deleteAllData - 追跡中のTaskが無い場合も正常にRealmを全削除する")
+    func deleteAllData_clearsRealmWhenNoTrackedTasks() async {
+        let group = Group(groupID: "test-group-2", title: "test2", color: 0, order: 0, created_at: Date())
+        try? RealmManager.shared.saveItem(group)
+
+        await InitializationManager.shared.deleteAllData()
+
+        let groups = (try? RealmManager.shared.getDataList(clazz: Group.self)) ?? []
+        #expect(groups.isEmpty)
+    }
+}


### PR DESCRIPTION
## 概要
`LoginViewModel.logout()`/`deleteAccount()`（および`login()`）が呼び出す`InitializationManager.deleteAllData()`は、保存操作が起動したバックグラウンドのFirebase同期タスク（`performBackgroundSync`）の完了を待たずに`RealmManager.shared.clearAll()`でローカルデータを物理削除していました。これにより、同期未完了のデータが失われる、または同期タスクが削除済み（invalidated）のRealmオブジェクトへアクセスしてクラッシュする可能性がありました。

新設した`BackgroundSyncTracker`（`@MainActor`シングルトン）が、起動済みのバックグラウンド同期Taskを追跡し、`InitializationManager.deleteAllData()`がRealm全削除を実行する直前にそれらの完了を待つようにしました。`performBackgroundSync`のFire-and-forget起動パターン自体（issueの「やらないこと」）は維持しています。

## 設計判断（issue記載からの変更点）
issue本文は変更対象ファイルを`LoginViewModel.swift`のみと想定していましたが、調査の結果「起動済みのTaskハンドルを追跡する仕組みが存在しない」ため、以下の設計に調整しました。

- `LoginViewModel.swift`自体は変更せず、`RealmManager.shared.clearAll()`を呼ぶ唯一の合流点である`InitializationManager.deleteAllData()`に待機処理を追加。`login()`/`logout()`/`deleteAccount()`の3経路すべてを1箇所でカバーできます。
- `performBackgroundSync`を経由しない独自Task起動パターン（`TaskViewModel.moveTask`・`GroupViewModel.moveGroup`）も同様にトラッカーへ登録し、抜け漏れを防止しました（`GroupViewModel.moveGroup`の対応はクロスレビューのmust-fix指摘を受けて追加）。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/BackgroundSyncTracker.swift`（新規）: バックグラウンド同期Taskの追跡・完了待機用シングルトン
- `SportsNote_iOS/Model/Manager/InitializationManager.swift`: `deleteAllData()`でRealm全削除前に`BackgroundSyncTracker.shared.waitForAll()`を追加
- `SportsNote_iOS/ViewModel/Protocols/FirebaseSyncable.swift`: `performBackgroundSync`が起動するTaskをトラッカーに登録
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`: `moveTask`の独自Taskをトラッカーに登録
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`: `moveGroup`の独自Taskをトラッカーに登録
- `SportsNote_iOSTests/Managers/BackgroundSyncTrackerTests.swift`（新規）: トラッカー単体のテスト4件
- `SportsNote_iOSTests/Managers/InitializationManagerDeleteAllDataTests.swift`（新規）: `deleteAllData()`が同期完了を待ってから削除する回帰テスト2件

## ビルド・テスト結果
- swift-format: 正常完了
- `xcodebuild build`: **BUILD SUCCEEDED**
- `xcodebuild test`: **TEST SUCCEEDED**（469 tests in 21 suites、全件成功。新規テスト6件含む）

## 完了条件チェックリスト
- [x] ログアウト/アカウント削除時に、進行中のFirebaseバックグラウンド同期が完了してから（または安全に打ち切られてから）Realmの全削除が実行されること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順（保存直後のログアウト）でクラッシュや同期データの消失が発生しないことを確認できる（`InitializationManagerDeleteAllDataTests`で、同期未完了のTaskがRealm全削除前に完了することを回帰テストとして検証。レビュアーが待機処理を一時的にコメントアウトしてロールバック実験を行い、テストが期待通り失敗することも実証済み）

## クロスレビュー結果
2ラウンド実施。
- ラウンド1: must-fix 1件（`GroupViewModel.moveGroup`の独自Taskが未追跡のまま残存。`TaskViewModel.moveTask`と同一パターンの見落とし）→ 修正済み
- ラウンド2: 上記修正を確認し **PASS**。should-fix 2件が残るがマージをブロックしないものとして記録:
  - `BackgroundSyncTracker.waitForAll()`にタイムアウト・打ち切り機構がなく、ネットワーク不調時に`deleteAllData()`が無期限にブロックされうる退行リスク（将来的な別issue化を推奨）
  - `BackgroundSyncTracker.shared`がテストスイート間で共有されるシングルトン状態のため、`.serialized`スイート外との並行実行時に理論上の混入リスクがある（実害は小さいと判断し合格扱い）

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)