### PR TITLE
fix: オフライン作成後にオンラインで編集するとFirestoreへの更新が必ず失敗する不具合を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/FirebaseManager.swift
+++ b/SportsNote_iOS/Model/Manager/FirebaseManager.swift
@@ -323,7 +323,7 @@ final class FirebaseManager {
         do {
             return try await withCheckedThrowingContinuation { continuation in
                 db.collection(collection).document(documentID)
-                    .updateData(data) { error in
+                    .setData(data, merge: true) { error in
                         if let error = error {
                             continuation.resume(throwing: error)
                         } else {
@@ -345,10 +345,13 @@ final class FirebaseManager {
         let documentID = FirebaseManager.buildDocumentID(userID: group.userID, entityID: group.groupID)
 
         let data: [String: Any] = [
+            "userID": group.userID,
+            "groupID": group.groupID,
             "title": group.title,
             "color": group.color,
             "order": group.order,
             "isDeleted": group.isDeleted,
+            "created_at": group.created_at,
             "updated_at": group.updated_at,
         ]
 
@@ -364,12 +367,15 @@ final class FirebaseManager {
         let documentID = FirebaseManager.buildDocumentID(userID: task.userID, entityID: task.taskID)
 
         let data: [String: Any] = [
+            "userID": task.userID,
+            "taskID": task.taskID,
             "groupID": task.groupID,
             "title": task.title,
             "cause": task.cause,
             "order": task.order,
             "isComplete": task.isComplete,
             "isDeleted": task.isDeleted,
+            "created_at": task.created_at,
             "updated_at": task.updated_at,
         ]
 
@@ -385,9 +391,13 @@ final class FirebaseManager {
         let documentID = FirebaseManager.buildDocumentID(userID: measures.userID, entityID: measures.measuresID)
 
         let data: [String: Any] = [
+            "userID": measures.userID,
+            "measuresID": measures.measuresID,
+            "taskID": measures.taskID,
             "title": measures.title,
             "order": measures.order,
             "isDeleted": measures.isDeleted,
+            "created_at": measures.created_at,
             "updated_at": measures.updated_at,
         ]
 
@@ -403,8 +413,13 @@ final class FirebaseManager {
         let documentID = FirebaseManager.buildDocumentID(userID: memo.userID, entityID: memo.memoID)
 
         let data: [String: Any] = [
+            "userID": memo.userID,
+            "memoID": memo.memoID,
+            "noteID": memo.noteID,
+            "measuresID": memo.measuresID,
             "detail": memo.detail,
             "isDeleted": memo.isDeleted,
+            "created_at": memo.created_at,
             "updated_at": memo.updated_at,
         ]
 
@@ -420,11 +435,14 @@ final class FirebaseManager {
         let documentID = FirebaseManager.buildDocumentID(userID: target.userID, entityID: target.targetID)
 
         let data: [String: Any] = [
+            "userID": target.userID,
+            "targetID": target.targetID,
             "title": target.title,
             "year": target.year,
             "month": target.month,
             "isYearlyTarget": target.isYearlyTarget,
             "isDeleted": target.isDeleted,
+            "created_at": target.created_at,
             "updated_at": target.updated_at,
         ]
 
@@ -440,7 +458,11 @@ final class FirebaseManager {
         let documentID = FirebaseManager.buildDocumentID(userID: note.userID, entityID: note.noteID)
 
         let data: [String: Any] = [
+            "userID": note.userID,
+            "noteID": note.noteID,
+            "noteType": note.noteType,
             "isDeleted": note.isDeleted,
+            "created_at": note.created_at,
             "updated_at": note.updated_at,
             "title": note.title,
             "date": note.date,


### PR DESCRIPTION
## 概要
オフライン中に新規作成したエンティティ（グループ・課題・対策・メモ・ノート・目標）を、同一セッション内でオンライン復帰後に編集すると、Firestoreへの更新が必ず失敗し、ローカル保存は成功しているにもかかわらずエラーアラートが表示される不具合を修正しました。

## 原因
オフライン中の新規作成では`isOnlineAndLoggedIn`ガードによりFirestoreへの書き込みがスキップされ、ローカルRealmにのみ保存される。その後オンライン復帰後に同じエンティティを編集すると`FirebaseManager.updateXxx`経由で`updateDocument`が実行されるが、内部の`updateData()`は対象ドキュメントが存在しない場合に必ずエラーを返す仕様（`setData()`と異なり新規作成しない）。Firestoreに一度もドキュメントが作成されていないため、更新が毎回失敗していた。

## 変更内容
- `updateDocument`内の`updateData(data)`を`setData(data, merge: true)`に変更し、ドキュメント未作成時は新規作成、既存時はマージ更新されるようにした
- `setData(merge: true)`は渡した`data`のフィールドのみでドキュメントを新規作成するため、各`updateXxx`メソッドの`data`引数に不足していた`userID`・プライマリキー・`created_at`を、対応する`saveXxx`メソッドと同じ内容になるよう追加。これを追加しないと、新規作成されたドキュメントで`userID`が欠落し、以後`getAllDocuments`（`whereField("userID", isEqualTo:)`）で二度と取得できない「幽霊ドキュメント」になってしまう問題がクロスレビューで判明したため対応した

## テスト
- ビルド成功（BUILD SUCCEEDED）
- 既存テスト565件中563件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビューを2回実施。1回目でuserID等のフィールド欠落によるデータ不整合リスクをmust-fixとして指摘、修正後の再レビューで指摘事項なしを確認
- `FirebaseManager`はFirebase未設定のテスト環境ではインスタンス化するだけでクラッシュするため、単体テストは追加していない

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)