### PR TITLE
fix: 対策詳細画面でノート未紐付けメモが表示されない不具合を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -190,6 +190,20 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         var measuresMemoList = [MeasuresMemo]()
 
         for memo in memos {
+            // noteIDが空文字の場合（旧アプリでノート未紐付けだったメモ）は
+            // Noteに依存せず、created_atをフォールバック日付として一覧に含める
+            guard !memo.noteID.isEmpty else {
+                let measuresMemo = MeasuresMemo(
+                    memoID: memo.memoID,
+                    measuresID: memo.measuresID,
+                    noteID: memo.noteID,
+                    detail: memo.detail,
+                    date: memo.created_at
+                )
+                measuresMemoList.append(measuresMemo)
+                continue
+            }
+
             do {
                 // Noteデータを取得
                 if let note = try RealmManager.shared.getObjectById(id: memo.noteID, type: Note.self) {

--- a/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
@@ -429,6 +429,35 @@ struct MemoViewModelTests {
         manager.clearAll()
     }
 
+    @Test("getMemosByMeasuresID - noteIDが空文字のメモ（旧データのノート未紐付けメモ）も一覧に含まれる")
+    func getMemosByMeasuresID_includesMemosWithEmptyNoteID() async {
+        let viewModel = MemoViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let note = Note(purpose: "Purpose", detail: "Detail")
+        note.noteID = "n1"
+        note.noteType = NoteType.practice.rawValue
+        note.date = Date()
+        try? manager.saveItem(note)
+
+        let linkedMemo = Memo(memoID: "m1", measuresID: "ms1", noteID: "n1", detail: "Linked", created_at: Date())
+        let unlinkedMemo = Memo(memoID: "m2", measuresID: "ms1", noteID: "", detail: "Unlinked", created_at: Date())
+        try? manager.saveItem(linkedMemo)
+        try? manager.saveItem(unlinkedMemo)
+
+        let result = viewModel.getMemosByMeasuresID(measuresID: "ms1")
+
+        if case .success(let memos) = result {
+            #expect(memos.count == 2)
+            #expect(memos.contains(where: { $0.memoID == "m2" && $0.noteID.isEmpty }))
+        } else {
+            Issue.record("GetMemosByMeasuresID failed")
+        }
+
+        manager.clearAll()
+    }
+
     @Test("saveMemo - 既存インターフェースでメモを保存できる")
     func saveMemo_savesWithLegacyInterface() async {
         let viewModel = MemoViewModel()


### PR DESCRIPTION
## 概要
旧アプリ（UIKit版）のマイグレーションで `noteID` が空文字になった対策メモ（ノート未紐付けの有効性コメント）が、`MemoViewModel.getMemosByMeasuresID` 内で `RealmManager.getObjectById` の空ID例外がcatchで握りつぶされ、対策詳細画面のメモ一覧から恒久的に欠落していた不具合を修正。

`noteID` が空文字の場合は `getObjectById` を呼び出さず、`memo.created_at` をフォールバック日付として `MeasuresMemo` を生成し一覧に含めるようにした。

Closes #90

## 変更ファイル
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`
- `SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift`（新規テスト追加）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 550件全て成功（新規追加した `getMemosByMeasuresID_includesMemosWithEmptyNoteID` を含む）

## 完了条件
- [x] `memo.noteID` が空文字のメモが、対策詳細画面のメモ一覧（`measuresMemoList`）に表示されるようになっている
- [x] `getMemosByMeasuresID` が空文字 `noteID` のメモに対して `getObjectById` を呼び出さない
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順の代替検証（ユニットテスト＋ロールバック実験＋コード追跡）で修正効果を確認（Firebase/Auth依存のため実機UIでの完全再現は未実施）

## クロスレビュー結果
must-fix指摘なし。以下はshould-fix/nitとして記録（対応は見送り）:
- `MemoViewModel.swift` のguard分岐とdo分岐で `MeasuresMemo` 構築コードがやや重複（issue対応方針の最小差分アプローチと整合するため許容）
- リンク済みメモは `note.date`、未紐付けメモは `memo.created_at` と異なる意味のDate値をソートキーに混在させている（旧データに代替可能なタイムスタンプが存在しないため許容）