### PR TITLE
fix: JapaneseHolidayCheckerの固定祝日判定が年を考慮せず制定前後の日付を誤判定する不具合を修正

### DIFF
--- a/SportsNote_iOS/Utils/JapaneseHolidayChecker.swift
+++ b/SportsNote_iOS/Utils/JapaneseHolidayChecker.swift
@@ -11,7 +11,7 @@ class JapaneseHolidayChecker {
         let day = jpCalendar.component(.day, from: date)
 
         // 固定の祝日をチェック
-        if isFixedHoliday(month: month, day: day) {
+        if isFixedHoliday(year: year, month: month, day: day) {
             return true
         }
 
@@ -38,15 +38,15 @@ class JapaneseHolidayChecker {
         return false
     }
 
-    // 固定祝日（毎年同じ月日の祝日）
-    private static func isFixedHoliday(month: Int, day: Int) -> Bool {
+    // 固定祝日（毎年同じ月日の祝日、制定年を考慮する）
+    private static func isFixedHoliday(year: Int, month: Int, day: Int) -> Bool {
         switch (month, day) {
         case (1, 1):  // 元日
             return true
         case (2, 11):  // 建国記念の日
             return true
-        case (2, 23):  // 天皇誕生日
-            return true
+        case (2, 23):  // 天皇誕生日（今上天皇即位の2020年以降）
+            return year >= 2020
         case (4, 29):  // 昭和の日
             return true
         case (5, 3):  // 憲法記念日
@@ -55,12 +55,14 @@ class JapaneseHolidayChecker {
             return true
         case (5, 5):  // こどもの日
             return true
-        case (8, 11):  // 山の日
-            return true
+        case (8, 11):  // 山の日（2016年制定）
+            return year >= 2016
         case (11, 3):  // 文化の日
             return true
         case (11, 23):  // 勤労感謝の日
             return true
+        case (12, 23):  // 天皇誕生日（平成期、1989年〜2018年）
+            return year >= 1989 && year <= 2018
         default:
             return false
         }
@@ -133,6 +135,7 @@ class JapaneseHolidayChecker {
         if let yesterday = jpCalendar.date(byAdding: .day, value: -1, to: date) {
             let isYesterdayHoliday =
                 isFixedHoliday(
+                    year: jpCalendar.component(.year, from: yesterday),
                     month: jpCalendar.component(.month, from: yesterday),
                     day: jpCalendar.component(.day, from: yesterday)
                 )
@@ -175,7 +178,7 @@ class JapaneseHolidayChecker {
         let month = jpCalendar.component(.month, from: date)
         let day = jpCalendar.component(.day, from: date)
 
-        return isFixedHoliday(month: month, day: day)
+        return isFixedHoliday(year: year, month: month, day: day)
             || isHappyMondayHoliday(year: year, month: month, day: day)
             || isEquinoxDay(year: year, month: month, day: day)
     }

--- a/SportsNote_iOSTests/Utils/JapaneseHolidayCheckerTests.swift
+++ b/SportsNote_iOSTests/Utils/JapaneseHolidayCheckerTests.swift
@@ -87,6 +87,56 @@ struct JapaneseHolidayCheckerTests {
         #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
     }
 
+    // MARK: - 固定祝日テスト（制定年境界）
+
+    @Test("固定祝日 - 天皇誕生日（2月23日）は制定前の2019年は祝日ではない")
+    func fixedHoliday_emperorsBirthday_before2020NotHoliday() {
+        let date = createDate(year: 2019, month: 2, day: 23)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 天皇誕生日（2月23日）は制定年の2020年から祝日")
+    func fixedHoliday_emperorsBirthday_from2020IsHoliday() {
+        let date = createDate(year: 2020, month: 2, day: 23)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 山の日（8月11日）は制定前の2015年は祝日ではない")
+    func fixedHoliday_mountainDay_before2016NotHoliday() {
+        let date = createDate(year: 2015, month: 8, day: 11)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 山の日（8月11日）は制定年の2016年から祝日")
+    func fixedHoliday_mountainDay_from2016IsHoliday() {
+        let date = createDate(year: 2016, month: 8, day: 11)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 天皇誕生日（12月23日、平成期）は1988年は祝日ではない")
+    func fixedHoliday_emperorsBirthdayHeisei_1988NotHoliday() {
+        let date = createDate(year: 1988, month: 12, day: 23)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 天皇誕生日（12月23日、平成期）は開始年の1989年から祝日")
+    func fixedHoliday_emperorsBirthdayHeisei_from1989IsHoliday() {
+        let date = createDate(year: 1989, month: 12, day: 23)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 天皇誕生日（12月23日、平成期）は終了年の2018年も祝日")
+    func fixedHoliday_emperorsBirthdayHeisei_2018IsHoliday() {
+        let date = createDate(year: 2018, month: 12, day: 23)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("固定祝日 - 天皇誕生日（12月23日、平成期）は2019年以降は祝日ではない（今上天皇即位後）")
+    func fixedHoliday_emperorsBirthdayHeisei_from2019NotHoliday() {
+        let date = createDate(year: 2019, month: 12, day: 23)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
     // MARK: - ハッピーマンデー祝日テスト
 
     @Test("ハッピーマンデー - 成人の日（1月第2月曜日）2025年")
@@ -189,6 +239,22 @@ struct JapaneseHolidayCheckerTests {
         // 2024年11月4日（月曜日）が振替休日
         let date = createDate(year: 2024, month: 11, day: 4)
         #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("振替休日 - 2018年12月24日（平成期最後の天皇誕生日の振替）")
+    func substituteHoliday_emperorsBirthdayHeisei_2018() {
+        // 2018年12月23日（天皇誕生日、平成期）は日曜日
+        // 2018年12月24日（月曜日）が振替休日
+        let date = createDate(year: 2018, month: 12, day: 24)
+        #expect(JapaneseHolidayChecker.isJapaneseHoliday(date))
+    }
+
+    @Test("振替休日 - 2019年12月24日は制定終了後のため振替休日にならない")
+    func substituteHoliday_emperorsBirthdayHeisei_2019NotHoliday() {
+        // 2019年12月23日（月曜日）は今上天皇即位後のため祝日ではなく、
+        // 翌24日（火曜日）も振替休日の対象にならない
+        let date = createDate(year: 2019, month: 12, day: 24)
+        #expect(!JapaneseHolidayChecker.isJapaneseHoliday(date))
     }
 
     // MARK: - 国民の休日テスト


### PR DESCRIPTION
## 概要
`JapaneseHolidayChecker.isFixedHoliday(month:day:)`が年を考慮しておらず、制定年より前の日付にも祝日と誤判定していた不具合を修正しました。

- 天皇誕生日（2/23）は今上天皇即位の2020年以降のみ有効だが、2019年以前の2/23も祝日と誤判定
- 山の日（8/11）は2016年制定だが、それ以前（〜2015年）の8/11も祝日と誤判定
- 1989〜2018年に「天皇誕生日」として有効だった12/23（平成期）は判定対象に含まれておらず、該当期間の12/23が祝日として扱われていなかった

## 変更内容
- `isFixedHoliday(month:day:)`を`isFixedHoliday(year:month:day:)`に変更し、天皇誕生日（2/23は2020年以降、12/23は1989〜2018年）・山の日（2016年以降）を制定期間に基づいて判定するようにした
- 呼び出し元3箇所（`isJapaneseHoliday`, `isSubstituteHoliday`, `isNamedHoliday`）を`year`引数を渡すよう修正
- 境界年（制定年の前年・当年）のテストケースを追加
- クロスレビューでの指摘を受け、平成期最後の天皇誕生日（2018年12月23日、日曜日）の振替休日（12月24日）が正しく祝日と判定され、制定終了後の2019年12月24日は祝日と判定されないことを検証する組み合わせテストも追加

## テスト
- ビルド成功（BUILD SUCCEEDED）
- `JapaneseHolidayCheckerTests`スイート63件全て成功
- 全体テストスイート573件中571件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビューを実施。制定年境界の正確性・呼び出し漏れなしを確認。should-fix指摘（振替休日との組み合わせテスト不足）に対応済み

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)