### PR TITLE
fix: 練習ノートの課題振り返りを空文字に編集しても保存されない不具合を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -367,10 +367,9 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - taskReflections: タスクの振り返り（キー: TaskListData, 値: 振り返りテキスト）
     private func updateTaskReflections(noteID: String, taskReflections: [TaskListData: String]) {
         for (task, reflectionText) in taskReflections {
-            if reflectionText.isEmpty { continue }
-
             let memo = Memo()
             var existingCreatedAt: Date?
+            var isExistingMemo = false
 
             // memoIDの決定ロジック:
             // 1. task.memoIDがあればそれを使用(既存メモ編集)
@@ -379,6 +378,7 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             // 4. なければ新規ID生成(新規作成)
             if let existingMemoID = task.memoID {
                 memo.memoID = existingMemoID
+                isExistingMemo = true
                 // 既存メモをRealmから取得し、created_atを引き継ぐ
                 existingCreatedAt = (try? realmManager.getObjectById(id: existingMemoID, type: Memo.self))?.created_at
             } else {
@@ -387,12 +387,17 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                     $0.measuresID == task.measuresID
                 }) {
                     memo.memoID = existingMemo.memoID  // 既存IDを使用
+                    isExistingMemo = true
                     // 検索でヒットした既存メモのcreated_atを引き継ぐ
                     existingCreatedAt = existingMemo.created_at
                 } else {
                     memo.memoID = UUIDGenerator.generateID()  // 新規生成
                 }
             }
+
+            // 既存メモがない状態で空文字のままの場合は新規メモを作成しない。
+            // 既存メモを空文字に編集するケースは保存対象とする（issue #105）
+            if !isExistingMemo && reflectionText.isEmpty { continue }
 
             memo.measuresID = task.measuresID
             memo.noteID = noteID

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -670,6 +670,82 @@ struct NoteViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - updateTaskReflections（課題振り返りメモ）の空文字編集テスト（issue #105）
+
+    @Test("updateTaskReflections - 既存メモを空文字に編集した場合、Realm上のdetailが空文字に更新される")
+    func updateTaskReflections_existingMemo_savesEmptyDetail() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let existingMemo = Memo(
+            memoID: "memo-fixed-3",
+            measuresID: "measures-3",
+            noteID: "note-3",
+            detail: "頑張った",
+            created_at: Date()
+        )
+        try? manager.saveItem(existingMemo)
+
+        let viewModel = NoteViewModel()
+        let task = TaskListData(
+            taskID: "task-3",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-3",
+            measures: "Test Measures",
+            memoID: "memo-fixed-3",
+            order: 0,
+            isComplete: false
+        )
+
+        // 振り返り欄を空文字に編集して保存
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-3",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: ""]
+        )
+
+        let updatedMemo = try? manager.getObjectById(id: "memo-fixed-3", type: Memo.self)
+
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.detail == "")
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - 既存メモがない状態で空文字のまま保存しても新規メモは作成されない")
+    func updateTaskReflections_noExistingMemo_emptyText_doesNotCreateMemo() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let viewModel = NoteViewModel()
+        let task = TaskListData(
+            taskID: "task-4",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-4",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-4",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: ""]
+        )
+
+        let memos = manager.getMemosByNoteID(noteID: "note-4")
+        #expect(memos.isEmpty)
+
+        manager.clearAll()
+    }
+
     // MARK: - updateTaskReflections（課題振り返りメモ）のFirebase同期テスト
 
     @Test("updateTaskReflections - 新規作成時、Memoの同期呼び出しがisUpdate=falseで発生する")


### PR DESCRIPTION
## 概要
練習ノートの課題振り返り（対策メモ）を編集して全文字を削除し空文字にした場合、その変更が保存されず、次回表示時に削除前のテキストへ静かに戻ってしまう不具合を修正。

`NoteViewModel.updateTaskReflections`が`if reflectionText.isEmpty { continue }`で、既存メモの更新かどうかに関わらず空文字の場合を一律スキップしていたのが原因。既存メモの有無を判定する`isExistingMemo`フラグを導入し、既存メモがある場合は空文字でも保存されるように修正した。新規作成時に空文字のまま保存してもメモを作らない従来の挙動は維持している。

Closes #105

## 変更ファイル
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`（新規テスト追加）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 551件全て成功（新規追加2件を含む）

## 完了条件
- [x] 既存の振り返りメモを空文字に編集して保存した場合、Realm上の`Memo.detail`が空文字に更新される
- [x] 既存メモが存在しない状態で振り返り欄を空のまま保存しても、新規メモが作成されない（従来通り）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で問題が再現しないことをユニットテストで確認

## クロスレビュー結果
must-fix指摘なし。should-fix指摘2件（対応は見送り、限定的なエッジケースのため）:
- `task.memoID`が非nilだが実際にはRealm上に存在しない（論理削除済み等）状態で空文字保存すると、新規作成扱いでメモが復活してしまう可能性がある。ただしこれはissue本文が指定した`isExistingMemo`判定基準（`task.memoID`の有無）に忠実に従った結果であり、非空文字での編集時も従来から同一の挙動。再現には同一セッション中のメモ削除（issue #92の領域）等の限定的な前提が必要
- 上記エッジケースを検証するテストが未追加