### PR TITLE
fix: 対策の優先度変更後、既存メモが別の対策に付け替わる問題を解消

### DIFF
--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -354,6 +354,9 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         for (task, reflectionText) in taskReflections {
             let memo = Memo()
             var existingCreatedAt: Date?
+            // 既存メモが元々紐づいていた対策ID。対策の優先度変更後にノートを保存しても、
+            // 既存メモの紐付け対策を上書きしないため（issue #160）
+            var existingMeasuresID: String?
             var isExistingMemo = false
 
             // memoIDの決定ロジック:
@@ -364,8 +367,10 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             if let existingMemoID = task.memoID {
                 memo.memoID = existingMemoID
                 isExistingMemo = true
-                // 既存メモをRealmから取得し、created_atを引き継ぐ
-                existingCreatedAt = (try? realmManager.getObjectById(id: existingMemoID, type: Memo.self))?.created_at
+                // 既存メモをRealmから取得し、created_at・measuresIDを引き継ぐ
+                let existingMemo = try? realmManager.getObjectById(id: existingMemoID, type: Memo.self)
+                existingCreatedAt = existingMemo?.created_at
+                existingMeasuresID = existingMemo?.measuresID
             } else {
                 let existingMemos = realmManager.getMemosByNoteID(noteID: noteID)
                 // task.measuresID（現在の最優先対策のID）だけでなく、taskIDに紐づく
@@ -378,8 +383,9 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 }) {
                     memo.memoID = existingMemo.memoID  // 既存IDを使用
                     isExistingMemo = true
-                    // 検索でヒットした既存メモのcreated_atを引き継ぐ
+                    // 検索でヒットした既存メモのcreated_at・measuresIDを引き継ぐ
                     existingCreatedAt = existingMemo.created_at
+                    existingMeasuresID = existingMemo.measuresID
                 } else {
                     memo.memoID = UUIDGenerator.generateID()  // 新規生成
                 }
@@ -389,7 +395,9 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             // 既存メモを空文字に編集するケースは保存対象とする（issue #105）
             if !isExistingMemo && reflectionText.isEmpty { continue }
 
-            memo.measuresID = task.measuresID
+            // 既存メモを更新する場合は元々紐づいていた対策IDを維持し、
+            // 新規作成時のみ現在の最優先対策IDを採用する（issue #160）
+            memo.measuresID = existingMeasuresID ?? task.measuresID
             memo.noteID = noteID
             memo.detail = reflectionText
             // 既存メモを更新する場合はcreated_atを維持し、新規作成時のみ現在時刻とする

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -737,6 +737,141 @@ struct NoteViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - updateTaskReflections（課題振り返りメモ）の対策付け替え回帰テスト（issue #160）
+
+    @Test("updateTaskReflections - 対策の並び替え後、既存メモのmeasuresIDが現在の最優先対策IDに上書きされず維持される（noteID+measuresID検索経由）")
+    func updateTaskReflections_existingMemoFoundAfterMeasuresReorder_preservesOriginalMeasuresID() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 既存メモは並び替え前の最優先対策(measures-old)に対して作成されたもの
+        let existingMemo = Memo(
+            memoID: "memo-reorder-2",
+            measuresID: "measures-old-2",
+            noteID: "note-reorder-2",
+            detail: "並び替え前の振り返り",
+            created_at: Date().addingTimeInterval(-3600)
+        )
+        try? manager.saveItem(existingMemo)
+
+        // measures-old-2・measures-new-2とも同じtask-reorder-2に属する対策
+        // （並び替え後はmeasures-new-2が最優先=order0になった状態）
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-old-2", taskID: "task-reorder-2", title: "Old", order: 1,
+                created_at: Date()))
+        try? manager.saveItem(
+            Measures(
+                measuresID: "measures-new-2", taskID: "task-reorder-2", title: "New", order: 0,
+                created_at: Date()))
+
+        let viewModel = NoteViewModel()
+        // taskListDataのmeasuresIDは並び替え後の現在の最優先対策(measures-new-2)を指す
+        let task = TaskListData(
+            taskID: "task-reorder-2",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-new-2",
+            measures: "New",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-reorder-2",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "並び替え後の振り返り"]
+        )
+
+        // 既存メモのmeasuresIDが並び替え後の最優先対策(measures-new-2)に上書きされず、
+        // 元々紐づいていた対策(measures-old-2)のまま維持されていること
+        let updatedMemo = try? manager.getObjectById(id: "memo-reorder-2", type: Memo.self)
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.measuresID == "measures-old-2")
+        #expect(updatedMemo?.detail == "並び替え後の振り返り")
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - task.memoIDによる既存メモ編集時も、対策の並び替え後にmeasuresIDが上書きされず維持される")
+    func updateTaskReflections_existingMemoWithMemoID_preservesOriginalMeasuresIDAfterReorder() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 既存メモは並び替え前の最優先対策(measures-old-3)に対して作成されたもの
+        let existingMemo = Memo(
+            memoID: "memo-reorder-3",
+            measuresID: "measures-old-3",
+            noteID: "note-reorder-3",
+            detail: "並び替え前の振り返り",
+            created_at: Date().addingTimeInterval(-3600)
+        )
+        try? manager.saveItem(existingMemo)
+
+        let viewModel = NoteViewModel()
+        // task.memoIDを直接指定するケース（並び替え後の最優先対策はmeasures-new-3）
+        let task = TaskListData(
+            taskID: "task-reorder-3",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-new-3",
+            measures: "New",
+            memoID: "memo-reorder-3",
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-reorder-3",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "並び替え後の振り返り"]
+        )
+
+        let updatedMemo = try? manager.getObjectById(id: "memo-reorder-3", type: Memo.self)
+        #expect(updatedMemo != nil)
+        #expect(updatedMemo?.measuresID == "measures-old-3")
+        #expect(updatedMemo?.detail == "並び替え後の振り返り")
+
+        manager.clearAll()
+    }
+
+    @Test("updateTaskReflections - 新規メモ作成時は引き続き現在の最優先対策IDが正しく設定される（回帰確認）")
+    func updateTaskReflections_newMemo_usesCurrentMostPriorityMeasuresID() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let viewModel = NoteViewModel()
+        let task = TaskListData(
+            taskID: "task-reorder-4",
+            groupID: "group-1",
+            groupColor: .blue,
+            title: "Test Task",
+            measuresID: "measures-new-4",
+            measures: "New",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+
+        viewModel.savePracticeNoteWithReflections(
+            noteID: "note-reorder-4",
+            purpose: "Practice Purpose",
+            detail: "Practice Detail",
+            taskReflections: [task: "新規の振り返り"]
+        )
+
+        let memos = manager.getMemosByNoteID(noteID: "note-reorder-4")
+        #expect(memos.count == 1)
+        #expect(memos.first?.measuresID == "measures-new-4")
+
+        manager.clearAll()
+    }
+
     // MARK: - updateTaskReflections（課題振り返りメモ）の空文字編集テスト（issue #105）
 
     @Test("updateTaskReflections - 既存メモを空文字に編集した場合、Realm上のdetailが空文字に更新される")


### PR DESCRIPTION
## 概要
練習ノートの課題メモが、対策の優先度（並び順）変更後にノートを開いて保存すると、メモの`measuresID`が現在の最優先対策のIDで上書きされ、本来紐付いていた対策とは別の対策に付け替わってしまう不具合を修正しました。`.claude/rules/sportsnote-ios.md`に明記された「対策の優先度を変更してもメモの紐付け対策は保持する」という規約に違反していました。

## 原因
`NoteViewModel.updateTaskReflections`が、既存メモを更新する場合でも`memo.measuresID = task.measuresID`（現在の最優先対策のID）で無条件に上書きしていた。

## 変更内容
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`: `updateTaskReflections`内で、既存メモ取得経路2箇所（`task.memoID`経由・`noteID+measuresID`検索経由）双方で既存メモの`measuresID`を取得し、`memo.measuresID = existingMeasuresID ?? task.measuresID`とすることで、既存メモ更新時は元の対策IDを維持し、新規メモ作成時のみ現在の最優先対策IDを採用するように修正
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`: 回帰テスト3件を追加
  - 既存メモ（noteID+measuresID検索経由）が並び替え後もmeasuresIDを維持することの検証
  - 既存メモ（task.memoID経由）が並び替え後もmeasuresIDを維持することの検証
  - 新規メモ作成時は引き続き現在の最優先対策IDが使われることの回帰確認

## テスト
- swift-format実行済み
- ビルド成功（BUILD SUCCEEDED）
- `NoteViewModelTests` 56件全て成功
- 全体テスト580件中578件成功。失敗2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`/`associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本変更と無関係のファイル（TaskViewModel関連）であり、直近のPR #152・#166にも「mainブランチ単体でも失敗する既知の不具合」と記録されている既知の問題
- 独立したサブエージェントによるクロスレビュー実施（1ラウンド）。レビュアーが修正前ロジックへの一時ロールバック実験を行い、新規テストが実際に失敗する（検知力がある）ことを確認。must-fix指摘なし

## 完了条件
- [x] 既存メモを更新する場合、`memo.measuresID`が元の対策IDのまま維持される（`updateTaskReflections`の修正）
- [x] 再現手順1〜5を実施し、練習ノートAのメモAが対策Bではなく対策Aのメモとして課題詳細画面に表示されることを確認（単体テストで再現・検証）
- [x] 新規メモ作成時は引き続き現在の最優先対策IDが正しく設定される（既存動作の回帰がないこと）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功、および本不具合を再現する単体テストを追加し成功すること

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)