### PR TITLE
fix: Mailerのフォールバックmailto URLで件名・本文が二重エンコードされる不具合を修正

### DIFF
--- a/SportsNote_iOS/View/Setting/Mailer.swift
+++ b/SportsNote_iOS/View/Setting/Mailer.swift
@@ -127,10 +127,9 @@ class Mailer: NSObject, @preconcurrency MFMailComposeViewControllerDelegate {
     }
 
     /// mailto: URLスキーム文字列を作成
-    private func createMailtoURLString(email: String, subject: String, body: String) -> String? {
+    func createMailtoURLString(email: String, subject: String, body: String) -> String? {
         return
             "mailto:\(email)?subject=\(subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&body=\(body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
-            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
     }
 
     /// メーラーが見つからない場合のアラートを表示

--- a/SportsNote_iOSTests/Utils/MailerTests.swift
+++ b/SportsNote_iOSTests/Utils/MailerTests.swift
@@ -1,0 +1,43 @@
+//
+//  MailerTests.swift
+//  SportsNote_iOSTests
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("Mailer Tests", .serialized)
+@MainActor
+struct MailerTests {
+
+    @Test("createMailtoURLString - 件名・本文が二重にパーセントエンコードされない")
+    func createMailtoURLString_doesNotDoubleEncode() {
+        let result = Mailer.shared.createMailtoURLString(
+            email: "test@example.com",
+            subject: "Test Subject",
+            body: "Test Body"
+        )
+
+        #expect(result != nil)
+        #expect(result?.contains("%2520") == false)
+        #expect(result?.contains("Test%20Subject") == true)
+        #expect(result?.contains("Test%20Body") == true)
+    }
+
+    @Test("createMailtoURLString - 有効なmailto URLとしてパースできる")
+    func createMailtoURLString_generatesValidURL() {
+        let result = Mailer.shared.createMailtoURLString(
+            email: "test@example.com",
+            subject: "Subject",
+            body: "Body"
+        )
+
+        #expect(result != nil)
+        #expect(result?.hasPrefix("mailto:test@example.com?subject=") == true)
+
+        let url = result.flatMap { URL(string: $0) }
+        #expect(url != nil)
+    }
+}


### PR DESCRIPTION
## 概要
端末にメールアカウントが未設定でMFMailComposeViewControllerが使えない場合、`mailto:` URLスキームへフォールバックするが、`createMailtoURLString`が件名・本文をそれぞれエンコードした後、組み立てたURL文字列全体にさらにパーセントエンコードを適用しており、スペースが`%20`ではなく`%2520`のように文字化けしていた不具合を修正。

Closes #99

## 変更ファイル
- `SportsNote_iOS/View/Setting/Mailer.swift`（全体への再エンコードを削除、テスト容易性のためアクセス修飾子をprivate→internalに変更）
- `SportsNote_iOSTests/Utils/MailerTests.swift`（新規、回帰防止テスト追加）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 551件全て成功（新規追加した`MailerTests`2件を含む）

## 完了条件
- [x] `createMailtoURLString`が件名・本文をそれぞれ1回だけパーセントエンコードする
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] フォールバックURLの件名・本文が文字化けしないことをユニットテストで確認

## クロスレビュー結果
should-fix指摘1件（`MailerTests`の`@Suite`に`.serialized`が付与されていなかった）を修正済み。他にmust-fix指摘なし。