### PR TITLE
fix: 練習ノートで新規追加した課題を削除してもMemoが孤立しないよう修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -504,6 +504,17 @@ final class RealmManager {
         }
     }
 
+    /// noteID・measuresIDに合致する未削除Memoを1件取得する
+    /// task.memoIDが未確定（View側のtaskReflectionsのDictionaryキーにmemoIDが反映されていない）
+    /// 場合でも、Realm上に実際に保存された対象Memoを特定するために使用する
+    /// - Parameters:
+    ///   - noteID: ノートID
+    ///   - measuresID: 対策ID
+    /// - Returns: 該当するMemo（存在しない場合はnil）
+    func findMemo(noteID: String, measuresID: String) -> Memo? {
+        return getMemosByNoteID(noteID: noteID).first(where: { $0.measuresID == measuresID })
+    }
+
     /// ノートの背景色を取得
     /// - Parameter noteID: ノートID
     /// - Returns: ノートの背景色

--- a/SportsNote_iOS/View/Note/Components/TaskListItemView.swift
+++ b/SportsNote_iOS/View/Note/Components/TaskListItemView.swift
@@ -8,6 +8,8 @@ struct TaskListSection: View {
 
     @Binding var taskReflections: [TaskListData: String]
     var unaddedTasks: [TaskListData]
+    /// ノートID（新規作成画面ではまだノートが保存されていないためnil）
+    var noteID: String? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -54,12 +56,23 @@ struct TaskListSection: View {
             Button(LocalizedStrings.cancel, role: .cancel) {}
             Button(LocalizedStrings.delete, role: .destructive) {
                 if let task = selectedTaskForDeletion {
-                    if let deleteMemoID = task.memoID {
-                        Task {
-                            let result = await memoViewModel.deleteMemo(memoID: deleteMemoID)
-                            if case .failure(let error) = result {
-                                memoViewModel.showErrorAlert(error)
-                            }
+                    Task {
+                        let result: Result<Void, SportsNoteError>
+                        if let deleteMemoID = task.memoID {
+                            result = await memoViewModel.deleteMemo(memoID: deleteMemoID)
+                        } else if let noteID = noteID {
+                            // 新規追加直後の課題はtaskReflectionsのキーにmemoIDが反映されないため、
+                            // noteID+measuresIDでRealm上の実メモを検索してから削除する
+                            result = await memoViewModel.deleteMemoByNoteAndMeasures(
+                                noteID: noteID,
+                                measuresID: task.measuresID
+                            )
+                        } else {
+                            // 未保存のノート（新規作成画面）ではRealmにメモがまだ存在しない
+                            result = .success(())
+                        }
+                        if case .failure(let error) = result {
+                            memoViewModel.showErrorAlert(error)
                         }
                     }
                     taskReflections.removeValue(forKey: task)

--- a/SportsNote_iOS/View/Note/PracticeNoteView.swift
+++ b/SportsNote_iOS/View/Note/PracticeNoteView.swift
@@ -64,7 +64,8 @@ struct PracticeNoteView: View {
                     Section(header: Text(LocalizedStrings.taskReflection)) {
                         TaskListSection(
                             taskReflections: $taskReflections,
-                            unaddedTasks: taskViewModel.getUnaddedTasks(taskReflections: taskReflections)
+                            unaddedTasks: taskViewModel.getUnaddedTasks(taskReflections: taskReflections),
+                            noteID: noteID
                         )
                         .onChange(of: taskReflections) { _ in
                             updateNote()

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -282,4 +282,18 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     func deleteMemo(memoID: String) async -> Result<Void, SportsNoteError> {
         return await delete(id: memoID)
     }
+
+    /// noteID・measuresIDに合致する既存メモを検索し、存在すれば論理削除する
+    /// task.memoIDが未確定（課題追加直後、taskReflectionsのDictionaryキーにmemoIDが
+    /// 反映されていない）場合でも、Realm上に実際に保存されているメモを確実に削除する
+    /// - Parameters:
+    ///   - noteID: ノートID
+    ///   - measuresID: 対策ID
+    /// - Returns: Result<Void, SportsNoteError>（該当メモが存在しない場合も.success(())を返す）
+    func deleteMemoByNoteAndMeasures(noteID: String, measuresID: String) async -> Result<Void, SportsNoteError> {
+        guard let memo = RealmManager.shared.findMemo(noteID: noteID, measuresID: measuresID) else {
+            return .success(())
+        }
+        return await delete(id: memo.memoID)
+    }
 }

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -381,17 +381,12 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 memo.memoID = existingMemoID
                 // 既存メモをRealmから取得し、created_atを引き継ぐ
                 existingCreatedAt = (try? realmManager.getObjectById(id: existingMemoID, type: Memo.self))?.created_at
+            } else if let existingMemo = realmManager.findMemo(noteID: noteID, measuresID: task.measuresID) {
+                memo.memoID = existingMemo.memoID  // 既存IDを使用
+                // 検索でヒットした既存メモのcreated_atを引き継ぐ
+                existingCreatedAt = existingMemo.created_at
             } else {
-                let existingMemos = realmManager.getMemosByNoteID(noteID: noteID)
-                if let existingMemo = existingMemos.first(where: {
-                    $0.measuresID == task.measuresID
-                }) {
-                    memo.memoID = existingMemo.memoID  // 既存IDを使用
-                    // 検索でヒットした既存メモのcreated_atを引き継ぐ
-                    existingCreatedAt = existingMemo.created_at
-                } else {
-                    memo.memoID = UUIDGenerator.generateID()  // 新規生成
-                }
+                memo.memoID = UUIDGenerator.generateID()  // 新規生成
             }
 
             memo.measuresID = task.measuresID

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -630,6 +630,41 @@ struct RealmManagerTests {
         manager.clearAll()
     }
 
+    @Test("findMemo - noteIDとmeasuresIDが一致するMemoを取得できる")
+    func findMemo_returnsMatchingMemo() async throws {
+        let memo1 = Memo()
+        memo1.memoID = "memo1"
+        memo1.noteID = "n1"
+        memo1.measuresID = "ms1"
+
+        let memo2 = Memo()
+        memo2.memoID = "memo2"
+        memo2.noteID = "n1"
+        memo2.measuresID = "ms2"
+
+        try manager.saveItem(memo1)
+        try manager.saveItem(memo2)
+
+        let result = manager.findMemo(noteID: "n1", measuresID: "ms1")
+        #expect(result?.memoID == "memo1")
+
+        manager.clearAll()
+    }
+
+    @Test("findMemo - 一致するMemoが存在しない場合はnilを返す")
+    func findMemo_returnsNilWhenNoMatch() async throws {
+        let memo1 = Memo()
+        memo1.memoID = "memo1"
+        memo1.noteID = "n1"
+        memo1.measuresID = "ms1"
+        try manager.saveItem(memo1)
+
+        let result = manager.findMemo(noteID: "n1", measuresID: "ms-not-exist")
+        #expect(result == nil)
+
+        manager.clearAll()
+    }
+
     @Test("fetchYearlyTargets - 年間目標を取得できる")
     func fetchYearlyTargets_returnsTargets() async throws {
         // let manager = RealmManager.shared

--- a/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
@@ -429,6 +429,41 @@ struct MemoViewModelTests {
         manager.clearAll()
     }
 
+    @Test("deleteMemoByNoteAndMeasures - 一致するメモを論理削除できる")
+    func deleteMemoByNoteAndMeasures_deletesMatchingMemo() async {
+        let viewModel = MemoViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let memo = Memo(memoID: "m1", measuresID: "ms1", noteID: "n1", detail: "Detail", created_at: Date())
+        try? manager.saveItem(memo)
+
+        let result = await viewModel.deleteMemoByNoteAndMeasures(noteID: "n1", measuresID: "ms1")
+
+        if case .failure = result {
+            Issue.record("DeleteMemoByNoteAndMeasures failed")
+        }
+
+        #expect(manager.findMemo(noteID: "n1", measuresID: "ms1") == nil)
+
+        manager.clearAll()
+    }
+
+    @Test("deleteMemoByNoteAndMeasures - 一致するメモが存在しない場合は何もせず成功を返す")
+    func deleteMemoByNoteAndMeasures_noMatchReturnsSuccess() async {
+        let viewModel = MemoViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let result = await viewModel.deleteMemoByNoteAndMeasures(noteID: "n1", measuresID: "ms-not-exist")
+
+        if case .failure = result {
+            Issue.record("DeleteMemoByNoteAndMeasures should succeed when no match found")
+        }
+
+        manager.clearAll()
+    }
+
     @Test("saveMemo - 既存インターフェースでメモを保存できる")
     func saveMemo_savesWithLegacyInterface() async {
         let viewModel = MemoViewModel()

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -782,6 +782,53 @@ struct NoteViewModelTests {
         manager.clearAll()
     }
 
+    @Test("updateTaskReflections - task.memoIDがなくnoteID+measuresID検索で既存メモが見つかる場合も、空文字への編集が保存される")
+    func updateTaskReflections_existingMemoFoundBySearch_savesEmptyDetail() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let existingMemo = Memo(
+            memoID: "memo-fixed-4b",
+            measuresID: "measures-4b",
+            noteID: "note-4b",
+            detail: "頑張った",
+            created_at: Date()
+        )
+        try? manager.saveItem(existingMemo)
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-4b", taskID: "task-4b", title: "Test Measures", order: 0, created_at: Date())
+        )
+
+        let viewModel = NoteViewModel()
+        // memoIDを持たないTaskListDataで渡す（noteID+measuresIDでの検索分岐を通す）
+        let task = TaskListData(
+            taskID: "task-4b",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-4b",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-4b",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: ""]
+        )
+
+        let updatedMemo = try? manager.getObjectById(id: "memo-fixed-4b", type: Memo.self)
+
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.detail == "")
+
+        manager.clearAll()
+    }
+
     @Test("updateTaskReflections - 既存メモがない状態で空文字のまま保存しても新規メモは作成されない")
     func updateTaskReflections_noExistingMemo_emptyText_doesNotCreateMemo() async {
         let manager = RealmManager.shared


### PR DESCRIPTION
## 概要
練習ノート編集画面で新規に課題を追加し感想を入力した直後にその課題を削除すると、対応するMemoレコードがRealm上で削除されず孤立して残り、ノート画面を再読み込みすると削除したはずの感想が復活する不具合を修正。

課題追加直後は`task.memoID`が常にnilで、`NoteViewModel.updateTaskReflections`がRealmにMemoを保存した後もView側の`taskReflections`辞書のキー（`TaskListData`インスタンス）は更新されずmemoIDはnilのまま残り続けていたため、削除時に`if let deleteMemoID = task.memoID`ガードでRealm削除処理自体がスキップされていた。

`noteID`+`measuresID`でRealm上の実メモを検索してから削除するように修正した。新規作成画面（`AddPracticeNoteView`、保存前でnoteIDが存在しない）にも影響しないよう`noteID`はOptionalにしている。

Closes #92

## 変更ファイル
- `SportsNote_iOS/Model/Manager/RealmManager.swift`（`findMemo`ヘルパー追加）
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`（`deleteMemoByNoteAndMeasures`追加）
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`（重複検索ロジックを`findMemo`に統合、挙動変更なし）
- `SportsNote_iOS/View/Note/Components/TaskListItemView.swift`（削除フロー修正、`noteID`パラメータ追加）
- `SportsNote_iOS/View/Note/PracticeNoteView.swift`（`noteID`を渡すよう変更）
- `SportsNote_iOSTests/Managers/RealmManagerTests.swift`（`findMemo`のテスト追加）
- `SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift`（`deleteMemoByNoteAndMeasures`のテスト追加）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 554件全て成功（新規追加4件を含む）

## 完了条件
- [x] `task.memoID`がnilの場合でも`noteID`+`measuresID`一致の既存Memoを検索して削除できる
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で問題が再現しないことをコード追跡・ユニットテストで確認

## クロスレビュー結果
指摘なし（合格）。`AddPracticeNoteView`（noteID未保存画面）への影響考慮、`TournamentNoteView`等の他画面に漏れがないことも独立確認済み。