### PR TITLE
fix: 6ViewModelのdelete(id:)がperformBackgroundSyncを不要なTaskでラップしていた非対称性を解消

### DIFF
--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -168,9 +168,7 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
 
             // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
             if let groupToDelete = groupToDelete {
-                Task {
-                    performBackgroundSync(groupToDelete, isUpdate: true)
-                }
+                performBackgroundSync(groupToDelete, isUpdate: true)
             }
 
             // UI更新

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -172,9 +172,7 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
 
             // 3. Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
             if let measuresToDelete = measuresToDelete {
-                Task {
-                    performBackgroundSync(measuresToDelete, isUpdate: true)
-                }
+                performBackgroundSync(measuresToDelete, isUpdate: true)
             }
 
             // 4. UI更新

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -99,9 +99,7 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
             // Firebase同期はバックグラウンドで実行（論理削除なので更新として扱う）
             if let memo = memoToDelete {
-                Task {
-                    performBackgroundSync(memo, isUpdate: true)
-                }
+                performBackgroundSync(memo, isUpdate: true)
             }
 
             // UI更新 - 配列から削除

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -523,9 +523,7 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
             // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
             if isOnlineAndLoggedIn, let noteToDelete = noteToDelete {
-                Task {
-                    performBackgroundSync(noteToDelete, isUpdate: true)
-                }
+                performBackgroundSync(noteToDelete, isUpdate: true)
             }
 
             // UI更新

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -198,9 +198,7 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
 
             // Firebase同期はバックグラウンドで実行（論理削除なので更新として扱う）
             if let target = targetToDelete {
-                Task {
-                    performBackgroundSync(target, isUpdate: true)
-                }
+                performBackgroundSync(target, isUpdate: true)
             }
 
             // UI更新 - 配列から削除

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -291,9 +291,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
             // 3. Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
             if let taskToDelete = taskToDelete {
-                Task {
-                    performBackgroundSync(taskToDelete, isUpdate: true)
-                }
+                performBackgroundSync(taskToDelete, isUpdate: true)
             }
 
             // 4. UI更新

--- a/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
@@ -425,6 +425,38 @@ struct GroupViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "delete - performBackgroundSyncが直接呼ばれ、戻り値を返す前にBackgroundSyncTrackerへ登録される（issue #164回帰）"
+    )
+    func delete_registersBackgroundSyncTaskBeforeReturning() async {
+        let viewModel = GroupViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 他テストの追跡Taskが残っていないことを保証
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        let group1 = Group(
+            groupID: "g1", title: "Group 1", color: GroupColor.red.rawValue, order: 0, created_at: Date())
+        let group2 = Group(
+            groupID: "g2", title: "Group 2", color: GroupColor.blue.rawValue, order: 1, created_at: Date())
+        try? manager.saveItem(group1)
+        try? manager.saveItem(group2)
+        _ = await viewModel.fetchData()
+
+        _ = await viewModel.delete(id: "g1")
+
+        // delete(id:)から戻った直後（追加のawait/yieldを挟まない）時点でperformBackgroundSyncが
+        // 直接（同期的に）呼ばれていればtrack()は既に完了している。外側Task{}でラップされていると
+        // この時点ではまだ登録されておらず0のままになる（issue #164のシナリオを再現する回帰テスト）
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 1)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+
+        manager.clearAll()
+    }
+
     @Test("saveGroup - 既存インターフェースでグループを保存できる")
     func saveGroup_savesWithLegacyInterface() async {
         let viewModel = GroupViewModel()

--- a/SportsNote_iOSTests/ViewModels/MeasuresViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/MeasuresViewModelTests.swift
@@ -344,6 +344,34 @@ struct MeasuresViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "delete - performBackgroundSyncが直接呼ばれ、戻り値を返す前にBackgroundSyncTrackerへ登録される（issue #164回帰）"
+    )
+    func delete_registersBackgroundSyncTaskBeforeReturning() async {
+        let viewModel = MeasuresViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 他テストの追跡Taskが残っていないことを保証
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        let measures = Measures(measuresID: "ms1", taskID: "t1", title: "Measures", order: 0, created_at: Date())
+        try? manager.saveItem(measures)
+        _ = await viewModel.fetchData()
+
+        _ = await viewModel.delete(id: "ms1")
+
+        // delete(id:)から戻った直後（追加のawait/yieldを挟まない）時点でperformBackgroundSyncが
+        // 直接（同期的に）呼ばれていればtrack()は既に完了している。外側Task{}でラップされていると
+        // この時点ではまだ登録されておらず0のままになる（issue #164のシナリオを再現する回帰テスト）
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 1)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+
+        manager.clearAll()
+    }
+
     @Test("getMeasuresByTaskID - 課題IDに紐づく対策を取得できる")
     func getMeasuresByTaskID_retrievesMeasures() async {
         let viewModel = MeasuresViewModel()

--- a/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
@@ -397,6 +397,34 @@ struct MemoViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "delete - performBackgroundSyncが直接呼ばれ、戻り値を返す前にBackgroundSyncTrackerへ登録される（issue #164回帰）"
+    )
+    func delete_registersBackgroundSyncTaskBeforeReturning() async {
+        let viewModel = MemoViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 他テストの追跡Taskが残っていないことを保証
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        let memo = Memo(memoID: "m1", measuresID: "ms1", noteID: "n1", detail: "Detail", created_at: Date())
+        try? manager.saveItem(memo)
+        _ = await viewModel.fetchData()
+
+        _ = await viewModel.delete(id: "m1")
+
+        // delete(id:)から戻った直後（追加のawait/yieldを挟まない）時点でperformBackgroundSyncが
+        // 直接（同期的に）呼ばれていればtrack()は既に完了している。外側Task{}でラップされていると
+        // この時点ではまだ登録されておらず0のままになる（issue #164のシナリオを再現する回帰テスト）
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 1)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+
+        manager.clearAll()
+    }
+
     @Test("getMemosByMeasuresID - 対策IDに紐づくメモを取得できる")
     func getMemosByMeasuresID_retrievesMemos() async {
         let viewModel = MemoViewModel()

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -391,6 +391,17 @@ struct NoteViewModelTests {
         manager.clearAll()
     }
 
+    // NOTE(issue #164): NoteViewModel.delete(id:)は他5ViewModelと異なり
+    // `if isOnlineAndLoggedIn, let noteToDelete = noteToDelete { performBackgroundSync(...) }`と
+    // 呼び出しサイトにオンライン/ログイン判定を持つ。テスト環境ではRealmManager.testConfiguration
+    // が設定されておりisOnlineAndLoggedInは常にfalseを返すため、performBackgroundSync自体が
+    // 呼ばれずBackgroundSyncTracker.shared.trackedCountForTestingで直接呼び出しを検証できない
+    // （修正の有無にかかわらず常に0のまま）。そのため他5ViewModel
+    // （Group/Measures/Memo/Task/Target）で追加した
+    // delete_registersBackgroundSyncTaskBeforeReturningと同型の回帰テストはここには追加せず、
+    // 上記delete_deletesNoteの成功と、実装が他5ViewModelと機械的に同一パターン
+    // （外側Task{}を除去しperformBackgroundSyncを直接呼び出す）であることのコードレビューで担保する。
+
     @Test("delete - フリーノートは削除できない")
     func delete_cannotDeleteFreeNote() async {
         let viewModel = NoteViewModel()

--- a/SportsNote_iOSTests/ViewModels/TargetViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TargetViewModelTests.swift
@@ -414,6 +414,34 @@ struct TargetViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "delete - performBackgroundSyncが直接呼ばれ、戻り値を返す前にBackgroundSyncTrackerへ登録される（issue #164回帰）"
+    )
+    func delete_registersBackgroundSyncTaskBeforeReturning() async {
+        let viewModel = TargetViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 他テストの追跡Taskが残っていないことを保証
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        let target = Target(title: "Target", year: 2024, month: 11, isYearlyTarget: false)
+        try? manager.saveItem(target)
+        _ = await viewModel.fetchTargetsByYearMonth(year: 2024, month: 11)
+
+        _ = await viewModel.delete(id: target.targetID)
+
+        // delete(id:)から戻った直後（追加のawait/yieldを挟まない）時点でperformBackgroundSyncが
+        // 直接（同期的に）呼ばれていればtrack()は既に完了している。外側Task{}でラップされていると
+        // この時点ではまだ登録されておらず0のままになる（issue #164のシナリオを再現する回帰テスト）
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 1)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+
+        manager.clearAll()
+    }
+
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）
 
     @Test(

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -960,6 +960,35 @@ struct TaskViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "delete - performBackgroundSyncが直接呼ばれ、戻り値を返す前にBackgroundSyncTrackerへ登録される（issue #164回帰）"
+    )
+    func delete_registersBackgroundSyncTaskBeforeReturning() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 他テストの追跡Taskが残っていないことを保証
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        let task = TaskData(
+            taskID: "t1", title: "Task", cause: "Cause", groupID: "g1", order: 0, isComplete: false, created_at: Date())
+        try? manager.saveItem(task)
+        _ = await viewModel.fetchData()
+
+        _ = await viewModel.delete(id: "t1")
+
+        // delete(id:)から戻った直後（追加のawait/yieldを挟まない）時点でperformBackgroundSyncが
+        // 直接（同期的に）呼ばれていればtrack()は既に完了している。外側Task{}でラップされていると
+        // この時点ではまだ登録されておらず0のままになる（issue #164のシナリオを再現する回帰テスト）
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 1)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+
+        manager.clearAll()
+    }
+
     // MARK: - TaskViewModel特有機能テスト
 
     @Test("toggleTaskCompletion - 課題の完了状態を切り替えられる")


### PR DESCRIPTION
## 概要
`GroupViewModel`・`MeasuresViewModel`・`MemoViewModel`・`TaskViewModel`・`TargetViewModel`・`NoteViewModel`の6ViewModelすべてで、`delete(id:)`が`performBackgroundSync(...)`を不要な外側`Task { }`でラップして呼び出していました。`save()`/`update()`系はこれを直接（同期的に）呼び出しているのと非対称であり、削除直後にログアウト/アカウント削除を行うと、`BackgroundSyncTracker.shared.track(task)`が呼ばれる前に`waitForAll()`→`clearAll()`が実行され、削除の同期Taskが追跡対象から漏れうる状態でした（issue #84が対策した問題の削除限定での再発リスク）。

Closes #164

## 変更内容
6ファイルすべての`delete(id:)`内で、`Task { performBackgroundSync(xxxToDelete, isUpdate: true) }`という外側`Task`ラップを除去し、`save()`/`update()`系と同様に`performBackgroundSync(xxxToDelete, isUpdate: true)`を直接呼び出す形に統一しました（`if let`のnilチェック自体は維持）。これにより`BackgroundSyncTracker.shared.track(task)`は`delete(id:)`の呼び出し元へ制御が戻る前に必ず完了します。

`performBackgroundSync`自体・`BackgroundSyncTracker`の実装、`save()`/`update()`系の実装は変更していません。

### NoteViewModelについて
`NoteViewModel.delete(id:)`のみ、呼び出しサイトが`if isOnlineAndLoggedIn, let noteToDelete = noteToDelete { ... }`という他5ファイルにはない追加のオンライン/ログイン判定を持っています。この条件自体は今回のissueのスコープ外のため変更していません。テスト環境では`isOnlineAndLoggedIn`が常に`false`を返す設計（`RealmManager.shared.testConfiguration != nil`時）のため、NoteViewModelでは`performBackgroundSync`自体がテスト内で呼ばれず、他5ViewModelに追加したのと同型の回帰テストを追加できません。`NoteViewModelTests.swift`にコメントで理由を明記し、既存の`delete_deletesNote`テストとコードレビューでの担保としました。

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`
- `SportsNote_iOS/ViewModel/MeasuresViewModel.swift`
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOS/ViewModel/TargetViewModel.swift`
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`
- `SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift`（回帰テスト追加）
- `SportsNote_iOSTests/ViewModels/MeasuresViewModelTests.swift`（回帰テスト追加）
- `SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift`（回帰テスト追加）
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`（回帰テスト追加）
- `SportsNote_iOSTests/ViewModels/TargetViewModelTests.swift`（回帰テスト追加）
- `SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift`（コメントのみ追加）

## ビルド・テスト結果
- swift-format実行済み
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test`（フルスイート） → 586 tests中584件成功。失敗2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`・`associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本PRの変更と無関係の既知の不具合（issue #162として起票済み、修正PR #170作成済み・未マージ）
- 新規回帰テスト5件（Group/Measures/Memo/Task/Target）はすべて成功。クロスレビューにて`performBackgroundSync`を再度`Task {}`でラップするロールバック実験を行い、期待通り検知に失敗する（テストが正しくFAILする）ことを確認済み

## 完了条件
- [x] 6ViewModelすべての`delete(id:)`で`performBackgroundSync`が外側Taskでラップされず直接呼び出されている
- [x] `BackgroundSyncTracker.shared.track(task)`が`delete(id:)`の呼び出し元へ制御が戻る前に必ず完了していることを検証する単体テストを追加（5件、NoteViewModelは上記理由によりコード比較で担保）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（無関係の既知failure2件を除く）、および本不具合を再現・検証する単体テストを追加し成功すること

## クロスレビュー
独立コンテキストのAgentによるクロスレビューを実施（1ラウンド）。must-fix/should-fix指摘なし、合格。NoteViewModelの判断妥当性についてもロールバック実験を含めて独立検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
