### PR TITLE
refactor: 5箇所のLocalizedStrings未経由ハードコード文字列をLocalizedStrings経由に修正

### DIFF
--- a/SportsNote_iOS/Resource/LocalizedString.swift
+++ b/SportsNote_iOS/Resource/LocalizedString.swift
@@ -109,6 +109,9 @@ struct LocalizedStrings {
     static let noTasksWorkedOn = "noTasksWorkedOn".localized
     static let addTask = "addTask".localized
     static let deleteTask = "deleteTask".localized
+    static let taskTitleRequiredError = "taskTitleRequiredError".localized
+    static let taskNotFoundError = "taskNotFoundError".localized
+    static let taskNotFoundLabel = "taskNotFoundLabel".localized
 
     // MARK: Measures
     static let measures = "measures".localized
@@ -117,6 +120,7 @@ struct LocalizedStrings {
     static let noNotesYet = "noNotesYet".localized
     static let noMeasures = "noMeasures".localized
     static let deleteMeasures = "deleteMeasures".localized
+    static let measuresTitleRequiredError = "measuresTitleRequiredError".localized
 
     // MARK: Note
     static let note = "note".localized
@@ -145,6 +149,9 @@ struct LocalizedStrings {
     static let deleteTaskFromNote = "deleteTaskFromNote".localized
     static let added = "added".localized
     static let defaltFreeNoteDetail = "defaltFreeNoteDetail".localized
+    static let cannotDeleteFreeNote = "cannotDeleteFreeNote".localized
+    static let noNotesInDay = "noNotesInDay".localized
+    static let unknownNoteType = "unknownNoteType".localized
 
     // MARK: Target
     static let target = "target".localized
@@ -155,6 +162,13 @@ struct LocalizedStrings {
     static let month = "month".localized
     static let notSet = "notSet".localized
     static let today = "today".localized
+    static let weekdaySun = "weekdaySun".localized
+    static let weekdayMon = "weekdayMon".localized
+    static let weekdayTue = "weekdayTue".localized
+    static let weekdayWed = "weekdayWed".localized
+    static let weekdayThu = "weekdayThu".localized
+    static let weekdayFri = "weekdayFri".localized
+    static let weekdaySat = "weekdaySat".localized
 
     // MARK: Setting
     static let data = "data".localized
@@ -170,6 +184,7 @@ struct LocalizedStrings {
     static let termsOfServiceMessage = "TermsOfServiceMessage".localized
     static let checkTermsOfService = "checkTermsOfService".localized
     static let agree = "agree".localized
+    static let unknown = "unknown".localized
 
     // MARK: Debug
     static let debugSectionTitle = "debugSectionTitle".localized

--- a/SportsNote_iOS/Resource/en.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/en.lproj/Localizable.strings
@@ -100,6 +100,9 @@
 "noTasksWorkedOn" = "No tasks worked on.";
 "addTask" = "Add Task";
 "deleteTask" = "Do you want to delete the task? \nOnce you delete an task, it cannot be restored.";
+"taskTitleRequiredError" = "Title is required";
+"taskNotFoundError" = "Task not found: %@";
+"taskNotFoundLabel" = "Task not found";
 
 // MARK: Measures
 "measures" = "Measures";
@@ -108,6 +111,7 @@
 "noNotesYet" = "No notes yet";
 "noMeasures" = "No measures";
 "deleteMeasures" = "Do you want to delete the measure? \nIf you delete a measure, all notes about this assignment that you have written in your notebook will also be deleted. Once deleted, the measure cannot be restored.";
+"measuresTitleRequiredError" = "Measures title is required";
 
 // MARK: Note
 "note" = "Note";
@@ -136,6 +140,9 @@
 "deleteTaskFromNote" = "Delete this task from note?";
 "added" = "Added";
 "defaltFreeNoteDetail" = "This note is always displayed at the top.";
+"cannotDeleteFreeNote" = "Cannot delete free note";
+"noNotesInDay" = "No notes";
+"unknownNoteType" = "None";
 
 // MARK: Target
 "target" = "Target";
@@ -146,6 +153,13 @@
 "month" = "Month";
 "notSet" = "Not Set";
 "today" = "Today";
+"weekdaySun" = "Sun";
+"weekdayMon" = "Mon";
+"weekdayTue" = "Tue";
+"weekdayWed" = "Wed";
+"weekdayThu" = "Thu";
+"weekdayFri" = "Fri";
+"weekdaySat" = "Sat";
 
 // MARK: Mail
 "pleaseEnterInquiry" = "Please enter your inquiry below.";
@@ -165,6 +179,7 @@
 "termsOfService" = "Terms of Service";
 "privacyPolicy" = "Privacy Policy";
 "appVersion" = "App Version";
+"unknown" = "Unknown";
 "TermsOfServiceTitle" = "Do you agree to the Terms of Service?";
 "TermsOfServiceMessage" = "You must agree to the Terms of Service to use this app.";
 "checkTermsOfService" = "Check Terms of Service";

--- a/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
+++ b/SportsNote_iOS/Resource/ja.lproj/Localizable.strings
@@ -100,6 +100,9 @@
 "noTasksWorkedOn" = "取り組んだ課題はありません。";
 "addTask" = "課題を追加";
 "deleteTask" = "課題を削除しますか？\n課題を削除すると復元できません。";
+"taskTitleRequiredError" = "タイトルは必須項目です";
+"taskNotFoundError" = "課題が見つかりません: %@";
+"taskNotFoundLabel" = "課題が見つかりません";
 
 // MARK: Measures
 "measures" = "対策";
@@ -108,6 +111,7 @@
 "noNotesYet" = "ノートがありません";
 "noMeasures" = "対策がありません";
 "deleteMeasures" = "対策を削除しますか？\n対策を削除するとノートに記入した本課題に関する記載も全て削除されます。一度削除した対策は復元できません。";
+"measuresTitleRequiredError" = "対策タイトルは必須項目です";
 
 // MARK: Note
 "note" = "ノート";
@@ -136,6 +140,9 @@
 "deleteTaskFromNote" = "ノートから課題を削除しますか？";
 "added" = "追加済み";
 "defaltFreeNoteDetail" = "常に最上位に表示されるノートです。";
+"cannotDeleteFreeNote" = "フリーノートは削除できません";
+"noNotesInDay" = "ノートがありません";
+"unknownNoteType" = "なし";
 
 // MARK: Target
 "target" = "目標";
@@ -146,6 +153,13 @@
 "month" = "月";
 "notSet" = "未設定";
 "today" = "今日";
+"weekdaySun" = "日";
+"weekdayMon" = "月";
+"weekdayTue" = "火";
+"weekdayWed" = "水";
+"weekdayThu" = "木";
+"weekdayFri" = "金";
+"weekdaySat" = "土";
 
 // MARK: Mail
 "pleaseEnterInquiry" = "お問い合わせ内容をご記入ください。";
@@ -165,6 +179,7 @@
 "termsOfService" = "利用規約";
 "privacyPolicy" = "プライバシーポリシー";
 "appVersion" = "アプリバージョン";
+"unknown" = "不明";
 "TermsOfServiceTitle" = "利用規約に同意しますか？";
 "TermsOfServiceMessage" = "このアプリを使用するには、利用規約に同意する必要があります。";
 "checkTermsOfService" = "利用規約を確認";

--- a/SportsNote_iOS/View/Setting/MenuView.swift
+++ b/SportsNote_iOS/View/Setting/MenuView.swift
@@ -16,8 +16,9 @@ struct MenuView: View {
     init(isMenuOpen: Binding<Bool>, onDismiss: @escaping () -> Void) {
         self._isMenuOpen = isMenuOpen
         self.onDismiss = onDismiss
-        self.appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "不明"
-        self.appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "不明"
+        self.appVersion =
+            Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? LocalizedStrings.unknown
+        self.appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? LocalizedStrings.unknown
     }
 
     /// メーラーを表示する処理

--- a/SportsNote_iOS/View/Target/Components/CalendarView.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarView.swift
@@ -15,7 +15,15 @@ struct CalendarView: View {
     @State private var datesWithTournament: Set<Date> = []  // 大会ノートがある日付のセット
 
     // 曜日の配列（日曜始まり）
-    private let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    private let weekdays = [
+        LocalizedStrings.weekdaySun,
+        LocalizedStrings.weekdayMon,
+        LocalizedStrings.weekdayTue,
+        LocalizedStrings.weekdayWed,
+        LocalizedStrings.weekdayThu,
+        LocalizedStrings.weekdayFri,
+        LocalizedStrings.weekdaySat,
+    ]
 
     init(
         selectedDate: Binding<Date?>, initialDate: Date = Date(), onDateSelected: @escaping (Date) -> Void,

--- a/SportsNote_iOS/View/Target/Components/NoteListSection.swift
+++ b/SportsNote_iOS/View/Target/Components/NoteListSection.swift
@@ -16,7 +16,7 @@ struct NoteListSection: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             if notes.isEmpty {
-                Text("ノートがありません")
+                Text(LocalizedStrings.noNotesInDay)
                     .foregroundColor(.gray)
                     .padding()
                     .frame(maxWidth: .infinity)
@@ -81,7 +81,7 @@ struct NoteListSection: View {
                     )
                 }
         case .none:
-            Text("なし")
+            Text(LocalizedStrings.unknownNoteType)
         }
     }
 }

--- a/SportsNote_iOS/View/Task/Components/TaskListSection.swift
+++ b/SportsNote_iOS/View/Task/Components/TaskListSection.swift
@@ -101,7 +101,7 @@ struct MainTaskList: View {
             )
             .eraseToAnyView()
         } else {
-            return Text("Task not found").eraseToAnyView()
+            return Text(LocalizedStrings.taskNotFoundLabel).eraseToAnyView()
         }
     }
 }

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -522,7 +522,7 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             if let note = notes.first(where: { $0.noteID == id }),
                 note.noteType == NoteType.free.rawValue
             {
-                return .failure(.systemError("フリーノートは削除できません"))
+                return .failure(.systemError(LocalizedStrings.cannotDeleteFreeNote))
             }
 
             // 削除前にオブジェクトを取得（論理削除後はisDeleted=trueで取得できなくなるため）

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -172,7 +172,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Returns: Result
     func addMeasureToTask(taskID: String, title: String) async -> Result<Void, SportsNoteError> {
         guard !title.isEmpty else {
-            let error = SportsNoteError.systemError("対策タイトルは必須項目です")
+            let error = SportsNoteError.systemError(LocalizedStrings.measuresTitleRequiredError)
             return .failure(error)
         }
 
@@ -201,7 +201,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ) async -> Result<Void, SportsNoteError> {
         // バリデーション
         guard !title.isEmpty else {
-            let error = SportsNoteError.systemError("タイトルは必須項目です")
+            let error = SportsNoteError.systemError(LocalizedStrings.taskTitleRequiredError)
             return .failure(error)
         }
 
@@ -209,7 +209,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         switch taskResult {
         case .success(let existingTask):
             guard let existingTask = existingTask else {
-                let error = SportsNoteError.systemError("Task not found: \(taskID)")
+                let error = SportsNoteError.systemError(String(format: LocalizedStrings.taskNotFoundError, taskID))
                 return .failure(error)
             }
 
@@ -236,7 +236,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         switch taskResult {
         case .success(let taskToUpdate):
             guard let taskToUpdate = taskToUpdate else {
-                let error = SportsNoteError.systemError("Task not found: \(taskID)")
+                let error = SportsNoteError.systemError(String(format: LocalizedStrings.taskNotFoundError, taskID))
                 return .failure(error)
             }
 


### PR DESCRIPTION
## 概要
「ユーザー向け文字列がLocalizedStringsを経由せず直接ハードコードされている」という同一パターンの多言語化違反が5件のissueに分散していたため、まとめて修正しました。

## 変更内容
- `CalendarView.swift`: 曜日ヘッダー配列（`["Sun", "Mon", ...]`）→`LocalizedStrings.weekdaySun`等（#116）
- `NoteListSection.swift`: "ノートがありません"/"なし"→`LocalizedStrings.noNotesInDay`/`unknownNoteType`（#17）
- `TaskListSection.swift`: "Task not found"→`LocalizedStrings.taskNotFoundLabel`（#17）
- `MenuView.swift`: バージョン/アプリ名取得失敗時のフォールバック"不明"→`LocalizedStrings.unknown`（#31）
- `NoteViewModel.swift`: "フリーノートは削除できません"→`LocalizedStrings.cannotDeleteFreeNote`（#111）
- `TaskViewModel.swift`: バリデーションエラー4箇所→`LocalizedStrings`経由（#58）

`LocalizedString.swift`・`ja.lproj`/`en.lproj`の`Localizable.strings`に対応する新規キーを追加。ja側は元の日本語リテラルと完全一致させ、元々英語ハードコードだった箇所（"Task not found"）は自然な日本語訳を新規追加。

## テスト
- ビルド成功（BUILD SUCCEEDED）
- 既存テスト565件中563件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビュー実施。must-fix/should-fix指摘なし

Closes #17
Closes #31
Closes #58
Closes #111
Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)