### PR TITLE
fix: グループ/対策の編集画面でタイトルを空文字にすると空のまま即保存される不具合を修正

### DIFF
--- a/SportsNote_iOS/View/Group/GroupView.swift
+++ b/SportsNote_iOS/View/Group/GroupView.swift
@@ -90,6 +90,8 @@ struct GroupView: View {
     }
 
     private func saveSelectedGroup() {
+        // 空白のみのタイトルで即時保存されるのを防ぐ（issue #133）
+        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         Task {
             let result = await viewModel.saveGroup(
                 groupID: selectedGroup.groupID,

--- a/SportsNote_iOS/View/Measures/MeasureDetailView.swift
+++ b/SportsNote_iOS/View/Measures/MeasureDetailView.swift
@@ -32,6 +32,8 @@ struct MeasureDetailView: View {
                 Section(header: Text(LocalizedStrings.title)) {
                     TextField(LocalizedStrings.title, text: $title)
                         .onChange(of: title) { newValue in
+                            // 空白のみのタイトルで即時保存されるのを防ぐ（issue #133）
+                            guard !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
                             Task {
                                 let result = await measuresViewModel.saveMeasures(
                                     measuresID: measure.measuresID,


### PR DESCRIPTION
## 概要
グループ編集画面（`GroupView`）と対策編集画面（`MeasureDetailView`）は、タイトル欄の`onChange`で即時保存する設計だが、新規追加画面と異なりisEmptyガードが一切なく、タイトルを全選択削除した瞬間に空文字のままRealm/Firebaseへ保存されていた不具合を修正。

`trimmingCharacters(in: .whitespacesAndNewlines).isEmpty`のガードを追加し、空白のみの入力では保存をスキップするようにした。

Closes #133

## 変更ファイル
- `SportsNote_iOS/View/Group/GroupView.swift`
- `SportsNote_iOS/View/Measures/MeasureDetailView.swift`

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 558件全て成功

## 完了条件
- [x] `GroupView`でタイトルを空文字にしても、空文字のままではRealm/Firebaseに保存されない（保存自体がスキップされる）
- [x] `MeasureDetailView`でタイトルを空文字にしても、同様に空文字のまま保存されない
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 再現手順で問題が再現しないことをコードレビューで確認

## クロスレビュー結果
must-fix指摘なし。should-fix指摘2件（対応は見送り、issue #133のスコープ外またはissue本文の実装案に忠実なため）:
- `GroupView.saveSelectedGroup()`はタイトルとカラー変更の両方から呼ばれる共通コールバックのため、今回のガードがカラー変更の保存も巻き込む（タイトルが空文字の間にカラーを変更すると保存されない）。issue本文が提示した実装案（`saveSelectedGroup()`冒頭にガード）通りの実装
- `FreeNoteView.swift`にも同種のガードなしonChange即時保存パターンが存在する。issue #133のスコープ外（`TaskDetailView`=#115、`AddGroupView`/`AddMeasure`=#98のみが対象）のため対応せず、フォローアップissueとして別途起票を検討