### PR TITLE
refactor: TermsViewModel.swift内のクラス名をTermsManagerからTermsViewModelにリネーム

### DIFF
--- a/SportsNote_iOS/SportsNote_iOSApp.swift
+++ b/SportsNote_iOS/SportsNote_iOSApp.swift
@@ -48,7 +48,7 @@ struct SportsNote_iOSApp: App {
                         isInitialized = false
                         Task {
                             // LoginViewModelの処理完了を待ってからRealmを再初期化
-                            try? await Task.sleep(nanoseconds: 300_000_000) // 0.3秒
+                            try? await Task.sleep(nanoseconds: 300_000_000)  // 0.3秒
                             do {
                                 try RealmManager.shared.initRealm()
                             } catch {
@@ -72,7 +72,7 @@ struct SportsNote_iOSApp: App {
     /// 利用規約の同意状態をチェックし、未同意の場合はダイアログを表示
     private func checkAndShowTermsDialog() {
         if !UserDefaultsManager.get(key: UserDefaultsManager.Keys.agree, defaultValue: false) {
-            TermsManager.showDialog()
+            TermsViewModel.showDialog()
         }
     }
 

--- a/SportsNote_iOS/View/Common/TermsDialogView.swift
+++ b/SportsNote_iOS/View/Common/TermsDialogView.swift
@@ -1,19 +1,19 @@
 import SwiftUI
 
 struct TermsDialogView: View {
-    @ObservedObject private var termsManager = TermsManager.shared
+    @ObservedObject private var termsViewModel = TermsViewModel.shared
 
     var body: some View {
         EmptyView()
-            .alert(isPresented: $termsManager.termsDialogShown) {
+            .alert(isPresented: $termsViewModel.termsDialogShown) {
                 Alert(
                     title: Text(LocalizedStrings.termsOfServiceTitle),
                     message: Text(LocalizedStrings.termsOfServiceMessage),
                     primaryButton: .default(Text(LocalizedStrings.checkTermsOfService)) {
-                        TermsManager.navigateToTermsOfService()
+                        TermsViewModel.navigateToTermsOfService()
                     },
                     secondaryButton: .default(Text(LocalizedStrings.agree)) {
-                        termsManager.agreeToTerms()
+                        termsViewModel.agreeToTerms()
                     }
                 )
             }

--- a/SportsNote_iOS/View/Setting/MenuView.swift
+++ b/SportsNote_iOS/View/Setting/MenuView.swift
@@ -71,13 +71,13 @@ struct MenuView: View {
                         title: LocalizedStrings.termsOfService,
                         subTitle: "",
                         iconRes: "doc.text",
-                        onClick: { TermsManager.navigateToTermsOfService() }
+                        onClick: { TermsViewModel.navigateToTermsOfService() }
                     ),
                     ItemData(
                         title: LocalizedStrings.privacyPolicy,
                         subTitle: "",
                         iconRes: "lock.shield",
-                        onClick: { TermsManager.navigateToPrivacyPolicy() }
+                        onClick: { TermsViewModel.navigateToPrivacyPolicy() }
                     ),
                     ItemData(
                         title: LocalizedStrings.appVersion,

--- a/SportsNote_iOS/ViewModel/TermsViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TermsViewModel.swift
@@ -2,8 +2,8 @@ import Foundation
 import UIKit
 
 @MainActor
-class TermsManager: ObservableObject {
-    static let shared = TermsManager()
+class TermsViewModel: ObservableObject {
+    static let shared = TermsViewModel()
     @Published var termsDialogShown = false
 
     /// 利用規約・プライバシーポリシーのURL

--- a/SportsNote_iOSTests/ViewModels/TermsViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TermsViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  TermsManagerTests.swift
+//  TermsViewModelTests.swift
 //  SportsNote_iOSTests
 //
 //  Created by Swift Testing on 2025/11/23.
@@ -10,24 +10,24 @@ import Testing
 
 @testable import SportsNote_iOS
 
-@Suite("TermsManager Tests")
+@Suite("TermsViewModel Tests")
 @MainActor
-struct TermsManagerTests {
+struct TermsViewModelTests {
 
     // MARK: - シングルトンテスト
 
     @Test("シングルトン - sharedインスタンスが存在する")
     func singleton_sharedInstanceExists() async {
-        let instance = TermsManager.shared
+        let instance = TermsViewModel.shared
 
-        // TermsManagerは非オプショナルなので、型の確認のみ
-        #expect(type(of: instance) == TermsManager.self)
+        // TermsViewModelは非オプショナルなので、型の確認のみ
+        #expect(type(of: instance) == TermsViewModel.self)
     }
 
     @Test("シングルトン - 同じインスタンスが返される")
     func singleton_sameInstanceReturned() async {
-        let instance1 = TermsManager.shared
-        let instance2 = TermsManager.shared
+        let instance1 = TermsViewModel.shared
+        let instance2 = TermsViewModel.shared
 
         #expect(instance1 === instance2)
     }
@@ -36,7 +36,7 @@ struct TermsManagerTests {
 
     @Test("初期化 - termsDialogShownはBool型")
     func initialization_termsDialogShownIsBool() async {
-        let manager = TermsManager.shared
+        let manager = TermsViewModel.shared
 
         // termsDialogShownがBool型であることを確認
         #expect(type(of: manager.termsDialogShown) == Bool.self)
@@ -46,7 +46,7 @@ struct TermsManagerTests {
 
     @Test("URL定数 - termsOfServiceAndPrivacyPolicyが有効なURL")
     func urlConstants_termsOfServiceAndPrivacyPolicyIsValid() async {
-        let urlString = TermsManager.TermsURL.termsOfServiceAndPrivacyPolicy
+        let urlString = TermsViewModel.TermsURL.termsOfServiceAndPrivacyPolicy
         let url = URL(string: urlString)
 
         #expect(url != nil)
@@ -55,7 +55,7 @@ struct TermsManagerTests {
 
     @Test("URL定数 - termsOfServiceが有効なURL")
     func urlConstants_termsOfServiceIsValid() async {
-        let urlString = TermsManager.TermsURL.termsOfService
+        let urlString = TermsViewModel.TermsURL.termsOfService
         let url = URL(string: urlString)
 
         #expect(url != nil)
@@ -64,7 +64,7 @@ struct TermsManagerTests {
 
     @Test("URL定数 - privacyPolicyが有効なURL")
     func urlConstants_privacyPolicyIsValid() async {
-        let urlString = TermsManager.TermsURL.privacyPolicy
+        let urlString = TermsViewModel.TermsURL.privacyPolicy
         let url = URL(string: urlString)
 
         #expect(url != nil)
@@ -74,9 +74,9 @@ struct TermsManagerTests {
     @Test(
         "URL定数 - 全てのURLがhttpsで始まる",
         arguments: [
-            TermsManager.TermsURL.termsOfServiceAndPrivacyPolicy,
-            TermsManager.TermsURL.termsOfService,
-            TermsManager.TermsURL.privacyPolicy,
+            TermsViewModel.TermsURL.termsOfServiceAndPrivacyPolicy,
+            TermsViewModel.TermsURL.termsOfService,
+            TermsViewModel.TermsURL.privacyPolicy,
         ])
     func urlConstants_allUrlsStartWithHttps(urlString: String) async {
         #expect(urlString.hasPrefix("https://"))
@@ -85,9 +85,9 @@ struct TermsManagerTests {
     @Test(
         "URL定数 - 全てのURLが有効なURL形式",
         arguments: [
-            TermsManager.TermsURL.termsOfServiceAndPrivacyPolicy,
-            TermsManager.TermsURL.termsOfService,
-            TermsManager.TermsURL.privacyPolicy,
+            TermsViewModel.TermsURL.termsOfServiceAndPrivacyPolicy,
+            TermsViewModel.TermsURL.termsOfService,
+            TermsViewModel.TermsURL.privacyPolicy,
         ])
     func urlConstants_allUrlsAreValid(urlString: String) async {
         let url = URL(string: urlString)
@@ -97,9 +97,9 @@ struct TermsManagerTests {
     @Test(
         "URL定数 - URLにfirebaseappが含まれる",
         arguments: [
-            TermsManager.TermsURL.termsOfServiceAndPrivacyPolicy,
-            TermsManager.TermsURL.termsOfService,
-            TermsManager.TermsURL.privacyPolicy,
+            TermsViewModel.TermsURL.termsOfServiceAndPrivacyPolicy,
+            TermsViewModel.TermsURL.termsOfService,
+            TermsViewModel.TermsURL.privacyPolicy,
         ])
     func urlConstants_urlsContainFirebaseapp(urlString: String) async {
         #expect(urlString.contains("firebaseapp"))
@@ -109,7 +109,7 @@ struct TermsManagerTests {
 
     @Test("agreeToTerms - termsDialogShownがfalseになる")
     func agreeToTerms_setsTermsDialogShownToFalse() async {
-        let manager = TermsManager.shared
+        let manager = TermsViewModel.shared
 
         // 初期状態を設定
         manager.termsDialogShown = true
@@ -123,7 +123,7 @@ struct TermsManagerTests {
 
     @Test("agreeToTerms - UserDefaultsに保存される")
     func agreeToTerms_savesToUserDefaults() async {
-        let manager = TermsManager.shared
+        let manager = TermsViewModel.shared
 
         // 事前にクリア
         UserDefaults.standard.removeObject(forKey: UserDefaultsManager.Keys.agree)
@@ -144,7 +144,7 @@ struct TermsManagerTests {
 
     @Test("termsDialogShown - 値の設定と取得")
     func termsDialogShown_setAndGet() async {
-        let manager = TermsManager.shared
+        let manager = TermsViewModel.shared
 
         manager.termsDialogShown = true
         #expect(manager.termsDialogShown == true)
@@ -155,7 +155,7 @@ struct TermsManagerTests {
 
     @Test("termsDialogShown - 複数回の切り替え")
     func termsDialogShown_multipleToggles() async {
-        let manager = TermsManager.shared
+        let manager = TermsViewModel.shared
 
         manager.termsDialogShown = true
         #expect(manager.termsDialogShown == true)
@@ -172,9 +172,9 @@ struct TermsManagerTests {
     @Test("URL構造体 - 3つのURL定数が定義されている")
     func urlStruct_hasThreeUrlConstants() async {
         // 構造体のプロパティが存在することを確認
-        let url1 = TermsManager.TermsURL.termsOfServiceAndPrivacyPolicy
-        let url2 = TermsManager.TermsURL.termsOfService
-        let url3 = TermsManager.TermsURL.privacyPolicy
+        let url1 = TermsViewModel.TermsURL.termsOfServiceAndPrivacyPolicy
+        let url2 = TermsViewModel.TermsURL.termsOfService
+        let url3 = TermsViewModel.TermsURL.privacyPolicy
 
         #expect(!url1.isEmpty)
         #expect(!url2.isEmpty)
@@ -183,9 +183,9 @@ struct TermsManagerTests {
 
     @Test("URL構造体 - 各URLが異なる値を持つ")
     func urlStruct_allUrlsAreDifferent() async {
-        let url1 = TermsManager.TermsURL.termsOfServiceAndPrivacyPolicy
-        let url2 = TermsManager.TermsURL.termsOfService
-        let url3 = TermsManager.TermsURL.privacyPolicy
+        let url1 = TermsViewModel.TermsURL.termsOfServiceAndPrivacyPolicy
+        let url2 = TermsViewModel.TermsURL.termsOfService
+        let url3 = TermsViewModel.TermsURL.privacyPolicy
 
         #expect(url1 != url2)
         #expect(url2 != url3)
@@ -218,11 +218,11 @@ struct TermsManagerTests {
 
 // MARK: - テストヘルパー拡張
 
-extension TermsManagerTests {
+extension TermsViewModelTests {
 
-    /// テスト用のTermsManagerインスタンスを取得
-    static func getTestManager() -> TermsManager {
-        return TermsManager.shared
+    /// テスト用のTermsViewModelインスタンスを取得
+    static func getTestManager() -> TermsViewModel {
+        return TermsViewModel.shared
     }
 
     /// UserDefaultsをクリーンアップ


### PR DESCRIPTION
## 概要
`ViewModel/TermsViewModel.swift`というファイル名にもかかわらず、中身のクラス名は`TermsManager`であり、CLAUDE.mdの命名規則（ファイル名とクラス名を一致させる慣習）に反していたため、クラス名を`TermsViewModel`にリネームしました。

## 変更内容
- クラス名`TermsManager`→`TermsViewModel`（`static let shared`の型も追従）
- 全参照箇所（`SportsNote_iOSApp.swift`、`TermsDialogView.swift`のローカル変数含む、`MenuView.swift`）を更新
- テストファイルを`TermsManagerTests.swift`→`TermsViewModelTests.swift`にリネームし中身も更新

機能的な変更はなく、命名のみの変更です。

## テスト
- ビルド成功（BUILD SUCCEEDED）
- 全体テストスイート565件中563件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビュー実施。must-fix/should-fix指摘なし

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)