### PR TITLE
Fix: TaskSelectionViewの課題一覧が追加済み課題を除外できていない問題を修正

### DIFF
--- a/SportsNote_iOS/Resource/LocalizedString.swift
+++ b/SportsNote_iOS/Resource/LocalizedString.swift
@@ -143,7 +143,6 @@ struct LocalizedStrings {
     static let noTasksAvailable = "noTasksAvailable".localized
     static let selectTask = "selectTask".localized
     static let deleteTaskFromNote = "deleteTaskFromNote".localized
-    static let added = "added".localized
     static let defaltFreeNoteDetail = "defaltFreeNoteDetail".localized
 
     // MARK: Target

--- a/SportsNote_iOS/Resource/en.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/en.lproj/Localizable.strings
@@ -134,7 +134,6 @@
 "noTasksAvailable" = "No tasks available to add";
 "selectTask" = "Select tasks to add to note";
 "deleteTaskFromNote" = "Delete this task from note?";
-"added" = "Added";
 "defaltFreeNoteDetail" = "This note is always displayed at the top.";
 
 // MARK: Target

--- a/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
@@ -134,7 +134,6 @@
 "noTasksAvailable" = "追加可能な課題がありません";
 "selectTask" = "ノートに追加する課題を選択";
 "deleteTaskFromNote" = "ノートから課題を削除しますか？";
-"added" = "追加済み";
 "defaltFreeNoteDetail" = "常に最上位に表示されるノートです。";
 
 // MARK: Target

--- a/SportsNote_iOS/View/Note/Components/TaskSelectionView.swift
+++ b/SportsNote_iOS/View/Note/Components/TaskSelectionView.swift
@@ -8,7 +8,7 @@ struct TaskSelectionView: View {
     var onTaskSelected: (TaskListData) -> Void
     var addedTaskIds: Set<String>
     private var incompleteTasks: [TaskListData] {
-        return taskViewModel.getUnaddedTasks(excludingTaskIds: [])
+        return taskViewModel.getUnaddedTasks(excludingTaskIds: addedTaskIds)
     }
 
     var body: some View {
@@ -24,26 +24,8 @@ struct TaskSelectionView: View {
                             onTaskSelected(task)
                             dismiss()
                         }) {
-                            HStack {
-                                TaskRow(taskList: task, isComplete: false)
-
-                                Spacer()
-
-                                // 追加済みの課題にはラベル表示
-                                if addedTaskIds.contains(task.taskID) {
-                                    Text(LocalizedStrings.added)
-                                        .font(.caption)
-                                        .foregroundColor(.green)
-                                        .padding(.horizontal, 8)
-                                        .padding(.vertical, 4)
-                                        .background(Color.green.opacity(0.1))
-                                        .cornerRadius(4)
-                                }
-                            }
+                            TaskRow(taskList: task, isComplete: false)
                         }
-                        .disabled(addedTaskIds.contains(task.taskID))
-                        .listRowBackground(
-                            addedTaskIds.contains(task.taskID) ? Color(.systemGray5) : Color(.systemBackground))
                     }
                 }
             }


### PR DESCRIPTION
## 概要
`TaskSelectionView.incompleteTasks`が呼び出し元から渡された`addedTaskIds`を使わず、常に空集合で`getUnaddedTasks`を呼んでいたため、既に追加済みの課題が一覧から除外されずに残ってしまう問題を修正。

Closes #63

## 変更内容
- `TaskSelectionView.incompleteTasks`が`getUnaddedTasks(excludingTaskIds: [])`を呼んでいた箇所を`getUnaddedTasks(excludingTaskIds: addedTaskIds)`に修正
- 上記修正により実行時に到達不能となった「追加済み」ラベル表示・`.disabled(...)`・グレー背景の分岐（デッドコード）を削除
- 未使用になった`LocalizedStrings.added`を`LocalizedString.swift`・`en.lproj`/`ja.lproj`の`Localizable.strings`から削除

## 補足（過去の経緯）
本issueには過去に一度PR #127が作成されましたが、マージされずクローズされていました（クローズ理由の記録なし）。当時のクロスレビューでは「フィルタ修正によりデッドコード化する箇所がある」というshould-fix指摘があり合格扱いでしたが、今回はこの指摘を踏まえてデッドコードも同時に除去しています。

## 変更ファイル一覧
- `SportsNote_iOS/View/Note/Components/TaskSelectionView.swift`
- `SportsNote_iOS/Resource/LocalizedString.swift`
- `SportsNote_iOS/Resource/en.lproj/Localizable.strings`
- `SportsNote_iOS/Resource/ja.lproj/Localizable.strings`

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test`（全テスト） → TEST SUCCEEDED（540 tests in 29 suites 全成功）

## 完了条件チェックリスト
- [x] `TaskSelectionView`が`addedTaskIds`をリスト絞り込みに使用するようになること
- [x] 追加済みの課題が課題選択画面の一覧に表示されなくなること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立コンテキストのサブエージェントによるクロスレビューを2ラウンド実施。
- ラウンド1: must-fix 1件（実装がコミットされていなかった）・should-fix 1件（`LocalizedStrings.added`の未使用化）を指摘 → 両方修正
- ラウンド2: 指摘なしで合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)