### PR TITLE
fix: 対策の優先度変更後にノート振り返りが消失する不具合とloadNoteのローディング未反映を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -90,6 +90,9 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: noteID
     func loadNote(id: String) {
         Task {
+            isLoading = true
+            defer { isLoading = false }
+
             let result = await fetchById(id: id)
             switch result {
             case .success(let note):
@@ -383,8 +386,13 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 existingCreatedAt = (try? realmManager.getObjectById(id: existingMemoID, type: Memo.self))?.created_at
             } else {
                 let existingMemos = realmManager.getMemosByNoteID(noteID: noteID)
+                // task.measuresID（現在の最優先対策のID）だけでなく、taskIDに紐づく
+                // 全対策のmeasuresIDのいずれかで検索する。対策の並び替えで最優先対策が
+                // 変わった後も、既存メモを同一課題のものとして正しく検出するため（issue #109）
+                let taskMeasuresIDs = Set(
+                    realmManager.getMeasuresByTaskID(taskID: task.taskID).map { $0.measuresID })
                 if let existingMemo = existingMemos.first(where: {
-                    $0.measuresID == task.measuresID
+                    taskMeasuresIDs.contains($0.measuresID)
                 }) {
                     memo.memoID = existingMemo.memoID  // 既存IDを使用
                     isExistingMemo = true

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -449,7 +449,14 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     func associateTasksWithMemos(memos: [Memo]) -> [(task: TaskListData, memo: Memo)] {
         var result: [String: (task: TaskListData, memo: Memo)] = [:]
         for memo in memos {
-            if let task = taskListData.first(where: { $0.measuresID == memo.measuresID }) {
+            // memo.measuresIDが指す対策のtaskIDを解決してから突合する。
+            // taskListData.measuresIDは常に現在の最優先対策のIDのため、対策の並び替えで
+            // 変わった場合でもtaskIDで突合すれば同一課題として認識できる（issue #109）
+            guard let measures = try? RealmManager.shared.getObjectById(id: memo.measuresID, type: Measures.self)
+            else {
+                continue
+            }
+            if let task = taskListData.first(where: { $0.taskID == measures.taskID }) {
                 result[task.taskID] = (task: task, memo: memo)
             }
         }

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -635,6 +635,9 @@ struct NoteViewModelTests {
             created_at: fixedCreatedAt
         )
         try? manager.saveItem(existingMemo)
+        try? manager.saveItem(
+            Measures(measuresID: "measures-2", taskID: "task-2", title: "Test Measures", order: 0, created_at: Date())
+        )
 
         let viewModel = NoteViewModel()
         // memoIDを持たないTaskListDataで渡す（noteID+measuresIDでの検索分岐を通す）
@@ -661,6 +664,70 @@ struct NoteViewModelTests {
 
         #expect(updatedMemo != nil)
         #expect(updatedMemo?.detail == "編集後の振り返り(検索経由)")
+        if let updatedCreatedAt = updatedMemo?.created_at {
+            #expect(abs(updatedCreatedAt.timeIntervalSince(fixedCreatedAt)) < 0.5)
+        } else {
+            Issue.record("更新後のMemoのcreated_atが取得できませんでした")
+        }
+
+        manager.clearAll()
+    }
+
+    // MARK: - updateTaskReflections（課題振り返りメモ）の対策並び替え回帰テスト（issue #109）
+
+    @Test("updateTaskReflections - 対策の並び替えでmeasuresIDが変わっても、既存メモが重複作成されず更新される")
+    func updateTaskReflections_existingMemoFoundAfterMeasuresReorder_updatesExistingMemo() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 既存メモは並び替え前の最優先対策(measures-old)に対して作成されたもの
+        let fixedCreatedAt = Date().addingTimeInterval(-3600)
+        let existingMemo = Memo(
+            memoID: "memo-reorder-1",
+            measuresID: "measures-old",
+            noteID: "note-reorder-1",
+            detail: "並び替え前の振り返り",
+            created_at: fixedCreatedAt
+        )
+        try? manager.saveItem(existingMemo)
+
+        // measures-old・measures-newとも同じtask-reorder-1に属する対策
+        // （並び替え後はmeasures-newが最優先=order0になった状態）
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-old", taskID: "task-reorder-1", title: "Old", order: 1, created_at: Date()))
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-new", taskID: "task-reorder-1", title: "New", order: 0, created_at: Date()))
+
+        let viewModel = NoteViewModel()
+        // taskListDataのmeasuresIDは並び替え後の現在の最優先対策(measures-new)を指す
+        let task = TaskListData(
+            taskID: "task-reorder-1",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-new",
+            measures: "New",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-reorder-1",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "並び替え後の振り返り"]
+        )
+
+        // 新規メモが作られず、既存メモが更新されていること（重複作成されないこと）
+        let memos = manager.getMemosByNoteID(noteID: "note-reorder-1")
+        #expect(memos.count == 1)
+
+        let updatedMemo = try? manager.getObjectById(id: "memo-reorder-1", type: Memo.self)
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.detail == "並び替え後の振り返り")
         if let updatedCreatedAt = updatedMemo?.created_at {
             #expect(abs(updatedCreatedAt.timeIntervalSince(fixedCreatedAt)) < 0.5)
         } else {
@@ -832,6 +899,10 @@ struct NoteViewModelTests {
             created_at: Date().addingTimeInterval(-3600)
         )
         try? manager.saveItem(existingMemo)
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-sync-3", taskID: "task-sync-3", title: "Test Measures", order: 0,
+                created_at: Date()))
 
         let viewModel = NoteViewModel()
         // memoIDを持たないTaskListDataで渡す（noteID+measuresIDでの検索分岐を通す）

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -394,8 +394,11 @@ struct TaskViewModelTests {
 
     // MARK: - associateTasksWithMemosテスト（issue #65）
 
-    @Test("associateTasksWithMemos - measuresIDが一致する課題とメモがペアになる")
+    @Test("associateTasksWithMemos - measuresIDが指す対策のtaskIDで課題とメモがペアになる")
     func associateTasksWithMemos_matchesTaskByMeasuresID() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
         let viewModel = TaskViewModel()
         let task = TaskListData(
             taskID: "task-1",
@@ -409,6 +412,10 @@ struct TaskViewModelTests {
             isComplete: false
         )
         viewModel.taskListData = [task]
+
+        try? manager.saveItem(
+            Measures(measuresID: "measures-1", taskID: "task-1", title: "Test Measures", order: 0, created_at: Date())
+        )
 
         let memo = Memo(
             memoID: "memo-1",
@@ -424,10 +431,15 @@ struct TaskViewModelTests {
         #expect(pairs.first?.task.taskID == "task-1")
         #expect(pairs.first?.memo.memoID == "memo-1")
         #expect(pairs.first?.memo.detail == "振り返り内容")
+
+        manager.clearAll()
     }
 
-    @Test("associateTasksWithMemos - measuresIDが一致しない場合はペアに含まれない")
+    @Test("associateTasksWithMemos - measuresIDが指す対策のtaskIDがtaskListDataに存在しない場合はペアに含まれない")
     func associateTasksWithMemos_noMatchIsExcluded() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
         let viewModel = TaskViewModel()
         let task = TaskListData(
             taskID: "task-1",
@@ -441,6 +453,12 @@ struct TaskViewModelTests {
             isComplete: false
         )
         viewModel.taskListData = [task]
+
+        // "measures-unmatched"はtask-1ではなく別課題(task-999)に属する対策
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-unmatched", taskID: "task-999", title: "Other", order: 0, created_at: Date())
+        )
 
         let memo = Memo(
             memoID: "memo-1",
@@ -453,10 +471,59 @@ struct TaskViewModelTests {
         let pairs = viewModel.associateTasksWithMemos(memos: [memo])
 
         #expect(pairs.isEmpty)
+
+        manager.clearAll()
+    }
+
+    @Test("associateTasksWithMemos - 対策の並び替えでmeasuresIDが変わっても、taskIDで同一課題として突合される")
+    func associateTasksWithMemos_matchesAfterMeasuresReorder() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let viewModel = TaskViewModel()
+        // taskListData.measuresIDは並び替え後の現在の最優先対策(measures-B)を指す
+        let task = TaskListData(
+            taskID: "task-1",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-b",
+            measures: "Measures B",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+        viewModel.taskListData = [task]
+
+        // Measures A・Bともtask-1に属する（並び替え後の優先度はB=0, A=1）
+        try? manager.saveItem(
+            Measures(measuresID: "measures-a", taskID: "task-1", title: "Measures A", order: 1, created_at: Date()))
+        try? manager.saveItem(
+            Measures(measuresID: "measures-b", taskID: "task-1", title: "Measures B", order: 0, created_at: Date()))
+
+        // Memoは並び替え前の最優先対策(measures-a)に対して作成されたもの
+        let memo = Memo(
+            memoID: "memo-1",
+            measuresID: "measures-a",
+            noteID: "note-1",
+            detail: "並び替え前の振り返り",
+            created_at: Date()
+        )
+
+        let pairs = viewModel.associateTasksWithMemos(memos: [memo])
+
+        #expect(pairs.count == 1)
+        #expect(pairs.first?.task.taskID == "task-1")
+        #expect(pairs.first?.memo.memoID == "memo-1")
+
+        manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - 同一課題に複数メモが一致する場合はtaskIDで重複排除される")
     func associateTasksWithMemos_dedupesBySameTaskID() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
         let viewModel = TaskViewModel()
         let task = TaskListData(
             taskID: "task-1",
@@ -470,6 +537,10 @@ struct TaskViewModelTests {
             isComplete: false
         )
         viewModel.taskListData = [task]
+
+        try? manager.saveItem(
+            Measures(measuresID: "measures-1", taskID: "task-1", title: "Test Measures", order: 0, created_at: Date())
+        )
 
         let memo1 = Memo(
             memoID: "memo-1",
@@ -493,10 +564,15 @@ struct TaskViewModelTests {
         // 重複排除は後勝ち（辞書の上書き）であることを固定化する（クロスレビュー指摘反映）
         #expect(pairs.first?.memo.memoID == "memo-2")
         #expect(pairs.first?.memo.detail == "2件目")
+
+        manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - 複数課題・複数メモで正しくペアが構築される")
     func associateTasksWithMemos_multipleTasksAndMemos() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
         let viewModel = TaskViewModel()
         let task1 = TaskListData(
             taskID: "task-1",
@@ -522,6 +598,11 @@ struct TaskViewModelTests {
         )
         viewModel.taskListData = [task1, task2]
 
+        try? manager.saveItem(
+            Measures(measuresID: "measures-1", taskID: "task-1", title: "Measures 1", order: 0, created_at: Date()))
+        try? manager.saveItem(
+            Measures(measuresID: "measures-2", taskID: "task-2", title: "Measures 2", order: 0, created_at: Date()))
+
         let memo1 = Memo(
             memoID: "memo-1",
             measuresID: "measures-1",
@@ -541,6 +622,8 @@ struct TaskViewModelTests {
 
         #expect(pairs.count == 2)
         #expect(Set(pairs.map { $0.task.taskID }) == Set(["task-1", "task-2"]))
+
+        manager.clearAll()
     }
 
     // MARK: - エラーハンドリングテスト


### PR DESCRIPTION
## 概要
修正箇所がともに`NoteViewModel.swift`のため、issue #109と#130を1つのPRにまとめて対応しました。

### issue #109: 対策の優先度変更後に練習ノートの課題振り返りが消失・重複作成される
練習ノートの課題振り返り（Memo）とタスクの対応付けが、対策の「現在の最優先対策のmeasuresID」を突合キーとしていたため、対策の優先度（並び順）を変更すると既存の振り返りメモが表示されなくなり、再度追加すると重複作成されていた。

Memoの`measuresID`が指す対策(Measures)の`taskID`を解決し、`taskID`で突合する方式に変更した（`TaskViewModel.associateTasksWithMemos`、`NoteViewModel.updateTaskReflections`）。

Closes #109

### issue #130: NoteViewModel.loadNote(id:)がisLoadingを更新せずノート詳細画面のローディング表示が機能しない
`loadNote(id:)`が`isLoading`を更新しておらず、ノート詳細画面のローディング表示が機能していなかった。他のCRUDメソッドと同様に`isLoading = true`/`defer`でのfalse復帰を追加した。

Closes #130

## 変更ファイル
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`（新規テスト追加、既存テスト修正）
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`（新規テスト追加、既存テスト修正）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 558件全て成功

## 完了条件
- [x] #109: 対策の優先度を変更しても、既存の練習ノート振り返りメモが正しく元の課題に再表示される
- [x] #109: 再度同じ課題を追加して振り返りを保存しても、重複Memoが作成されず既存Memoが更新される
- [x] #130: `loadNote(id:)`実行中に`isLoading`が`true`になり、完了後に`false`へ戻る
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で問題が再現しないことをユニットテストで確認

## クロスレビュー結果
1ラウンド目でshould-fix指摘（`updateTaskReflections`側の対策並び替えシナリオを検証する回帰テストが不足）を受け、`updateTaskReflections_existingMemoFoundAfterMeasuresReorder_updatesExistingMemo`を追加して対応済み。他にmust-fix指摘なし。