### PR TITLE
fix: カレンダー画面のノートセルが中央寄せで表示される問題を解消

### DIFF
--- a/SportsNote_iOS/View/Note/Components/NoteRow.swift
+++ b/SportsNote_iOS/View/Note/Components/NoteRow.swift
@@ -41,6 +41,7 @@ struct NoteRow: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 4)
     }
 


### PR DESCRIPTION
## 概要
カレンダー画面（目標画面の日付選択セクション）のノートセルが中央寄せで表示されていた問題を修正しました。

## 原因
`NoteListView.swift`は`List`を使用しており行が自然に幅いっぱいに広がり左寄せになるが、`NoteListSection.swift`（カレンダー画面が使用）は素の`VStack`（デフォルトalignment=`.center`）内で`NoteRow`を表示しており、`NoteRow`のルート`HStack`に幅を固定するmodifierがなかったため内容サイズに応じて中央寄せされていた。

## 変更内容
- `SportsNote_iOS/View/Note/Components/NoteRow.swift`: ルート`HStack`に`.frame(maxWidth: .infinity, alignment: .leading)`を追加し、どのコンテナ（List/VStack）から使われても常に左寄せで表示されるようにした

## テスト
- swift-format実行済み
- ビルド成功（BUILD SUCCEEDED）
- 既存テスト577件中575件成功。失敗した2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`/`associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本変更と無関係のファイル（TaskViewModel関連）であり、直近のPR #152にも「mainブランチ単体でも失敗する既知の不具合」と記録されている既知の問題
- 独立したサブエージェントによるクロスレビュー実施（2ラウンド）。ラウンド1でmust-fix指摘（実装がコミットされていなかった）→コミットし解消。コード内容自体への指摘はなし

## 完了条件
- [x] `NoteRow.swift`のルート`HStack`に`.frame(maxWidth: .infinity, alignment: .leading)`が追加されている
- [x] カレンダー画面（Target画面の日付選択）のノートセルが左寄せで表示される
- [x] ノート一覧画面（`NoteListView`）のノートセルの表示が引き続き左寄せのまま崩れていない
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（上記の既知の無関係な2件を除く）

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)