### PR TITLE
fix: 課題詳細画面の対策並び替えでドラッグ後に指を離すと元の位置に戻る不具合を修正

### DIFF
--- a/SportsNote_iOS/View/Task/Components/MeasuresList.swift
+++ b/SportsNote_iOS/View/Task/Components/MeasuresList.swift
@@ -15,17 +15,17 @@ struct MeasuresListView: View {
                     .foregroundColor(.gray)
                     .italic()
             } else {
-                ForEach(detail.measuresList.indices, id: \.self) { index in
+                ForEach(detail.measuresList, id: \.measuresID) { measure in
                     NavigationLink(
                         destination: MeasureDetailView(
-                            measure: detail.measuresList[index],
+                            measure: measure,
                             measuresViewModel: measuresViewModel,
                             memoViewModel: memoViewModel,
                             noteViewModel: noteViewModel
                         )
                     ) {
                         HStack {
-                            Text(detail.measuresList[index].title)
+                            Text(measure.title)
                                 .font(.body)
                                 .lineLimit(2)
                                 .padding(.vertical, 4)
@@ -35,10 +35,16 @@ struct MeasuresListView: View {
                 }
                 .onMove { source, destination in
                     if isReorderingMeasures {
-                        var updatedMeasures = detail.measuresList
-                        updatedMeasures.move(fromOffsets: source, toOffset: destination)
+                        // 表示上の並び替えは同期的に即座に反映する（issue #165、issue #161と同パターン）。
+                        // Task{}でラップすると一瞬元の位置に戻る視覚的不整合が発生するため直接呼ぶ
+                        guard let reordered = viewModel.reorderMeasuresListData(from: source, to: destination) else {
+                            return
+                        }
                         Task {
-                            _ = await viewModel.updateMeasuresOrder(measures: updatedMeasures)
+                            let result = await viewModel.persistMeasuresOrder(reordered)
+                            if case .failure(let error) = result {
+                                viewModel.showErrorAlert(error)
+                            }
                         }
                     }
                 }

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -472,10 +472,25 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         return measuresList.min { $0.order < $1.order }
     }
 
-    /// 対策の並び順を更新（MeasuresViewModelへの委譲メソッド）
-    /// - Parameter measures: 並び替え後の対策リスト
+    /// 対策表示上の並び替えを同期的に即時反映する（Realm永続化・Firebase同期は含まない）
+    /// MeasuresListView.onMoveハンドラから非同期Taskでラップせず直接呼ぶことで、ドラッグを離した瞬間に
+    /// 並び順が確定するようにするため分離した（issue #165、issue #161のreorderTaskListDataと同パターン）
+    /// - Parameters:
+    ///   - source: 移動元のインデックス
+    ///   - destination: 移動先のインデックス
+    /// - Returns: Realm永続化用の並び替え後の対策配列（`persistMeasuresOrder`に渡す）。taskDetail未取得時はnil
+    func reorderMeasuresListData(from source: IndexSet, to destination: Int) -> [Measures]? {
+        guard var detail = taskDetail else { return nil }
+        detail.measuresList.move(fromOffsets: source, toOffset: destination)
+        taskDetail = detail
+        return detail.measuresList
+    }
+
+    /// 並び替え後の対策配列をRealmへ永続化し、課題詳細を再取得して整合させる
+    /// （Realm保存・Firebase同期自体はMeasuresViewModel.updateMeasuresOrderに委譲、ロジックは変更しない）
+    /// - Parameter measures: `reorderMeasuresListData`が返す並び替え後の対策配列
     /// - Returns: Result
-    func updateMeasuresOrder(measures: [Measures]) async -> Result<Void, SportsNoteError> {
+    func persistMeasuresOrder(_ measures: [Measures]) async -> Result<Void, SportsNoteError> {
         guard !measures.isEmpty else {
             return .success(())
         }
@@ -495,6 +510,18 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         }
 
         return .success(())
+    }
+
+    /// 対策の並び替え（表示反映＋永続化を一括で行う）。moveTaskと対になる統合テスト用の便利メソッド
+    /// - Parameters:
+    ///   - source: 移動元のインデックス
+    ///   - destination: 移動先のインデックス
+    /// - Returns: Result
+    func moveMeasures(from source: IndexSet, to destination: Int) async -> Result<Void, SportsNoteError> {
+        guard let reordered = reorderMeasuresListData(from: source, to: destination) else {
+            return .success(())
+        }
+        return await persistMeasuresOrder(reordered)
     }
 
     // MARK: - 並び替え処理

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -1363,6 +1363,149 @@ struct TaskViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - reorderMeasuresListData / persistMeasuresOrder（対策並び替えの同期性）テスト（issue #165）
+
+    @Test(
+        "reorderMeasuresListData - Realmへの永続化を待たずに同期的にtaskDetail.measuresListへ反映される"
+    )
+    func reorderMeasuresListData_synchronouslyUpdatesTaskDetailMeasuresList() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let task = TaskViewModelTests.createTestTask(id: "task-1", groupID: "g1", order: 0)
+        try? manager.saveItem(task)
+        let measuresA = TaskViewModelTests.createTestMeasures(
+            id: "m-A", taskID: "task-1", title: "A", order: 0)
+        let measuresB = TaskViewModelTests.createTestMeasures(
+            id: "m-B", taskID: "task-1", title: "B", order: 1)
+        let measuresC = TaskViewModelTests.createTestMeasures(
+            id: "m-C", taskID: "task-1", title: "C", order: 2)
+        try? manager.saveItem(measuresA)
+        try? manager.saveItem(measuresB)
+        try? manager.saveItem(measuresC)
+
+        _ = await viewModel.fetchTaskDetail(taskID: "task-1")
+        #expect(viewModel.taskDetail?.measuresList.map { $0.measuresID } == ["m-A", "m-B", "m-C"])
+
+        // CをAより前に移動（index2->0）。awaitを挟まず、同期呼び出し直後に
+        // taskDetail.measuresListが更新済みであることを確認する
+        // (MeasuresListView.onMoveハンドラから非同期Taskでラップせず直接呼べることの検証、issue #165)
+        let reordered = viewModel.reorderMeasuresListData(from: IndexSet(integer: 2), to: 0)
+
+        #expect(viewModel.taskDetail?.measuresList.map { $0.measuresID } == ["m-C", "m-A", "m-B"])
+        #expect(reordered?.map { $0.measuresID } == ["m-C", "m-A", "m-B"])
+
+        // この時点ではRealmへの永続化（persistMeasuresOrder）はまだ行われていないため、
+        // Realm上のorderは変化していないはず
+        let measuresBeforePersist = manager.getMeasuresByTaskID(taskID: "task-1")
+        let orderABeforePersist = measuresBeforePersist.first { $0.measuresID == "m-A" }?.order
+        #expect(orderABeforePersist == 0)
+
+        manager.clearAll()
+    }
+
+    @Test(
+        "persistMeasuresOrder - Realmのorderへ反映後、fetchTaskDetail再取得でも同じ並び順を維持する"
+    )
+    func persistMeasuresOrder_updatesRealmOrderAndRefetchesTaskDetail() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let task = TaskViewModelTests.createTestTask(id: "task-1", groupID: "g1", order: 0)
+        try? manager.saveItem(task)
+        let measuresA = TaskViewModelTests.createTestMeasures(
+            id: "m-A", taskID: "task-1", title: "A", order: 0)
+        let measuresB = TaskViewModelTests.createTestMeasures(
+            id: "m-B", taskID: "task-1", title: "B", order: 1)
+        let measuresC = TaskViewModelTests.createTestMeasures(
+            id: "m-C", taskID: "task-1", title: "C", order: 2)
+        try? manager.saveItem(measuresA)
+        try? manager.saveItem(measuresB)
+        try? manager.saveItem(measuresC)
+
+        _ = await viewModel.fetchTaskDetail(taskID: "task-1")
+        guard let reordered = viewModel.reorderMeasuresListData(from: IndexSet(integer: 2), to: 0) else {
+            Issue.record("reorderMeasuresListData returned nil")
+            manager.clearAll()
+            return
+        }
+
+        let result = await viewModel.persistMeasuresOrder(reordered)
+        guard case .success = result else {
+            Issue.record("persistMeasuresOrder failed")
+            manager.clearAll()
+            return
+        }
+
+        let updatedMeasures = manager.getMeasuresByTaskID(taskID: "task-1")
+        let orderC = updatedMeasures.first { $0.measuresID == "m-C" }?.order
+        let orderA = updatedMeasures.first { $0.measuresID == "m-A" }?.order
+        let orderB = updatedMeasures.first { $0.measuresID == "m-B" }?.order
+        #expect(orderC == 0 && orderA == 1 && orderB == 2)
+
+        // fetchTaskDetailによる再取得後も、ドラッグ確定時に反映した並び順から変化しない
+        // （＝一旦元の位置に戻ってから正しい位置に変わるスナップバックが発生しない）ことを確認
+        #expect(viewModel.taskDetail?.measuresList.map { $0.measuresID } == ["m-C", "m-A", "m-B"])
+
+        manager.clearAll()
+    }
+
+    @Test("reorderMeasuresListData - taskDetailがnilの場合はnilを返しクラッシュしない")
+    func reorderMeasuresListData_withNilTaskDetail_returnsNil() async {
+        let viewModel = TaskViewModel()
+        RealmManager.shared.clearAll()
+
+        #expect(viewModel.taskDetail == nil)
+        let reordered = viewModel.reorderMeasuresListData(from: IndexSet(integer: 0), to: 1)
+        #expect(reordered == nil)
+    }
+
+    @Test("persistMeasuresOrder - 空配列を渡した場合は即座に成功を返す")
+    func persistMeasuresOrder_withEmptyArray_returnsSuccessWithoutCallingMeasuresViewModel() async {
+        let viewModel = TaskViewModel()
+        RealmManager.shared.clearAll()
+
+        let result = await viewModel.persistMeasuresOrder([])
+        guard case .success = result else {
+            Issue.record("persistMeasuresOrder with empty array should succeed immediately")
+            return
+        }
+    }
+
+    @Test("moveMeasures - 表示反映と永続化を一括で行いRealmへ反映される")
+    func moveMeasures_reordersAndPersists() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let task = TaskViewModelTests.createTestTask(id: "task-1", groupID: "g1", order: 0)
+        try? manager.saveItem(task)
+        let measuresA = TaskViewModelTests.createTestMeasures(
+            id: "m-A", taskID: "task-1", title: "A", order: 0)
+        let measuresB = TaskViewModelTests.createTestMeasures(
+            id: "m-B", taskID: "task-1", title: "B", order: 1)
+        try? manager.saveItem(measuresA)
+        try? manager.saveItem(measuresB)
+
+        _ = await viewModel.fetchTaskDetail(taskID: "task-1")
+
+        let result = await viewModel.moveMeasures(from: IndexSet(integer: 1), to: 0)
+        guard case .success = result else {
+            Issue.record("moveMeasures failed")
+            manager.clearAll()
+            return
+        }
+
+        let updatedMeasures = manager.getMeasuresByTaskID(taskID: "task-1")
+        let orderA = updatedMeasures.first { $0.measuresID == "m-A" }?.order
+        let orderB = updatedMeasures.first { $0.measuresID == "m-B" }?.order
+        #expect(orderB == 0 && orderA == 1)
+
+        manager.clearAll()
+    }
+
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）
 
     @Test(
@@ -1426,6 +1569,24 @@ extension TaskViewModelTests {
             memoID: nil,
             order: order,
             isComplete: isComplete
+        )
+    }
+
+    /// テスト用のMeasuresを作成
+    static func createTestMeasures(
+        id: String = "measures-1",
+        taskID: String = "task-1",
+        title: String = "Test Measures",
+        order: Int = 0,
+        isDeleted: Bool = false
+    ) -> Measures {
+        return Measures(
+            measuresID: id,
+            taskID: taskID,
+            title: title,
+            order: order,
+            created_at: Date(),
+            isDeleted: isDeleted
         )
     }
 


### PR DESCRIPTION
## 概要
課題詳細画面（`TaskDetailView`）の対策（Measures）並び替えで、ドラッグして指を離すと一旦元の位置に戻り、非同期のRealm更新・再取得が完了して初めて意図した並び順が反映される不具合を修正した。issue #161（課題一覧の並び替え）と同じクラスの不具合が対策の並び替えには未修正のまま残っていたため、同じ設計パターンを適用した。

`TaskViewModel.updateMeasuresOrder(measures:)`を以下2つの関数に分割:
- `reorderMeasuresListData(from:to:) -> [Measures]?`: `taskDetail.measuresList`を同期的に並び替えて即時反映（Realm未使用）
- `persistMeasuresOrder(_:) async -> Result<Void, SportsNoteError>`: 旧`updateMeasuresOrder`のロジックそのまま（Realm永続化＋再取得）
- 統合用の`moveMeasures(from:to:) async`も追加（`moveTask`と対になるテスト用便利メソッド）

`MeasuresListView.onMove`を、`reorderMeasuresListData`をTask{}の外で同期呼び出しし、`persistMeasuresOrder`のみをTask{}内で非同期呼び出しする形に変更。`ForEach`の識別子もindexベース（`indices, id: \.self`）からmeasuresIDベース（`id: \.measuresID`）に変更した。

Closes #165

## 変更ファイル
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOS/View/Task/Components/MeasuresList.swift`
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test`（TaskViewModelTests）→ 55件中53件成功。新規追加5件（`reorderMeasuresListData_synchronouslyUpdatesTaskDetailMeasuresList`等）はすべて成功。失敗2件（`associateTasksWithMemos_sortsResultByTaskOrder`・`associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本PRと無関係な既知の不具合（issue #162、対応中PR #170）

## 完了条件チェックリスト
- [x] `MeasuresListView`の対策並び替えで、ドラッグ後の配列反映が同期的に行われ、非同期処理（Realm書き込み・再取得）と分離されている
- [x] `ForEach`が`measuresID`ベースの識別子を使っている
- [x] シミュレータでの目視確認は無人フロー実行のため省略（回帰テストで同期呼び出し直後の反映を検証）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（issue #162関連の既知の無関係な2件を除く）

## クロスレビュー
独立コンテキストによるクロスレビュー1ラウンドで指摘なし合格（コミット実在・ビルド・テストを独自実行して検証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)