### PR TITLE
refactor: RealmManager.markAsDeletedで6モデル分の型キャスト分岐が完全重複している問題を解消

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -6,11 +6,10 @@ struct RealmConstants {
     static let schemaVersion: UInt64 = 0
 }
 
-/// 論理削除フラグ(isDeleted)を持つRealmモデルの共通インターフェース
-/// issue #38でmarkAsDeleted用にSoftDeletableプロトコルが新設された場合は、
-/// 本プロトコルとの重複を解消し統合すること
-protocol SoftDeletable {
-    var isDeleted: Bool { get }
+/// 論理削除フラグ(isDeleted)と更新日時(updated_at)を持つRealmモデルの共通インターフェース
+protocol SoftDeletable: Object {
+    var isDeleted: Bool { get set }
+    var updated_at: Date { get set }
 }
 
 // Realmモデルに対してSoftDeletableプロトコルを適用する拡張
@@ -625,31 +624,12 @@ final class RealmManager {
     ///   - realm: Realmインスタンス
     private func markAsDeleted(_ item: Object, realm: Realm) {
         // itemが「削除フラグ」を持っているかどうかでチェックし、削除マークを付ける
-        if let itemWithDeleteFlag = item as? Note {
-            itemWithDeleteFlag.isDeleted = true
-            itemWithDeleteFlag.updated_at = Date()
-            realm.add(itemWithDeleteFlag, update: .modified)
-        } else if let itemWithDeleteFlag = item as? Group {
-            itemWithDeleteFlag.isDeleted = true
-            itemWithDeleteFlag.updated_at = Date()
-            realm.add(itemWithDeleteFlag, update: .modified)
-        } else if let itemWithDeleteFlag = item as? TaskData {
-            itemWithDeleteFlag.isDeleted = true
-            itemWithDeleteFlag.updated_at = Date()
-            realm.add(itemWithDeleteFlag, update: .modified)
-        } else if let itemWithDeleteFlag = item as? Measures {
-            itemWithDeleteFlag.isDeleted = true
-            itemWithDeleteFlag.updated_at = Date()
-            realm.add(itemWithDeleteFlag, update: .modified)
-        } else if let itemWithDeleteFlag = item as? Memo {
-            itemWithDeleteFlag.isDeleted = true
-            itemWithDeleteFlag.updated_at = Date()
-            realm.add(itemWithDeleteFlag, update: .modified)
-        } else if let itemWithDeleteFlag = item as? Target {
-            itemWithDeleteFlag.isDeleted = true
-            itemWithDeleteFlag.updated_at = Date()
-            realm.add(itemWithDeleteFlag, update: .modified)
-        }
+        // realm.add<T: Object>への引数はexistentialの暗黙オープン(SE-0352)により
+        // 実行時の具象型（Note/Group等）で解決されるため、型不一致は起きない
+        guard let itemWithDeleteFlag = item as? SoftDeletable else { return }
+        itemWithDeleteFlag.isDeleted = true
+        itemWithDeleteFlag.updated_at = Date()
+        realm.add(itemWithDeleteFlag, update: .modified)
     }
 
     /// Note に関連する Memo を削除

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -286,6 +286,24 @@ struct RealmManagerTests {
         manager.clearAll()
     }
 
+    @Test("logicalDelete - Targetを論理削除できる（issue #38: SoftDeletable共通化の回帰防止）")
+    func logicalDelete_target_marksAsDeleted() async throws {
+        let target = Target(title: "Delete Me", year: 2025, month: 1, isYearlyTarget: false)
+        target.targetID = "target-del-1"
+        try manager.saveItem(target)
+
+        try manager.logicalDelete(id: "target-del-1", type: Target.self)
+
+        let deletedTarget = try manager.getObjectById(id: "target-del-1", type: Target.self)
+        #expect(deletedTarget == nil)
+
+        let rawTarget = manager.getRawObjectById(id: "target-del-1", type: Target.self)
+        #expect(rawTarget != nil)
+        #expect(rawTarget?.isDeleted == true)
+
+        manager.clearAll()
+    }
+
     @Test("logicalDelete - updated_atが更新される（issue #26: Firebase同期時に削除が新しいと判定されるようにするため）")
     func logicalDelete_updatesUpdatedAt() async throws {
         let oldDate = Date().addingTimeInterval(-3600)  // 1時間前


### PR DESCRIPTION
## 概要
`RealmManager.markAsDeleted`が「`isDeleted = true`を設定し`realm.add(item, update: .modified)`する」という同一の2行を、`Note`/`Group`/`TaskData`/`Measures`/`Memo`/`Target`への型キャストを変えただけで6回繰り返していたのを解消しました。

## 変更内容
既に issue #75 対応時に追加されていた読み取り専用の`SoftDeletable`プロトコル（`var isDeleted: Bool { get }`、6モデルへの`extension`準拠も既存）に、そのコメントで予告されていた通り本issueで統合しました。

- `SoftDeletable`に`Object`制約・`isDeleted`のsetter・`updated_at`を追加
- `markAsDeleted`を6分岐のif-elseから`item as? SoftDeletable`による1回のキャストで済む実装に置き換え

新規プロトコルは作らず、既存の重複解消予告コメント通りに統合する形にしています。

## テスト
- ビルド成功（BUILD SUCCEEDED）。`realm.add<T: Object>`への`any SoftDeletable`型引数の型解決も問題なし
- 全体テストスイート566件中564件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビューを実施。should-fix指摘2件（existentialの暗黙オープンに関する実装コメント不足、Target単体の論理削除テスト欠落）に対応済み

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)