### PR TITLE
refactor: Realmモデル6ファイルでuserID取得がUserDefaultsManagerを経由せず直接UserDefaults.standardにアクセスしている問題を解消

### DIFF
--- a/SportsNote_iOS/Model/Group.swift
+++ b/SportsNote_iOS/Model/Group.swift
@@ -23,11 +23,7 @@ class Group: Object {
         updated_at = Date()
 
         // UserDefaultsから同期的に値を取得
-        if let userID = UserDefaults.standard.string(forKey: "userID") {
-            self.userID = userID
-        } else {
-            self.userID = ""
-        }
+        self.userID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
     }
 
     convenience init(

--- a/SportsNote_iOS/Model/Measures.swift
+++ b/SportsNote_iOS/Model/Measures.swift
@@ -23,11 +23,7 @@ class Measures: Object {
         updated_at = Date()
 
         // UserDefaultsから同期的に値を取得
-        if let userID = UserDefaults.standard.string(forKey: "userID") {
-            self.userID = userID
-        } else {
-            self.userID = ""
-        }
+        self.userID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
     }
 
     convenience init(

--- a/SportsNote_iOS/Model/Memo.swift
+++ b/SportsNote_iOS/Model/Memo.swift
@@ -24,11 +24,7 @@ class Memo: Object {
         self.created_at = Date()
         self.updated_at = Date()
         // UserDefaultsから同期的に値を取得
-        if let userID = UserDefaults.standard.string(forKey: "userID") {
-            self.userID = userID
-        } else {
-            self.userID = ""
-        }
+        self.userID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
     }
 
     convenience init(

--- a/SportsNote_iOS/Model/Note.swift
+++ b/SportsNote_iOS/Model/Note.swift
@@ -51,11 +51,7 @@ class Note: Object {
         self.result = ""
 
         // UserDefaultsから同期的に値を取得
-        if let userID = UserDefaults.standard.string(forKey: "userID") {
-            self.userID = userID
-        } else {
-            self.userID = ""
-        }
+        self.userID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
     }
 
     /// フリーノートのイニシャライザ

--- a/SportsNote_iOS/Model/Target.swift
+++ b/SportsNote_iOS/Model/Target.swift
@@ -25,11 +25,7 @@ open class Target: Object {
         updated_at = Date()
 
         // UserDefaultsから同期的に値を取得
-        if let userID = UserDefaults.standard.string(forKey: "userID") {
-            self.userID = userID
-        } else {
-            self.userID = ""
-        }
+        self.userID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
     }
 
     convenience init(

--- a/SportsNote_iOS/Model/TaskData.swift
+++ b/SportsNote_iOS/Model/TaskData.swift
@@ -27,11 +27,7 @@ open class TaskData: Object {
         updated_at = Date()
 
         // UserDefaultsから同期的に値を取得
-        if let userID = UserDefaults.standard.string(forKey: "userID") {
-            self.userID = userID
-        } else {
-            self.userID = ""
-        }
+        self.userID = UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")
     }
 
     convenience init(

--- a/SportsNote_iOSTests/Models/GroupTests.swift
+++ b/SportsNote_iOSTests/Models/GroupTests.swift
@@ -10,7 +10,10 @@ import Testing
 
 @testable import SportsNote_iOS
 
-@Suite("Group Model Tests")
+// Group()のデフォルトinit()がUserDefaultsManager経由でuserIDを取得するようになった
+// （issue #23）ため、UserDefaultsの共有可変状態(cachedUserID)に触れる他のスイートとの
+// 並列実行によるフレーキー化・汚染を防ぐため直列実行にする
+@Suite("Group Model Tests", .serialized)
 struct GroupTests {
 
     // MARK: - groupColor テスト（issue #43: 範囲外colorでのクラッシュ防止）
@@ -33,5 +36,18 @@ struct GroupTests {
             groupID: "g1", title: "Test", color: invalidColor, order: 0, created_at: Date())
 
         #expect(group.groupColor == .gray)
+    }
+
+    // MARK: - userID テスト（issue #23: UserDefaultsManager経由でのuserID取得）
+
+    @Test("init - userIDがUserDefaultsManager経由で設定される")
+    func init_setsUserIDFromUserDefaultsManager() {
+        let testUserID = "test-user-\(UUID().uuidString)"
+        UserDefaultsManager.set(key: UserDefaultsManager.Keys.userID, value: testUserID)
+        defer { UserDefaultsManager.remove(key: UserDefaultsManager.Keys.userID) }
+
+        let group = Group()
+
+        #expect(group.userID == testUserID)
     }
 }


### PR DESCRIPTION
## 概要
`Group`/`TaskData`/`Measures`/`Memo`/`Note`/`Target`の6モデルのデフォルトイニシャライザで、`userID`初期値の取得に`UserDefaultsManager`経由ではなく`UserDefaults.standard.string(forKey: "userID")`への直接アクセス・キー文字列のハードコードが使われていました。CLAUDE.mdの「ユーザー管理: UserDefaultsManager経由UserDefaults」ルールに違反していたため修正しました。

## 変更内容
6ファイル全てで、`UserDefaults.standard.string(forKey: "userID")`への直接アクセスを`UserDefaultsManager.get(key: UserDefaultsManager.Keys.userID, defaultValue: "")`に置き換えました。`InitializationManager.swift`で既に同一パターンが使われている実例を確認し、それを踏襲しています。

## 検討した挙動差分
`UserDefaultsManager.get`はuserIDキーの場合特別処理があり、値が未設定なら新規UUIDを自動生成して永続化します（元のModel側は空文字列を設定するのみでした）。クロスレビューでこの差分のリスクを検証してもらい、現在の起動フロー上は実害がないことを確認しました。ただし、`Group()`等のデフォルトinit()が`UserDefaultsManager`の共有可変状態（`cachedUserID`）に触れるようになったため、`GroupTests.swift`に`.serialized`を付与し他スイートとの並列実行によるフレーキー化を防止し、userID取得の回帰防止テストも追加しています。

## テスト
- ビルド成功（BUILD SUCCEEDED）
- `grep`でModel層への`UserDefaults.standard`直接アクセスが残っていないことを確認
- 全体テストスイート576件中574件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビューを実施。should-fix指摘2件（テスト分離違反リスク、回帰防止テスト不足）に対応済み

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)