### PR TITLE
refactor: 6ViewModel間で重複していたdidClearAllData購読・fetchById・Firebase同期処理を共通化

### DIFF
--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -19,23 +19,11 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
 
     init() {
         // 初期化のみ実行、データ取得はView側で明示的に実行
-        setupNotifications()
-    }
-
-
-    /// 通知の設定
-    private func setupNotifications() {
-        NotificationCenter.default.publisher(for: .didClearAllData)
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.clearRealmReferences()
-                }
-            }
-            .store(in: &cancellables)
+        observeClearAllData(cancellables: &cancellables)
     }
 
     /// Realmオブジェクトの参照をクリア
-    private func clearRealmReferences() {
+    func clearRealmReferences() {
         groups = []
     }
 
@@ -156,19 +144,12 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
     ///   - isUpdate: 更新要否
     /// - Returns: Result
     func syncEntityToFirebase(_ entity: Group, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            if isUpdate {
-                try await FirebaseManager.shared.updateGroup(group: entity)
-            } else {
-                try await FirebaseManager.shared.saveGroup(group: entity)
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertFirebaseSyncError(error, context: "GroupViewModel-syncEntityToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncEntityToFirebaseDefault(
+            isUpdate: isUpdate,
+            context: "GroupViewModel-syncEntityToFirebase",
+            updateAction: { try await FirebaseManager.shared.updateGroup(group: entity) },
+            saveAction: { try await FirebaseManager.shared.saveGroup(group: entity) }
+        )
     }
 
     /// 指定されたIDのエンティティを削除
@@ -206,14 +187,7 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
     /// - Parameter id: ID
     /// - Returns: Result
     func fetchById(id: String) async -> Result<Group?, SportsNoteError> {
-        do {
-            let group = try RealmManager.shared.getObjectById(id: id, type: Group.self)
-            hideErrorAlert()
-            return .success(group)
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-fetchById")
-            return .failure(sportsNoteError)
-        }
+        await fetchByIdDefault(id: id, context: "GroupViewModel-fetchById", onSuccess: { self.hideErrorAlert() })
     }
 
     /// Firebaseへの同期処理を実行

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -15,23 +15,11 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
 
     init() {
         // 初期化のみ実行、データ取得はView側で明示的に実行
-        setupNotifications()
-    }
-
-
-    /// 通知の設定
-    private func setupNotifications() {
-        NotificationCenter.default.publisher(for: .didClearAllData)
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.clearRealmReferences()
-                }
-            }
-            .store(in: &cancellables)
+        observeClearAllData(cancellables: &cancellables)
     }
 
     /// Realmオブジェクトの参照をクリア
-    private func clearRealmReferences() {
+    func clearRealmReferences() {
         measuresList = []
         memos = []
     }
@@ -60,13 +48,7 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
     /// - Parameter id: 対策ID
     /// - Returns: Result
     func fetchById(id: String) async -> Result<Measures?, SportsNoteError> {
-        do {
-            let measures = try RealmManager.shared.getObjectById(id: id, type: Measures.self)
-            return .success(measures)
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MeasuresViewModel-fetchById")
-            return .failure(sportsNoteError)
-        }
+        await fetchByIdDefault(id: id, context: "MeasuresViewModel-fetchById")
     }
 
     /// 対策に紐づくメモを取得
@@ -240,42 +222,17 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
     ///   - isUpdate: 更新かどうか
     /// - Returns: 同期処理の結果
     func syncEntityToFirebase(_ entity: Measures, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else {
-            return .success(())
-        }
-
-        do {
-            if isUpdate {
-                try await FirebaseManager.shared.updateMeasures(measures: entity)
-            } else {
-                try await FirebaseManager.shared.saveMeasures(measures: entity)
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertFirebaseSyncError(error, context: "MeasuresViewModel-syncEntityToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncEntityToFirebaseDefault(
+            isUpdate: isUpdate,
+            context: "MeasuresViewModel-syncEntityToFirebase",
+            updateAction: { try await FirebaseManager.shared.updateMeasures(measures: entity) },
+            saveAction: { try await FirebaseManager.shared.saveMeasures(measures: entity) }
+        )
     }
 
     /// 全ての対策をFirebaseに同期する
     /// - Returns: 同期処理の結果
     func syncToFirebase() async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else {
-            return .success(())
-        }
-
-        do {
-            let allMeasures = try RealmManager.shared.getDataList(clazz: Measures.self)
-            for measures in allMeasures {
-                let result = await syncEntityToFirebase(measures)
-                if case .failure(let error) = result {
-                    return .failure(error)
-                }
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MeasuresViewModel-syncToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncToFirebaseDefault(context: "MeasuresViewModel-syncToFirebase")
     }
 }

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -15,23 +15,11 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
     init() {
         // 自動データ取得は削除、View側で明示的に実行
-        setupNotifications()
-    }
-
-
-    /// 通知の設定
-    private func setupNotifications() {
-        NotificationCenter.default.publisher(for: .didClearAllData)
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.clearRealmReferences()
-                }
-            }
-            .store(in: &cancellables)
+        observeClearAllData(cancellables: &cancellables)
     }
 
     /// Realmオブジェクトの参照をクリア
-    private func clearRealmReferences() {
+    func clearRealmReferences() {
         memoList = []
         measuresMemoList = []
     }
@@ -130,13 +118,7 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: 取得するエンティティのID
     /// - Returns: Result
     func fetchById(id: String) async -> Result<Memo?, SportsNoteError> {
-        do {
-            let memo = try RealmManager.shared.getObjectById(id: id, type: Memo.self)
-            return .success(memo)
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MemoViewModel-fetchById")
-            return .failure(sportsNoteError)
-        }
+        await fetchByIdDefault(id: id, context: "MemoViewModel-fetchById")
     }
 
     // MARK: - FirebaseSyncable準拠
@@ -147,39 +129,18 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - isUpdate: 更新かどうか
     /// - Returns: 同期処理の結果
     func syncEntityToFirebase(_ entity: Memo, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            if isUpdate {
-                try await FirebaseManager.shared.updateMemo(memo: entity)
-            } else {
-                try await FirebaseManager.shared.saveMemo(memo: entity)
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertFirebaseSyncError(error, context: "MemoViewModel-syncEntityToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncEntityToFirebaseDefault(
+            isUpdate: isUpdate,
+            context: "MemoViewModel-syncEntityToFirebase",
+            updateAction: { try await FirebaseManager.shared.updateMemo(memo: entity) },
+            saveAction: { try await FirebaseManager.shared.saveMemo(memo: entity) }
+        )
     }
 
     /// Firebaseへの同期処理を実行する
     /// - Returns: 同期処理の結果
     func syncToFirebase() async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            let allMemos = try RealmManager.shared.getDataList(clazz: Memo.self)
-            for memo in allMemos {
-                let syncResult = await syncEntityToFirebase(memo)
-                if case .failure(let error) = syncResult {
-                    return .failure(error)
-                }
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MemoViewModel-syncToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncToFirebaseDefault(context: "MemoViewModel-syncToFirebase")
     }
 
     /// 対策IDに紐づくメモを取得（非Reactive版 - 下位互換性のため残す）

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -27,23 +27,11 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
     init() {
         // 初期化のみ実行、データ取得はView側で明示的に実行
-        setupNotifications()
-    }
-
-
-    /// 通知の設定
-    private func setupNotifications() {
-        NotificationCenter.default.publisher(for: .didClearAllData)
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.clearRealmReferences()
-                }
-            }
-            .store(in: &cancellables)
+        observeClearAllData(cancellables: &cancellables)
     }
 
     /// Realmオブジェクトの参照をクリア
-    private func clearRealmReferences() {
+    func clearRealmReferences() {
         notes = []
         selectedNote = nil
         practiceNotes = []
@@ -115,13 +103,7 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: エンティティのID
     /// - Returns: Result
     func fetchById(id: String) async -> Result<Note?, SportsNoteError> {
-        do {
-            let note = try realmManager.getObjectById(id: id, type: Note.self)
-            return .success(note)
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "NoteViewModel-fetchById")
-            return .failure(sportsNoteError)
-        }
+        await fetchByIdDefault(id: id, context: "NoteViewModel-fetchById")
     }
 
     /// ノートタイプを取得（同期的）
@@ -553,38 +535,18 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - isUpdate: 更新フラグ
     /// - Returns: Result
     func syncEntityToFirebase(_ entity: Note, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            if isUpdate {
-                try await FirebaseManager.shared.updateNote(note: entity)
-            } else {
-                try await FirebaseManager.shared.saveNote(note: entity)
-            }
-            return .success(())
-        } catch {
-            return .failure(convertFirebaseSyncError(error, context: "NoteViewModel-syncEntityToFirebase"))
-        }
+        await syncEntityToFirebaseDefault(
+            isUpdate: isUpdate,
+            context: "NoteViewModel-syncEntityToFirebase",
+            updateAction: { try await FirebaseManager.shared.updateNote(note: entity) },
+            saveAction: { try await FirebaseManager.shared.saveNote(note: entity) }
+        )
     }
 
     /// 全データをFirebaseに同期
     /// - Returns: Result
     func syncToFirebase() async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            let allNotes = try realmManager.getDataList(clazz: Note.self)
-            for note in allNotes {
-                let result = await syncEntityToFirebase(note)
-                if case .failure = result {
-                    // 1つでも失敗したら処理を続行するがエラーを返す
-                    return result
-                }
-            }
-            return .success(())
-        } catch {
-            return .failure(convertToSportsNoteError(error, context: "NoteViewModel-syncToFirebase"))
-        }
+        await syncToFirebaseDefault(context: "NoteViewModel-syncToFirebase")
     }
 
     /// ノートのインジケーター色を取得（練習: グループカラー、大会: オレンジ、フリー: ブルー）

--- a/SportsNote_iOS/ViewModel/Protocols/BaseViewModelProtocol.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/BaseViewModelProtocol.swift
@@ -24,6 +24,9 @@ protocol BaseViewModelProtocol: ObservableObject {
 
     /// データをリフレッシュする統一メソッド
     func refresh() async
+
+    /// Realmオブジェクトの参照をクリアする（didClearAllData通知受信時に呼ばれる）
+    func clearRealmReferences()
 }
 
 /// BaseViewModelProtocolのデフォルト実装
@@ -63,5 +66,17 @@ extension BaseViewModelProtocol {
         } else {
             return ErrorMapper.mapRealmError(error, context: context)
         }
+    }
+
+    /// didClearAllData通知を購読し、受信時にclearRealmReferences()を呼び出す
+    /// - Parameter cancellables: 購読を保持するSet（呼び出し元のプロパティを渡す）
+    func observeClearAllData(cancellables: inout Set<AnyCancellable>) {
+        NotificationCenter.default.publisher(for: .didClearAllData)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.clearRealmReferences()
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
@@ -1,8 +1,9 @@
 import Foundation
+import RealmSwift
 
 /// CRUD操作を行うViewModelのプロトコル
 @MainActor
-protocol CRUDViewModelProtocol: BaseViewModelProtocol {
+protocol CRUDViewModelProtocol: BaseViewModelProtocol where EntityType: Object {
     /// エンティティを保存（新規作成・更新）する
     /// - Parameter entity: 保存するエンティティ
     /// - Parameter isUpdate: 更新かどうか（デフォルトはfalse）
@@ -18,4 +19,27 @@ protocol CRUDViewModelProtocol: BaseViewModelProtocol {
     /// - Parameter id: 取得するエンティティのID
     /// - Returns: 成功時は.success(entity)、失敗時は.failure(SportsNoteError)
     func fetchById(id: String) async -> Result<EntityType?, SportsNoteError>
+}
+
+extension CRUDViewModelProtocol {
+    /// 指定されたIDのエンティティを取得する共通実装
+    /// - Parameters:
+    ///   - id: 取得するエンティティのID
+    ///   - context: エラー変換時のコンテキスト（メソッド名など）
+    ///   - onSuccess: 取得成功時に追加で実行する処理（例: hideErrorAlert）
+    /// - Returns: 成功時は.success(entity)、失敗時は.failure(SportsNoteError)
+    func fetchByIdDefault(
+        id: String,
+        context: String,
+        onSuccess: (() -> Void)? = nil
+    ) async -> Result<EntityType?, SportsNoteError> {
+        do {
+            let entity = try RealmManager.shared.getObjectById(id: id, type: EntityType.self)
+            onSuccess?()
+            return .success(entity)
+        } catch {
+            let sportsNoteError = convertToSportsNoteError(error, context: context)
+            return .failure(sportsNoteError)
+        }
+    }
 }

--- a/SportsNote_iOS/ViewModel/Protocols/FirebaseSyncable.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/FirebaseSyncable.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RealmSwift
 
 /// Firebase同期機能を持つViewModelのプロトコル
 @MainActor
@@ -52,6 +53,34 @@ extension FirebaseSyncable {
         }
         return ErrorMapper.mapFirebaseError(error, context: context)
     }
+
+    /// エンティティをFirebaseに同期する共通実装
+    /// - Parameters:
+    ///   - isUpdate: 更新かどうか
+    ///   - context: エラー変換時のコンテキスト（メソッド名など）
+    ///   - updateAction: 更新時に呼び出すFirebaseManagerの処理
+    ///   - saveAction: 新規作成時に呼び出すFirebaseManagerの処理
+    /// - Returns: 同期処理の結果
+    func syncEntityToFirebaseDefault(
+        isUpdate: Bool,
+        context: String,
+        updateAction: () async throws -> Void,
+        saveAction: () async throws -> Void
+    ) async -> Result<Void, SportsNoteError> {
+        guard isOnlineAndLoggedIn else { return .success(()) }
+
+        do {
+            if isUpdate {
+                try await updateAction()
+            } else {
+                try await saveAction()
+            }
+            return .success(())
+        } catch {
+            let sportsNoteError = convertFirebaseSyncError(error, context: context)
+            return .failure(sportsNoteError)
+        }
+    }
 }
 
 extension FirebaseSyncable where Self: BaseViewModelProtocol {
@@ -69,5 +98,28 @@ extension FirebaseSyncable where Self: BaseViewModelProtocol {
         }
         // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）
         BackgroundSyncTracker.shared.track(task)
+    }
+}
+
+extension FirebaseSyncable where Self: BaseViewModelProtocol, EntityType: Object {
+    /// 全エンティティをFirebaseに同期する共通実装
+    /// - Parameter context: エラー変換時のコンテキスト（メソッド名など）
+    /// - Returns: 同期処理の結果
+    func syncToFirebaseDefault(context: String) async -> Result<Void, SportsNoteError> {
+        guard isOnlineAndLoggedIn else { return .success(()) }
+
+        do {
+            let allEntities = try RealmManager.shared.getDataList(clazz: EntityType.self)
+            for entity in allEntities {
+                let result = await syncEntityToFirebase(entity, isUpdate: false)
+                if case .failure(let error) = result {
+                    return .failure(error)
+                }
+            }
+            return .success(())
+        } catch {
+            let sportsNoteError = convertToSportsNoteError(error, context: context)
+            return .failure(sportsNoteError)
+        }
     }
 }

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -33,22 +33,11 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
             }
             .store(in: &cancellables)
 
-        setupNotifications()
-    }
-
-    /// 通知の設定
-    private func setupNotifications() {
-        NotificationCenter.default.publisher(for: .didClearAllData)
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.clearRealmReferences()
-                }
-            }
-            .store(in: &cancellables)
+        observeClearAllData(cancellables: &cancellables)
     }
 
     /// Realmオブジェクトの参照をクリア
-    private func clearRealmReferences() {
+    func clearRealmReferences() {
         yearlyTargets = []
         monthlyTargets = []
     }
@@ -230,13 +219,7 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
     /// - Parameter id: 取得するエンティティのID
     /// - Returns: Result
     func fetchById(id: String) async -> Result<Target?, SportsNoteError> {
-        do {
-            let target = try RealmManager.shared.getObjectById(id: id, type: Target.self)
-            return .success(target)
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TargetViewModel-fetchById")
-            return .failure(sportsNoteError)
-        }
+        await fetchByIdDefault(id: id, context: "TargetViewModel-fetchById")
     }
 
     /// 現在の年月を更新
@@ -256,38 +239,17 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
     ///   - isUpdate: 更新かどうか
     /// - Returns: 同期処理の結果
     func syncEntityToFirebase(_ entity: Target, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            if isUpdate {
-                try await FirebaseManager.shared.updateTarget(target: entity)
-            } else {
-                try await FirebaseManager.shared.saveTarget(target: entity)
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertFirebaseSyncError(error, context: "TargetViewModel-syncEntityToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncEntityToFirebaseDefault(
+            isUpdate: isUpdate,
+            context: "TargetViewModel-syncEntityToFirebase",
+            updateAction: { try await FirebaseManager.shared.updateTarget(target: entity) },
+            saveAction: { try await FirebaseManager.shared.saveTarget(target: entity) }
+        )
     }
 
     /// Firebaseへの同期処理を実行する
     /// - Returns: 同期処理の結果
     func syncToFirebase() async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else { return .success(()) }
-
-        do {
-            let allTargets = try RealmManager.shared.getDataList(clazz: Target.self)
-            for target in allTargets {
-                let syncResult = await syncEntityToFirebase(target)
-                if case .failure(let error) = syncResult {
-                    return .failure(error)
-                }
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TargetViewModel-syncToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncToFirebaseDefault(context: "TargetViewModel-syncToFirebase")
     }
 }

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -28,23 +28,11 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
     init() {
         // 初期化のみ実行、データ取得はView側で明示的に実行
-        setupNotifications()
-    }
-
-
-    /// 通知の設定
-    private func setupNotifications() {
-        NotificationCenter.default.publisher(for: .didClearAllData)
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.clearRealmReferences()
-                }
-            }
-            .store(in: &cancellables)
+        observeClearAllData(cancellables: &cancellables)
     }
 
     /// Realmオブジェクトの参照をクリア
-    private func clearRealmReferences() {
+    func clearRealmReferences() {
         tasks = []
         taskListData = []
         filteredTaskListData = []
@@ -75,13 +63,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: 課題ID
     /// - Returns: Result
     func fetchById(id: String) async -> Result<TaskData?, SportsNoteError> {
-        do {
-            let task = try RealmManager.shared.getObjectById(id: id, type: TaskData.self)
-            return .success(task)
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TaskViewModel-fetchById")
-            return .failure(sportsNoteError)
-        }
+        await fetchByIdDefault(id: id, context: "TaskViewModel-fetchById")
     }
 
     /// 指定したグループIDの課題を取得（新Resultパターン対応）
@@ -577,42 +559,17 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - isUpdate: 更新かどうか
     /// - Returns: 同期処理の結果
     func syncEntityToFirebase(_ entity: TaskData, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else {
-            return .success(())
-        }
-
-        do {
-            if isUpdate {
-                try await FirebaseManager.shared.updateTask(task: entity)
-            } else {
-                try await FirebaseManager.shared.saveTask(task: entity)
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertFirebaseSyncError(error, context: "TaskViewModel-syncEntityToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncEntityToFirebaseDefault(
+            isUpdate: isUpdate,
+            context: "TaskViewModel-syncEntityToFirebase",
+            updateAction: { try await FirebaseManager.shared.updateTask(task: entity) },
+            saveAction: { try await FirebaseManager.shared.saveTask(task: entity) }
+        )
     }
 
     /// 全ての課題をFirebaseに同期する
     /// - Returns: 同期処理の結果
     func syncToFirebase() async -> Result<Void, SportsNoteError> {
-        guard isOnlineAndLoggedIn else {
-            return .success(())
-        }
-
-        do {
-            let allTasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
-            for task in allTasks {
-                let result = await syncEntityToFirebase(task)
-                if case .failure(let error) = result {
-                    return .failure(error)
-                }
-            }
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TaskViewModel-syncToFirebase")
-            return .failure(sportsNoteError)
-        }
+        await syncToFirebaseDefault(context: "TaskViewModel-syncToFirebase")
     }
 }


### PR DESCRIPTION
## 概要
Group/Measures/Memo/Target/Task/NoteViewModelの6ファイルで、同一骨格のまま個別実装されていた以下の重複コードを、各プロトコルのデフォルト実装に集約しました。

- `didClearAllData`通知の購読処理（6ファイルで1文字違わず同一）
- `fetchById(id:)`（GroupViewModelのみ`hideErrorAlert()`呼び出しの差分あり）
- `syncEntityToFirebase(_:isUpdate:)`（呼び出すFirebaseManagerのメソッド名以外は同一骨格）
- `syncToFirebase()`（GroupViewModelはno-op実装のため対象外）

## 変更内容
- `BaseViewModelProtocol`: プロトコル要件に`clearRealmReferences()`を追加、デフォルト実装`observeClearAllData(cancellables:)`を追加
- `CRUDViewModelProtocol`: `EntityType`にRealmSwiftの`Object`制約を追加、デフォルト実装`fetchByIdDefault(id:context:onSuccess:)`を追加
- `FirebaseSyncable`: デフォルト実装`syncEntityToFirebaseDefault(isUpdate:context:updateAction:saveAction:)`と`syncToFirebaseDefault(context:)`を追加
- 6つのViewModelを上記の共通実装呼び出しに置き換え。各ファイル固有の差分（GroupViewModelの`hideErrorAlert()`呼び出し等）は挙動を変更せず保持

正味136行の削減（151行追加、287行削除）。

## テスト
- ビルド成功（BUILD SUCCEEDED）
- 既存テスト565件中563件成功。残り2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`, `associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本PRの変更と無関係な既存の不具合で、mainブランチ単体でも同じ2件が失敗することを確認済み（別issueとして報告予定）
- 独立したサブエージェントによるクロスレビュー実施。must-fix/should-fix指摘なし

Closes #19
Closes #22
Closes #27
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)