### PR TITLE
refactor: fetchData()+エラー表示の個別実装をrefresh()呼び出しに統一

### DIFF
--- a/SportsNote_iOS/View/Group/GroupView.swift
+++ b/SportsNote_iOS/View/Group/GroupView.swift
@@ -80,10 +80,7 @@ struct GroupView: View {
             showingAlert: $viewModel.showingErrorAlert,
             onRetry: {
                 Task {
-                    let result = await viewModel.fetchData()
-                    if case .failure(let error) = result {
-                        viewModel.showErrorAlert(error)
-                    }
+                    await viewModel.refresh()
                 }
             }
         )

--- a/SportsNote_iOS/View/Note/NoteView.swift
+++ b/SportsNote_iOS/View/Note/NoteView.swift
@@ -31,10 +31,7 @@ struct NoteView: View {
                     VStack(spacing: 0) {
                         SearchBarView(searchText: $searchQuery) {
                             Task {
-                                let result = await viewModel.fetchData()
-                                if case .failure(let error) = result {
-                                    viewModel.showErrorAlert(error)
-                                }
+                                await viewModel.refresh()
                             }
                         }
                         NoteListView(viewModel: viewModel)
@@ -44,10 +41,7 @@ struct NoteView: View {
                                     viewModel.searchNotes(query: searchQuery)
                                 } else {
                                     Task {
-                                        let result = await viewModel.fetchData()
-                                        if case .failure(let error) = result {
-                                            viewModel.showErrorAlert(error)
-                                        }
+                                        await viewModel.refresh()
                                     }
                                 }
                             }
@@ -62,10 +56,7 @@ struct NoteView: View {
                             viewModel.searchNotes(query: newValue)
                         } else {
                             Task {
-                                let result = await viewModel.fetchData()
-                                if case .failure(let error) = result {
-                                    viewModel.showErrorAlert(error)
-                                }
+                                await viewModel.refresh()
                             }
                         }
                     }
@@ -79,28 +70,19 @@ struct NoteView: View {
         .sheet(isPresented: $isPracticeNotePresented) {
             AddPracticeNoteView(onSave: {
                 Task {
-                    let result = await viewModel.fetchData()
-                    if case .failure(let error) = result {
-                        viewModel.showErrorAlert(error)
-                    }
+                    await viewModel.refresh()
                 }
             })
         }
         .sheet(isPresented: $isTournamentNotePresented) {
             AddTournamentNoteView(onSave: {
                 Task {
-                    let result = await viewModel.fetchData()
-                    if case .failure(let error) = result {
-                        viewModel.showErrorAlert(error)
-                    }
+                    await viewModel.refresh()
                 }
             })
         }
         .task {
-            let result = await viewModel.fetchData()
-            if case .failure(let error) = result {
-                viewModel.showErrorAlert(error)
-            }
+            await viewModel.refresh()
         }
         .errorAlert(
             currentError: $viewModel.currentError,

--- a/SportsNote_iOS/View/Task/TaskDetailView.swift
+++ b/SportsNote_iOS/View/Task/TaskDetailView.swift
@@ -211,6 +211,9 @@ struct TaskDetailView: View {
         // グループとタスクデータを非同期で取得
         Task {
             // グループデータの読み込み
+            // groupViewModelはTaskView/GroupView等と共有されるインスタンスのため、
+            // refresh()のhideErrorAlert()で他画面の未確認エラーを消してしまわないよう、
+            // fetchData()を直接呼びこの画面固有のエラー転送のみ行う
             let result = await groupViewModel.fetchData()
             if case .failure(let error) = result {
                 viewModel.showErrorAlert(error)

--- a/SportsNote_iOS/View/Task/TaskView.swift
+++ b/SportsNote_iOS/View/Task/TaskView.swift
@@ -89,10 +89,7 @@ struct TaskView: View {
                         },
                         refreshAction: {
                             Task {
-                                let result = await viewModel.fetchData()
-                                if case .failure(let error) = result {
-                                    viewModel.showErrorAlert(error)
-                                }
+                                await viewModel.refresh()
 
                                 let taskResult: Result<Void, SportsNoteError>
                                 if let id = selectedGroupID {
@@ -139,10 +136,7 @@ struct TaskView: View {
         .onAppear {
             // 画面が表示されるたびに最新データを取得
             Task {
-                let result = await viewModel.fetchData()
-                if case .failure(let error) = result {
-                    viewModel.showErrorAlert(error)
-                }
+                await viewModel.refresh()
 
                 let taskResult: Result<Void, SportsNoteError>
                 if let id = selectedGroupID {


### PR DESCRIPTION
## 概要
`BaseViewModelProtocol`には`fetchData()`実行後のエラーハンドリングまで含めた統一メソッド`refresh()`が既に用意されているにもかかわらず、複数のViewが`refresh()`を使わず`let result = await viewModel.fetchData(); if case .failure(let error) = result { viewModel.showErrorAlert(error) }`というパターンを個別に書き下しており、`hideErrorAlert()`の呼び出し漏れという挙動差もありました。

## 変更内容
- `NoteView.swift`: 6箇所全てを`await viewModel.refresh()`に置換
- `GroupView.swift`: `.errorAlert`の`onRetry`クロージャ内1箇所を置換
- `TaskView.swift`: 条件分岐を含まない単純な`fetchData()`パターン2箇所（`refreshAction`内、`.onAppear`内）のみ置換

## スコープ外とした箇所（issue記載時点から実装が変わっていた/共有インスタンスのため）
- `TaskView.swift`の残り4箇所: `fetchTasksByGroupID`との条件分岐に組み込まれている、または`delete`/`toggleCompletion`/`moveTask`等`fetchData`以外のメソッド呼び出しのため、`refresh()`（fetchData専用）には単純に置き換えられませんでした
- `TaskDetailView.swift`の`groupViewModel.fetchData()`: 当初`refresh()`に置換しましたが、クロスレビューで`groupViewModel`が`TaskView`/`GroupView`/`TaskDetailView`の複数画面で共有されるインスタンスであり、`refresh()`内部の`hideErrorAlert()`がタスク詳細画面を開くたびに他画面（グループ編集画面等）の未確認エラー状態を意図せず消してしまう副作用があるとの指摘を受け、元の`fetchData()`直呼び出し＋エラー転送パターンに戻しました

## テスト
- ビルド成功（BUILD SUCCEEDED）
- 全体テストスイート575件中573件成功。残り2件はmainブランチ単体でも失敗する既知の不具合で本PRと無関係
- 独立したサブエージェントによるクロスレビューを実施。should-fix指摘（`TaskDetailView.swift`の共有インスタンス副作用）に対応済み
- View層の変更のためUIテストは未整備（プロジェクトの既存慣行）、手動UI検証は未実施

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)