### PR TITLE
fix: 練習ノートの「取り組んだ課題」表示順がDictionary列挙順に依存し不定な不具合を修正

### DIFF
--- a/SportsNote_iOS/View/Note/Components/TaskListItemView.swift
+++ b/SportsNote_iOS/View/Note/Components/TaskListItemView.swift
@@ -9,14 +9,26 @@ struct TaskListSection: View {
     @Binding var taskReflections: [TaskListData: String]
     var unaddedTasks: [TaskListData]
 
+    /// taskReflections.keysをtask.order昇順にソートした配列。
+    /// Dictionaryの列挙順は不定（アプリ再起動のたびに変わりうる）のため、描画順の
+    /// 安定化にはこちらを使う（issue #137）。orderはグループ内スコープで採番されるため
+    /// 異なるグループの課題間で同値になり得る。taskIDを副次キーにして同値時の順序も
+    /// 決定的にする
+    private var sortedTasks: [TaskListData] {
+        taskReflections.keys.sorted {
+            $0.order != $1.order ? $0.order < $1.order : $0.taskID < $1.taskID
+        }
+    }
+
     var body: some View {
-        VStack(spacing: 0) {
+        let sortedTasks = sortedTasks
+        return VStack(spacing: 0) {
             if taskReflections.isEmpty {
                 emptyStateView
                     .disabled(true)
             } else {
-                ForEach(Array(taskReflections.keys), id: \.taskID) { task in
-                    if task.taskID != Array(taskReflections.keys).first?.taskID {
+                ForEach(sortedTasks, id: \.taskID) { task in
+                    if task.taskID != sortedTasks.first?.taskID {
                         Divider()
                     }
 
@@ -33,7 +45,7 @@ struct TaskListSection: View {
                     )
                     .contentShape(Rectangle())
 
-                    if task.taskID != Array(taskReflections.keys).last?.taskID {
+                    if task.taskID != sortedTasks.last?.taskID {
                         Divider()
                     }
                 }

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -453,7 +453,14 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 result[task.taskID] = (task: task, memo: memo)
             }
         }
+        // Dictionary経由で組み立てるため列挙順が不定になる。task.order昇順にソートし、
+        // アプリ再起動のたびに表示順が入れ替わらないようにする（issue #137）。
+        // orderはグループ内スコープで採番されるため異なるグループの課題間で同値になり得る。
+        // taskIDを副次キーにして同値時の順序も決定的にする
         return Array(result.values)
+            .sorted {
+                $0.task.order != $1.task.order ? $0.task.order < $1.task.order : $0.task.taskID < $1.task.taskID
+            }
     }
 
     /// 未追加のタスクを取得（taskReflectionsから直接算出）

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -543,6 +543,99 @@ struct TaskViewModelTests {
         #expect(Set(pairs.map { $0.task.taskID }) == Set(["task-1", "task-2"]))
     }
 
+    @Test("associateTasksWithMemos - 戻り値がtask.order昇順にソートされる（issue #137: Dictionary列挙順への依存を排除）")
+    func associateTasksWithMemos_sortsResultByTaskOrder() async {
+        let viewModel = TaskViewModel()
+        // orderが降順になるように課題を用意し、Dictionary経由でも意図した順序に
+        // 並び替えられることを確認する
+        let task1 = TaskListData(
+            taskID: "task-1",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Task 1",
+            measuresID: "measures-1",
+            measures: "Measures 1",
+            memoID: nil,
+            order: 2,
+            isComplete: false
+        )
+        let task2 = TaskListData(
+            taskID: "task-2",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Task 2",
+            measuresID: "measures-2",
+            measures: "Measures 2",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+        let task3 = TaskListData(
+            taskID: "task-3",
+            groupID: "group-1",
+            groupColor: .green,
+            title: "Task 3",
+            measuresID: "measures-3",
+            measures: "Measures 3",
+            memoID: nil,
+            order: 1,
+            isComplete: false
+        )
+        viewModel.taskListData = [task1, task2, task3]
+
+        let memo1 = Memo(
+            memoID: "memo-1", measuresID: "measures-1", noteID: "note-1", detail: "1", created_at: Date())
+        let memo2 = Memo(
+            memoID: "memo-2", measuresID: "measures-2", noteID: "note-1", detail: "2", created_at: Date())
+        let memo3 = Memo(
+            memoID: "memo-3", measuresID: "measures-3", noteID: "note-1", detail: "3", created_at: Date())
+
+        let pairs = viewModel.associateTasksWithMemos(memos: [memo1, memo2, memo3])
+
+        #expect(pairs.map { $0.task.taskID } == ["task-2", "task-3", "task-1"])
+    }
+
+    @Test(
+        "associateTasksWithMemos - orderが同値の課題はtaskID昇順でタイブレークされる（異なるグループの課題がorder同値になるケース）"
+    )
+    func associateTasksWithMemos_sameOrderTiesBreakByTaskID() async {
+        let viewModel = TaskViewModel()
+        // 異なるグループの課題はグループ内スコープでorderが採番されるため、
+        // order=0同士が複数存在しうる
+        let taskB = TaskListData(
+            taskID: "task-b",
+            groupID: "group-b",
+            groupColor: .blue,
+            title: "Task B",
+            measuresID: "measures-b",
+            measures: "Measures B",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+        let taskA = TaskListData(
+            taskID: "task-a",
+            groupID: "group-a",
+            groupColor: .red,
+            title: "Task A",
+            measuresID: "measures-a",
+            measures: "Measures A",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+        viewModel.taskListData = [taskB, taskA]
+
+        let memoB = Memo(
+            memoID: "memo-b", measuresID: "measures-b", noteID: "note-1", detail: "B", created_at: Date())
+        let memoA = Memo(
+            memoID: "memo-a", measuresID: "measures-a", noteID: "note-1", detail: "A", created_at: Date())
+
+        let pairs = viewModel.associateTasksWithMemos(memos: [memoB, memoA])
+
+        #expect(pairs.map { $0.task.taskID } == ["task-a", "task-b"])
+    }
+
     // MARK: - エラーハンドリングテスト
 
     @Test("エラーハンドリング - isLoadingの初期状態")


### PR DESCRIPTION
## 概要
練習ノートの「取り組んだ課題」欄の表示順が`Dictionary`の列挙順に依存しており、アプリ再起動のたびに表示順が入れ替わる可能性があった不具合を修正。

`TaskViewModel.associateTasksWithMemos`の戻り値、および`TaskListSection`の`ForEach`が`Dictionary`経由で構築されるため列挙順が不定だった。`task.order`昇順にソートするよう修正した。

Closes #137

## 変更ファイル
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOS/View/Note/Components/TaskListItemView.swift`
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`（新規テスト追加）

## 注意（他PRとの関係）
[#146](https://github.com/Takatoshi-Miura/SportsNote_iOS/pull/146)（issue #109）でも同じ`associateTasksWithMemos`を触っています。本PRはmainベースで、issue #109の突合ロジック変更は含んでいません。両PRがマージされる際にコンフリクトが発生する見込みですが、次回実行時のコンフリクト解消フェーズで対応します。

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 558件全て成功（新規追加2件を含む）

## 完了条件
- [x] `associateTasksWithMemos`の戻り値が`task.order`昇順でソートされている
- [x] `TaskListSection`の描画順が`task.order`昇順に基づく
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（順序を検証する新規テスト含む）
- [x] 再現手順（再起動しても表示順が変わらない）をユニットテストで確認

## クロスレビュー結果
1ラウンド目でmust-fix指摘2件を受け修正済み:
- `order`はグループ内スコープで採番されるため、異なるグループの課題が同値orderを持ちうる。この場合Dictionary経由のソートは不安定になり得るため、`taskID`を副次ソートキーとして両ソート箇所（`associateTasksWithMemos`・`TaskListSection.sortedTasks`）に追加し、同値ケースを検証する回帰テストも追加した
should-fix指摘1件（`TaskListSection`の描画順は自動テストで直接検証できない。View層はプロジェクトの慣行としてUIテスト対象外）は既存の慣行と整合するため対応見送り。