### PR TITLE
fix: 課題一覧の並び替えでドラッグ後に指を離すと元の位置に戻る問題を解消

### DIFF
--- a/SportsNote_iOS/View/Task/TaskView.swift
+++ b/SportsNote_iOS/View/Task/TaskView.swift
@@ -79,9 +79,14 @@ struct TaskView: View {
                             }
                         },
                         onMoveTask: { source, destination in
+                            // 表示上の並び替えは同期的に即座に反映する(issue #161)。
+                            // List.onMoveのタイミングでfilteredTaskListDataが即時更新されないと
+                            // 一瞬元の位置に戻る視覚的な不整合が発生するため、Task{}でラップしない
+                            let mergedTasks = taskViewModel.reorderTaskListData(
+                                from: source, to: destination)
+                            // Realmへの永続化・Firebase同期は非同期で実行
                             Task {
-                                let result = await taskViewModel.moveTask(
-                                    from: source, to: destination)
+                                let result = await taskViewModel.persistTaskOrder(mergedTasks)
                                 if case .failure(let error) = result {
                                     taskViewModel.showErrorAlert(error)
                                 }

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -499,12 +499,14 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
     // MARK: - 並び替え処理
 
-    /// 課題の並び替え
+    /// 表示上の並び替えを同期的に即時反映する（Realm永続化・Firebase同期は含まない）
+    /// List.onMoveハンドラから非同期Taskでラップせず直接呼ぶことで、ドラッグを離した瞬間に
+    /// 並び順が確定するようにするため分離した（issue #161）
     /// - Parameters:
     ///   - source: 移動元のインデックス
     ///   - destination: 移動先のインデックス
-    /// - Returns: Result
-    func moveTask(from source: IndexSet, to destination: Int) async -> Result<Void, SportsNoteError> {
+    /// - Returns: Realm永続化用のマージ済み課題配列（完了課題を含む全件、`persistTaskOrder`に渡す）
+    func reorderTaskListData(from source: IndexSet, to destination: Int) -> [TaskData] {
         // filteredTaskListData上で移動（表示上の並び替え）
         var reordered = filteredTaskListData
         reordered.move(fromOffsets: source, toOffset: destination)
@@ -530,7 +532,13 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                     return task
                 }
             }
+        return mergedTasks
+    }
 
+    /// 並び替え後の課題配列をRealmへ永続化し、Firebaseへバックグラウンド同期する
+    /// - Parameter mergedTasks: `reorderTaskListData`が返す並び替え後の全課題配列
+    /// - Returns: Result
+    func persistTaskOrder(_ mergedTasks: [TaskData]) async -> Result<Void, SportsNoteError> {
         do {
             try RealmManager.shared.updateTaskOrder(tasks: mergedTasks)
 
@@ -549,6 +557,16 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 error, context: "TaskViewModel-moveTask")
             return .failure(sportsNoteError)
         }
+    }
+
+    /// 課題の並び替え（表示反映＋永続化を一括で行う）
+    /// - Parameters:
+    ///   - source: 移動元のインデックス
+    ///   - destination: 移動先のインデックス
+    /// - Returns: Result
+    func moveTask(from source: IndexSet, to destination: Int) async -> Result<Void, SportsNoteError> {
+        let mergedTasks = reorderTaskListData(from: source, to: destination)
+        return await persistTaskOrder(mergedTasks)
     }
 
     // MARK: - Firebase同期処理

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -1312,6 +1312,57 @@ struct TaskViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - reorderTaskListData（表示反映の同期性）テスト（issue #161）
+
+    @Test(
+        "reorderTaskListData - Realmへの永続化を待たずに同期的にfilteredTaskListDataへ反映される"
+    )
+    func reorderTaskListData_synchronouslyUpdatesFilteredTaskListData() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
+        let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: false)
+        let taskC = TaskViewModelTests.createTestTask(id: "C", groupID: "g1", order: 2, isComplete: false)
+        try? manager.saveItem(taskA)
+        try? manager.saveItem(taskB)
+        try? manager.saveItem(taskC)
+
+        _ = await viewModel.fetchData()
+        #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["A", "B", "C"])
+
+        // CをAより前に移動（index2->0）。awaitを挟まず、同期呼び出し直後に
+        // filteredTaskListDataが更新済みであることを確認する
+        // (List.onMoveハンドラから非同期Taskでラップせず直接呼べることの検証、issue #161)
+        let mergedTasks = viewModel.reorderTaskListData(from: IndexSet(integer: 2), to: 0)
+
+        #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A", "B"])
+        #expect(mergedTasks.map { $0.taskID } == ["C", "A", "B"])
+
+        // この時点ではRealmへの永続化（persistTaskOrder）はまだ行われていないため、
+        // Realm上のorderは変化していないはず
+        let tasksBeforePersist = (try? manager.getDataList(clazz: TaskData.self)) ?? []
+        let orderABeforePersist = tasksBeforePersist.first { $0.taskID == "A" }?.order
+        #expect(orderABeforePersist == 0)
+
+        // persistTaskOrderを実行して初めてRealmに反映される
+        let result = await viewModel.persistTaskOrder(mergedTasks)
+        guard case .success = result else {
+            Issue.record("persistTaskOrder failed")
+            manager.clearAll()
+            return
+        }
+
+        let updatedTasks = (try? manager.getDataList(clazz: TaskData.self)) ?? []
+        let orderC = updatedTasks.first { $0.taskID == "C" }?.order
+        let orderA = updatedTasks.first { $0.taskID == "A" }?.order
+        let orderB = updatedTasks.first { $0.taskID == "B" }?.order
+        #expect(orderC == 0 && orderA == 1 && orderB == 2)
+
+        manager.clearAll()
+    }
+
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）
 
     @Test(


### PR DESCRIPTION
## 概要
課題一覧の並び替えモードでドラッグして指を離すと、一瞬元の位置に戻り、並び替えモードの「完了」操作をして初めて意図した並び順が反映される不具合を修正しました。

## 原因
`TaskView.swift`の`onMoveTask`クロージャが`Task { await taskViewModel.moveTask(...) }`と、表示反映・Realm永続化・Firebase同期をすべて含む処理を非同期Taskでラップしていた。これにより`filteredTaskListData`への反映が次のランループにずれ、SwiftUIの`List`が`.onMove`完了時点で期待する即時のデータ反映に間に合わず、ドラッグを離した瞬間に一瞬元の位置へ戻る視覚的な不整合が発生していた。

## 変更内容
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`: `moveTask(from:to:)`を以下の2関数に分割
  - `reorderTaskListData(from:to:) -> [TaskData]`（同期、表示上の並び替えを即時反映しRealm永続化用の配列を返す）
  - `persistTaskOrder(_:) async -> Result<Void, SportsNoteError>`（非同期、Realm永続化＋Firebase同期）
  - 既存の`moveTask(from:to:) async`は両者を順に呼ぶ後方互換ラッパーとして維持し、既存テストとの互換性を保持
- `SportsNote_iOS/View/Task/TaskView.swift`: `onMoveTask`クロージャで`reorderTaskListData`をTask{}の外で同期的に呼び、`persistTaskOrder`のみ非同期Task内で呼ぶように変更
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`: `reorderTaskListData`がRealmへの永続化を待たずに同期的に`filteredTaskListData`へ反映されることを検証する回帰テストを追加

## テスト
- swift-format実行済み
- ビルド成功（BUILD SUCCEEDED）
- `TaskViewModelTests` 50件中48件成功。失敗2件（`associateTasksWithMemos_sortsResultByTaskOrder`/`associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本変更と無関係のロジック（Memo紐付けのソート順）であり、直近のPR #152・#166・#167にも「mainブランチ単体でも失敗する既知の不具合」と記録されている既知の問題
- 全体テスト578件中576件成功（同じ2件のみ失敗）
- 独立したサブエージェントによるクロスレビュー実施（1ラウンド）。must-fix指摘なし。should-fix所見として、`GroupView.swift`の`onMoveGroup`にも同型のパターンがあり将来の横展開候補となる旨の記録あり（本PRのスコープ外）

## 完了条件
- [x] `List.onMove`で並び替え後の配列反映が同期的に行われ、非同期処理（Realm書き込み・Firebase同期）と分離されている
- [ ] シミュレータでドラッグ&ドロップし、指を離した時点で意図した並び順が即座に反映され、元の位置に戻らないことを確認（無人フロー実行のため実機/シミュレータでの目視確認は未実施。コードレベルでは根本原因を解消する設計としてクロスレビューで妥当性を確認済み。マージ前に目視確認を推奨）
- [x] 並び替えモードの「完了」操作後も同じ並び順が維持されていることを確認（`persistTaskOrder`がRealmへ永続化するロジック自体は変更していないため、既存の`moveTask`テスト3件で担保）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（上記の既知の無関係な2件を除く）

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)