### PR TITLE
fix: グループ一覧の並び替えでドラッグ後に指を離すと元の位置に戻る不具合を修正

### DIFF
--- a/SportsNote_iOS/View/Group/GroupView.swift
+++ b/SportsNote_iOS/View/Group/GroupView.swift
@@ -30,8 +30,11 @@ struct GroupView: View {
                 selectedColor = group.groupColor
             },
             onMoveGroup: { source, destination in
+                // 表示上の並び替えは同期的に即座に反映する（issue #169、issue #161と同パターン）。
+                // Task{}でラップすると一瞬元の位置に戻る視覚的不整合が発生するため直接呼ぶ
+                let reorderedGroups = viewModel.reorderGroups(from: source, to: destination)
                 Task {
-                    let result = await viewModel.moveGroup(from: source, to: destination)
+                    let result = await viewModel.persistGroupOrder(reorderedGroups)
                     if case .failure(let error) = result {
                         viewModel.showErrorAlert(error)
                     }

--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -77,18 +77,26 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
         return await save(group, isUpdate: isUpdate)
     }
 
-    /// グループの並び順を変更し Realm に保存
+    /// グループ表示上の並び替えを同期的に即時反映する（Realm永続化・Firebase同期は含まない）
+    /// GroupForm.onMoveハンドラから非同期Taskでラップせず直接呼ぶことで、ドラッグを離した瞬間に
+    /// 並び順が確定するようにするため分離した（issue #169、issue #161のreorderTaskListDataと同パターン）
     /// - Parameters:
     ///   - source: 移動元インデックス集合（ForEach .onMove の引数）
     ///   - destination: 移動先インデックス
-    /// - Returns: Result
-    func moveGroup(from source: IndexSet, to destination: Int) async -> Result<Void, SportsNoteError> {
+    /// - Returns: Realm永続化用の並び替え後のグループ配列（`persistGroupOrder`に渡す）
+    func reorderGroups(from source: IndexSet, to destination: Int) -> [Group] {
         var reorderedGroups = groups
         reorderedGroups.move(fromOffsets: source, toOffset: destination)
+        groups = reorderedGroups
+        return reorderedGroups
+    }
 
+    /// 並び替え後のグループ配列をRealmへ永続化し、Firebaseへ同期する
+    /// - Parameter reorderedGroups: `reorderGroups`が返す並び替え後のグループ配列
+    /// - Returns: Result
+    func persistGroupOrder(_ reorderedGroups: [Group]) async -> Result<Void, SportsNoteError> {
         do {
             try RealmManager.shared.updateGroupOrder(groups: reorderedGroups)
-            groups = reorderedGroups
             // Firebase 同期（各グループを order 更新で同期）
             // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）
             let syncTask = Task<Void, Never> {
@@ -102,6 +110,16 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
             let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-moveGroup")
             return .failure(sportsNoteError)
         }
+    }
+
+    /// グループの並び順を変更し Realm に保存（表示反映＋永続化を一括で行う、後方互換用ラッパー）
+    /// - Parameters:
+    ///   - source: 移動元インデックス集合（ForEach .onMove の引数）
+    ///   - destination: 移動先インデックス
+    /// - Returns: Result
+    func moveGroup(from source: IndexSet, to destination: Int) async -> Result<Void, SportsNoteError> {
+        let reorderedGroups = reorderGroups(from: source, to: destination)
+        return await persistGroupOrder(reorderedGroups)
     }
 
     /// エンティティを保存（新規作成・更新）

--- a/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
@@ -516,6 +516,108 @@ struct GroupViewModelTests {
         manager.clearAll()
     }
 
+    // MARK: - reorderGroups / persistGroupOrder（グループ並び替えの同期性）テスト（issue #169）
+
+    @Test("reorderGroups - Realmへの永続化を待たずに同期的にgroups配列へ反映される")
+    func reorderGroups_synchronouslyUpdatesGroups() async {
+        let viewModel = GroupViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let groupA = GroupViewModelTests.createTestGroup(id: "g-A", title: "A", order: 0)
+        let groupB = GroupViewModelTests.createTestGroup(id: "g-B", title: "B", order: 1)
+        let groupC = GroupViewModelTests.createTestGroup(id: "g-C", title: "C", order: 2)
+        try? manager.saveItem(groupA)
+        try? manager.saveItem(groupB)
+        try? manager.saveItem(groupC)
+
+        _ = await viewModel.fetchData()
+        #expect(viewModel.groups.map { $0.groupID } == ["g-A", "g-B", "g-C"])
+
+        // CをAより前に移動（index2->0）。awaitを挟まず、同期呼び出し直後にgroupsが
+        // 更新済みであることを確認する（GroupForm.onMoveから非同期Taskでラップせず
+        // 直接呼べることの検証、issue #169）
+        let reordered = viewModel.reorderGroups(from: IndexSet(integer: 2), to: 0)
+
+        #expect(viewModel.groups.map { $0.groupID } == ["g-C", "g-A", "g-B"])
+        #expect(reordered.map { $0.groupID } == ["g-C", "g-A", "g-B"])
+
+        // この時点ではRealmへの永続化（persistGroupOrder）はまだ行われていないため、
+        // Realm上のorderは変化していないはず
+        let groupsBeforePersist = (try? manager.getDataList(clazz: Group.self)) ?? []
+        let orderABeforePersist = groupsBeforePersist.first { $0.groupID == "g-A" }?.order
+        #expect(orderABeforePersist == 0)
+
+        manager.clearAll()
+    }
+
+    @Test("persistGroupOrder - Realmのorderへ反映後、fetchDataで再取得しても同じ並び順を維持する")
+    func persistGroupOrder_updatesRealmOrderAndRefetchesGroups() async {
+        let viewModel = GroupViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let groupA = GroupViewModelTests.createTestGroup(id: "g-A", title: "A", order: 0)
+        let groupB = GroupViewModelTests.createTestGroup(id: "g-B", title: "B", order: 1)
+        let groupC = GroupViewModelTests.createTestGroup(id: "g-C", title: "C", order: 2)
+        try? manager.saveItem(groupA)
+        try? manager.saveItem(groupB)
+        try? manager.saveItem(groupC)
+
+        _ = await viewModel.fetchData()
+        let reordered = viewModel.reorderGroups(from: IndexSet(integer: 2), to: 0)
+
+        let result = await viewModel.persistGroupOrder(reordered)
+        guard case .success = result else {
+            Issue.record("persistGroupOrder failed")
+            manager.clearAll()
+            return
+        }
+
+        let updatedGroups = (try? manager.getDataList(clazz: Group.self)) ?? []
+        let orderC = updatedGroups.first { $0.groupID == "g-C" }?.order
+        let orderA = updatedGroups.first { $0.groupID == "g-A" }?.order
+        let orderB = updatedGroups.first { $0.groupID == "g-B" }?.order
+        #expect(orderC == 0 && orderA == 1 && orderB == 2)
+
+        // fetchDataによる再取得後も、ドラッグ確定時に反映した並び順から変化しない
+        // （＝一旦元の位置に戻ってから正しい位置に変わるスナップバックが発生しない）ことを確認
+        _ = await viewModel.fetchData()
+        #expect(viewModel.groups.map { $0.groupID } == ["g-C", "g-A", "g-B"])
+
+        manager.clearAll()
+    }
+
+    @Test("moveGroup - 表示反映と永続化を一括で行いRealmへ反映される（後方互換ラッパーの回帰確認）")
+    func moveGroup_reordersAndPersists() async {
+        let viewModel = GroupViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let groupA = GroupViewModelTests.createTestGroup(id: "g-A", title: "A", order: 0)
+        let groupB = GroupViewModelTests.createTestGroup(id: "g-B", title: "B", order: 1)
+        try? manager.saveItem(groupA)
+        try? manager.saveItem(groupB)
+
+        _ = await viewModel.fetchData()
+
+        let result = await viewModel.moveGroup(from: IndexSet(integer: 1), to: 0)
+        guard case .success = result else {
+            Issue.record("moveGroup failed")
+            manager.clearAll()
+            return
+        }
+
+        #expect(viewModel.groups.map { $0.groupID } == ["g-B", "g-A"])
+
+        let updatedGroups = (try? manager.getDataList(clazz: Group.self)) ?? []
+        let orderA = updatedGroups.first { $0.groupID == "g-A" }?.order
+        let orderB = updatedGroups.first { $0.groupID == "g-B" }?.order
+        #expect(orderB == 0 && orderA == 1)
+
+        manager.clearAll()
+    }
+
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）
 
     @Test(


### PR DESCRIPTION
## 概要
グループ一覧画面（`GroupView`）でグループをドラッグして並び替えた際、指を離した瞬間に一旦元の位置へ戻ってから正しい位置に反映される視覚的な不整合を修正した。issue #161（課題一覧、対応済み）・#165（対策一覧、同一パターンで対応済み）と同一クラスの不具合が、グループ一覧には未対応のまま残っていたため、同じ設計パターンを適用した。

`GroupViewModel.moveGroup(from:to:)`を以下の関数に分割:
- `reorderGroups(from:to:) -> [Group]`: `groups`配列を同期的に並び替えて即時反映（Realm未使用）
- `persistGroupOrder(_:) async -> Result<Void, SportsNoteError>`: 旧`moveGroup`のRealm永続化・Firebase同期ロジックそのまま
- `moveGroup(from:to:) async`: 既存シグネチャを維持した後方互換ラッパー

`GroupView.swift`の`onMoveGroup`クロージャを、`reorderGroups`をTask{}の外で同期呼び出しし、`persistGroupOrder`のみをTask{}内で非同期呼び出しする形に変更した。`GroupForm.swift`の`ForEach`は既に`groups, id: \.groupID`（要素ベース識別子）だったため、issue #165で必要だった識別子変更は本issueでは不要と判断し変更していない。

Closes #169

## 変更ファイル
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`
- `SportsNote_iOS/View/Group/GroupView.swift`
- `SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift`

## ビルド・テスト結果
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test`（GroupViewModelTests）→ 40件全成功（新規追加3件含む）
- `xcodebuild test`（フルスイート）→ 584件中582件成功。失敗2件（`associateTasksWithMemos_sortsResultByTaskOrder`・`associateTasksWithMemos_sameOrderTiesBreakByTaskID`）は本PRと無関係な既知の不具合（issue #162、対応中PR #170）

## 完了条件チェックリスト
- [x] `GroupViewModel`に同期のUI反映関数と非同期の永続化関数が分離され、`GroupView.swift`が前者をTask{}の外で同期呼び出しするようになっている
- [x] グループ一覧のドラッグ並び替えで、指を離した瞬間にスナップバックせず即座に正しい位置に反映される（回帰テストで、同期呼び出し直後に`groups`が更新済みであることを検証）
- [x] 既存の`moveGroup`呼び出し元・既存テストが無改修で成功する
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（issue #162関連の既知の無関係な2件を除く）

## クロスレビュー
独立コンテキストによるクロスレビュー1ラウンドで指摘なし合格。レビュアーは`reorderGroups`のロジックを一時的に無効化するロールバック実験を行い、追加した回帰テストが実際にバグを検知できることを実証した上で元に戻して確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)