### PR TITLE
fix: associateTasksWithMemosの新規テスト2件がMeasures未保存で常に失敗する不備を修正

### DIFF
--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -628,6 +628,9 @@ struct TaskViewModelTests {
 
     @Test("associateTasksWithMemos - 戻り値がtask.order昇順にソートされる（issue #137: Dictionary列挙順への依存を排除）")
     func associateTasksWithMemos_sortsResultByTaskOrder() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
         let viewModel = TaskViewModel()
         // orderが降順になるように課題を用意し、Dictionary経由でも意図した順序に
         // 並び替えられることを確認する
@@ -666,6 +669,15 @@ struct TaskViewModelTests {
         )
         viewModel.taskListData = [task1, task2, task3]
 
+        // associateTasksWithMemosはmemo.measuresIDに対応するMeasuresの実在確認を行うため、
+        // Realmに保存しておく必要がある（issue #162: 未保存のため常に空配列になっていた不備の修正）
+        try? manager.saveItem(
+            Measures(measuresID: "measures-1", taskID: "task-1", title: "Measures 1", order: 2, created_at: Date()))
+        try? manager.saveItem(
+            Measures(measuresID: "measures-2", taskID: "task-2", title: "Measures 2", order: 0, created_at: Date()))
+        try? manager.saveItem(
+            Measures(measuresID: "measures-3", taskID: "task-3", title: "Measures 3", order: 1, created_at: Date()))
+
         let memo1 = Memo(
             memoID: "memo-1", measuresID: "measures-1", noteID: "note-1", detail: "1", created_at: Date())
         let memo2 = Memo(
@@ -676,12 +688,17 @@ struct TaskViewModelTests {
         let pairs = viewModel.associateTasksWithMemos(memos: [memo1, memo2, memo3])
 
         #expect(pairs.map { $0.task.taskID } == ["task-2", "task-3", "task-1"])
+
+        manager.clearAll()
     }
 
     @Test(
         "associateTasksWithMemos - orderが同値の課題はtaskID昇順でタイブレークされる（異なるグループの課題がorder同値になるケース）"
     )
     func associateTasksWithMemos_sameOrderTiesBreakByTaskID() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
         let viewModel = TaskViewModel()
         // 異なるグループの課題はグループ内スコープでorderが採番されるため、
         // order=0同士が複数存在しうる
@@ -709,6 +726,13 @@ struct TaskViewModelTests {
         )
         viewModel.taskListData = [taskB, taskA]
 
+        // associateTasksWithMemosはmemo.measuresIDに対応するMeasuresの実在確認を行うため、
+        // Realmに保存しておく必要がある（issue #162: 未保存のため常に空配列になっていた不備の修正）
+        try? manager.saveItem(
+            Measures(measuresID: "measures-b", taskID: "task-b", title: "Measures B", order: 0, created_at: Date()))
+        try? manager.saveItem(
+            Measures(measuresID: "measures-a", taskID: "task-a", title: "Measures A", order: 0, created_at: Date()))
+
         let memoB = Memo(
             memoID: "memo-b", measuresID: "measures-b", noteID: "note-1", detail: "B", created_at: Date())
         let memoA = Memo(
@@ -717,6 +741,8 @@ struct TaskViewModelTests {
         let pairs = viewModel.associateTasksWithMemos(memos: [memoB, memoA])
 
         #expect(pairs.map { $0.task.taskID } == ["task-a", "task-b"])
+
+        manager.clearAll()
     }
 
     // MARK: - エラーハンドリングテスト


### PR DESCRIPTION
## 概要
`TaskViewModelTests.swift`の`associateTasksWithMemos`関連テスト2件（issue #137対応時に追加）が、Realmに`Measures`オブジェクトを保存しないまま`associateTasksWithMemos`を呼び出していたため、プロダクトコードの正誤に関わらず常に失敗していた不備を修正しました。

Closes #162

## 変更内容
`TaskViewModel.associateTasksWithMemos`は各`memo.measuresID`に対して`RealmManager.shared.getObjectById(id:type:)`でMeasuresの実在確認を行い、取得できなければ`continue`でスキップします。以下2テストはMeasuresをRealmへ保存せずにメモだけを作成していたため、必ず空配列が返り常に失敗していました。

- `associateTasksWithMemos_sortsResultByTaskOrder`
- `associateTasksWithMemos_sameOrderTiesBreakByTaskID`

既存の模範パターン（`associateTasksWithMemos_multipleTasksAndMemos`）と同様に、両テストの冒頭・末尾で`RealmManager.shared.clearAll()`を呼び、各メモに対応する`Measures`オブジェクトを`saveItem`で保存してから`associateTasksWithMemos`を呼び出すように修正しました。

`TaskViewModel.associateTasksWithMemos`本体のロジック変更、他のテスト関数の変更は行っていません（テストファイルのみの修正）。

## 変更ファイル一覧
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`

## ビルド・テスト結果
- swift-format実行済み
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test`（フルスイート） → 581 tests in 30 suites 全成功
- `xcodebuild test -only-testing:SportsNote_iOSTests/TaskViewModelTests` → 対象2テストを含む50件全成功

## 完了条件
- [x] `associateTasksWithMemos_sortsResultByTaskOrder`・`associateTasksWithMemos_sameOrderTiesBreakByTaskID`の両テストが、対応するMeasuresオブジェクトをRealmに保存したうえで実行され、期待通りの並び順で成功すること
- [x] `xcodebuild test -only-testing:SportsNote_iOSTests/TaskViewModelTests`が全件成功すること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（フルスイート回帰なし）

## クロスレビュー
独立コンテキストのAgentによるクロスレビューを実施（1ラウンド）。must-fix/should-fix指摘なし、合格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
