### PR TITLE
fix: 課題関連画面の空白タイトル・グループ選択の二重状態・タイトル打ち替え時のエラー割り込みを修正

### DIFF
--- a/SportsNote_iOS/View/Task/AddTaskView.swift
+++ b/SportsNote_iOS/View/Task/AddTaskView.swift
@@ -8,7 +8,6 @@ struct AddTaskView: View {
     @State private var cause: String = ""
     @State private var selectedGroupIndex: Int = 0
     @State private var measuresTitle: String = ""
-    let groups: [Group]
 
     var body: some View {
         NavigationView {
@@ -27,7 +26,7 @@ struct AddTaskView: View {
                 }
                 // グループ
                 Section(header: Text(LocalizedStrings.group)) {
-                    if !groups.isEmpty {
+                    if !groupViewModel.groups.isEmpty {
                         GroupSelectorView(
                             selectedGroupIndex: $selectedGroupIndex,
                             viewModel: groupViewModel
@@ -54,7 +53,7 @@ struct AddTaskView: View {
                             let result = await viewModel.saveNewTaskWithMeasures(
                                 title: taskTitle,
                                 cause: cause,
-                                groupID: groups[selectedGroupIndex].groupID,
+                                groupID: groupViewModel.groups[selectedGroupIndex].groupID,
                                 measuresTitle: measuresTitle.isEmpty ? nil : measuresTitle
                             )
 
@@ -66,7 +65,9 @@ struct AddTaskView: View {
                             }
                         }
                     }
-                    .disabled(taskTitle.isEmpty || groups.isEmpty)
+                    .disabled(
+                        taskTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || !groupViewModel.groups.indices.contains(selectedGroupIndex))
                 }
             }
         }

--- a/SportsNote_iOS/View/Task/TaskDetailView.swift
+++ b/SportsNote_iOS/View/Task/TaskDetailView.swift
@@ -32,7 +32,6 @@ struct TaskDetailView: View {
     @State private var cause: String = ""
     @State private var selectedGroupIndex: Int = 0
     @State private var newMeasureTitle = ""
-    @State private var groups: [Group] = []
     @State private var isReorderingMeasures = false
     @State private var alertType: AlertType?
 
@@ -43,7 +42,11 @@ struct TaskDetailView: View {
             // タイトル
             Section(header: Text(LocalizedStrings.title)) {
                 TextField(LocalizedStrings.title, text: $taskTitle)
-                    .onChange(of: taskTitle) { _ in
+                    .onChange(of: taskTitle) { newValue in
+                        // 全選択して削除→再入力する一連の操作中、空文字になった瞬間の
+                        // バリデーションエラーで入力が割り込まれないよう、空白のみの間は
+                        // 保存をスキップし非空になった時点で保存する（issue #115）
+                        guard !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
                         persistTaskChanges()
                     }
             }
@@ -60,7 +63,7 @@ struct TaskDetailView: View {
             }
             // グループ
             Section(header: Text(LocalizedStrings.group)) {
-                if !groups.isEmpty {
+                if !groupViewModel.groups.isEmpty {
                     GroupSelectorView(
                         selectedGroupIndex: $selectedGroupIndex,
                         viewModel: groupViewModel,
@@ -186,6 +189,7 @@ struct TaskDetailView: View {
     /// タイトル・原因・グループの変更をRealmへ反映し、失敗時はエラーアラートを表示する
     private func persistTaskChanges() {
         Task {
+            let groups = groupViewModel.groups
             guard !groups.isEmpty, groups.indices.contains(selectedGroupIndex) else { return }
             let result = await viewModel.updateTask(
                 taskID: taskData.taskID,
@@ -213,13 +217,13 @@ struct TaskDetailView: View {
                 return
             }
 
-            groups = groupViewModel.groups
+            let groups = groupViewModel.groups
             if groups.isEmpty { return }
 
             // 現在のグループを選択
             if let index = groups.firstIndex(where: { $0.groupID == taskData.groupID }) {
                 selectedGroupIndex = index
-            } else if !groups.isEmpty {
+            } else {
                 // グループIDに一致するものがなければ、最初のグループを選択
                 selectedGroupIndex = 0
             }

--- a/SportsNote_iOS/View/Task/TaskView.swift
+++ b/SportsNote_iOS/View/Task/TaskView.swift
@@ -134,7 +134,7 @@ struct TaskView: View {
             AddGroupView(viewModel: viewModel)
         }
         .sheet(isPresented: $isAddTaskPresented) {
-            AddTaskView(viewModel: taskViewModel, groupViewModel: viewModel, groups: viewModel.groups)
+            AddTaskView(viewModel: taskViewModel, groupViewModel: viewModel)
         }
         .onAppear {
             // 画面が表示されるたびに最新データを取得


### PR DESCRIPTION
## 概要
修正箇所がいずれも`AddTaskView.swift`/`TaskDetailView.swift`のため、issue #114・#115・#138を1つのPRにまとめて対応しました。

### issue #114: 課題（Task）新規作成時、空白（スペースのみ）のタイトルで保存できてしまう
`AddTaskView`の保存ボタンが`taskTitle.isEmpty`のみで判定しており、空白のみのタイトルで保存できていた。`trimmingCharacters(in: .whitespacesAndNewlines).isEmpty`判定に変更した。

Closes #114

### issue #115: 課題詳細画面でタイトルを打ち替える際、一時的な空文字が即時保存されエラーアラートが割り込む
`TaskDetailView`のタイトル欄が`.onChange`で即時保存する際、全選択削除→再入力の一連の操作中に空文字状態でバリデーションエラーのアラートが割り込んでいた。空白のみの間は`persistTaskChanges()`をスキップするよう修正した。

Closes #115

### issue #138: AddTaskView/TaskDetailViewのグループ選択が表示用と保存用で二重の状態を持っている
`AddTaskView`/`TaskDetailView`が表示用（`groupViewModel.groups`）と保存用（各Viewのローカルな`groups`配列のスナップショット）の二重状態を持っていた。ローカルな`groups`配列を廃止し`groupViewModel.groups`に一本化した。

Closes #138

## 変更ファイル
- `SportsNote_iOS/View/Task/AddTaskView.swift`
- `SportsNote_iOS/View/Task/TaskDetailView.swift`
- `SportsNote_iOS/View/Task/TaskView.swift`（`AddTaskView`呼び出しから不要になった`groups`引数を削除）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 556件全て成功（View層の変更のためユニットテストは追加なし）

## 完了条件
- [x] #114: 空白のみのタイトル入力時に保存ボタンがdisabledになる
- [x] #115: タイトル全消去→再入力でエラーアラートが割り込まない
- [x] #138: AddTaskView/TaskDetailViewが独自のgroups配列を持たずgroupViewModel.groupsを保存時にも参照する
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] グループ選択UIの見た目・保存動作がリファクタリング前と変わらない

## クロスレビュー結果
1ラウンド目でshould-fix指摘2件を受け修正済み:
- `TaskDetailView`のタイトル`onChange`ガードがtrimなしの`isEmpty`だったため、スペースのみへの打ち替えで空白タイトルが保存されてしまう非対称があった → trim込みの判定に変更
- `AddTaskView`の保存ボタンで`selectedGroupIndex`の範囲外アクセスに対するガードがなかった → `indices.contains`チェックを追加
nit指摘1件（ローカル変数化のコメントが実質的な保護効果を持たない）は軽微なため対応見送り。