### PR TITLE
fix: 課題のグループ変更時にorderが移動先グループ内で衝突する不具合を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -345,12 +345,24 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ) -> TaskData {
         if let existingTask = existingTask {
             // 更新の場合: 既存データをベースに新しいTaskDataを作成
+            // groupIDが変更された場合は移動先グループ内の最大order+1を採番し、
+            // 既存課題とのorder衝突を防ぐ（groupIDが変わらない通常の更新ではorderを維持する）
+            let order: Int
+            if groupID != existingTask.groupID {
+                order = RealmManager.shared.getNextOrder(
+                    clazz: TaskData.self,
+                    predicate: NSPredicate(format: "groupID == %@", groupID)
+                )
+            } else {
+                order = existingTask.order
+            }
+
             return TaskData(
                 taskID: existingTask.taskID,
                 title: title,
                 cause: cause,
                 groupID: groupID,
-                order: existingTask.order,
+                order: order,
                 isComplete: overrideIsComplete ?? existingTask.isComplete,
                 created_at: existingTask.created_at
             )

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -853,6 +853,61 @@ struct TaskViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - グループ変更時のorder衝突回帰テスト（issue #106）
+
+    @Test("updateTask - グループを変更した場合、移動先グループ内の最大order+1に再採番される")
+    func updateTask_groupChanged_reassignsOrderToAvoidCollision() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // Group1にTask A（order=0）
+        let taskA = TaskData(
+            taskID: "task-a", title: "Task A", cause: "", groupID: "group1", order: 0, isComplete: false,
+            created_at: Date())
+        try? manager.saveItem(taskA)
+
+        // Group2にTask X（order=0）・Task Y（order=1）
+        let taskX = TaskData(
+            taskID: "task-x", title: "Task X", cause: "", groupID: "group2", order: 0, isComplete: false,
+            created_at: Date())
+        let taskY = TaskData(
+            taskID: "task-y", title: "Task Y", cause: "", groupID: "group2", order: 1, isComplete: false,
+            created_at: Date())
+        try? manager.saveItem(taskX)
+        try? manager.saveItem(taskY)
+
+        // Task AをGroup2に変更して保存
+        _ = await viewModel.updateTask(taskID: "task-a", title: "Task A", cause: "", groupID: "group2")
+
+        let updatedTaskA = try? manager.getObjectById(id: "task-a", type: TaskData.self)
+        #expect(updatedTaskA?.groupID == "group2")
+        // Group2内の既存最大order(1)+1に採番され、Task X・Task Yと衝突しないこと
+        #expect(updatedTaskA?.order == 2)
+
+        manager.clearAll()
+    }
+
+    @Test("updateTask - グループを変更しない場合、orderは維持される")
+    func updateTask_groupUnchanged_preservesOrder() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let task = TaskData(
+            taskID: "task-a", title: "Task A", cause: "", groupID: "group1", order: 3, isComplete: false,
+            created_at: Date())
+        try? manager.saveItem(task)
+
+        // グループを変更せずタイトルのみ更新
+        _ = await viewModel.updateTask(taskID: "task-a", title: "Updated", cause: "", groupID: "group1")
+
+        let updatedTask = try? manager.getObjectById(id: "task-a", type: TaskData.self)
+        #expect(updatedTask?.order == 3)
+
+        manager.clearAll()
+    }
+
     @Test("saveNewTaskWithMeasures - 課題と対策を同時に保存できる")
     func saveNewTaskWithMeasures_savesTaskAndMeasures() async {
         let viewModel = TaskViewModel()


### PR DESCRIPTION
## 概要
課題（Task）の所属グループを変更して保存した際、`order`が移動先グループの並び順に合わせて再計算されず、移動先グループ内の既存課題と`order`が衝突する不具合を修正。

`TaskViewModel.createTaskData(basedOn:)`の更新パスが`groupID`変更時も`existingTask.order`を無条件に引き継いでいたのが原因。`groupID`が変わった場合のみ`RealmManager.getNextOrder`で移動先グループ内の最大order+1を採番するように修正した。`groupID`が変わらない通常の更新では従来通り`existingTask.order`を維持する。

Closes #106

## 変更ファイル
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`（新規テスト追加）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 551件全て成功（新規追加2件を含む）

## 完了条件
- [x] 課題のグループを変更して保存した場合、移動先グループ内の既存課題と`order`が重複しない
- [x] グループを変更しない通常の更新では、`order`が従来通り維持される
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で問題が再現しないことをユニットテストで確認

## クロスレビュー結果
指摘なし（合格）。`createTaskData`の他の呼び出し元（`toggleTaskCompletion`は常に既存groupIDを渡すため影響なし、新規作成パスは対象外）への影響、`getNextOrder`が移動先グループが空の場合も正しく`order=0`を返すことも確認済み。