### PR TITLE
refactor: 空白のみタイトル判定をString.isBlankに共通化

### DIFF
--- a/SportsNote_iOS/Utils/StringExtensions.swift
+++ b/SportsNote_iOS/Utils/StringExtensions.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// String型の拡張ユーティリティ
+///
+/// 文字列操作を簡潔に記述するためのヘルパーメソッド群。
+/// 空白判定などの共通ロジックを集約し、コードの重複を防ぐことを目的とする。
+extension String {
+
+    // MARK: - Blank Check
+
+    /// 空文字列、または空白・改行のみで構成されているかどうかを判定
+    /// - Returns: 空白のみ（または空文字列）の場合はtrue
+    var isBlank: Bool {
+        return trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/SportsNote_iOS/View/Group/AddGroupView.swift
+++ b/SportsNote_iOS/View/Group/AddGroupView.swift
@@ -40,7 +40,7 @@ struct AddGroupView: View {
                                 }
                             }
                         }
-                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .disabled(title.isBlank)
                     }
                 }
         }

--- a/SportsNote_iOS/View/Group/GroupView.swift
+++ b/SportsNote_iOS/View/Group/GroupView.swift
@@ -88,7 +88,7 @@ struct GroupView: View {
 
     private func saveSelectedGroup() {
         // 空白のみのタイトルで即時保存されるのを防ぐ（issue #133）
-        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard !title.isBlank else { return }
         Task {
             let result = await viewModel.saveGroup(
                 groupID: selectedGroup.groupID,

--- a/SportsNote_iOS/View/Measures/MeasureDetailView.swift
+++ b/SportsNote_iOS/View/Measures/MeasureDetailView.swift
@@ -33,7 +33,7 @@ struct MeasureDetailView: View {
                     TextField(LocalizedStrings.title, text: $title)
                         .onChange(of: title) { newValue in
                             // 空白のみのタイトルで即時保存されるのを防ぐ（issue #133）
-                            guard !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                            guard !newValue.isBlank else { return }
                             Task {
                                 let result = await measuresViewModel.saveMeasures(
                                     measuresID: measure.measuresID,

--- a/SportsNote_iOS/View/Target/AddTargetView.swift
+++ b/SportsNote_iOS/View/Target/AddTargetView.swift
@@ -77,7 +77,7 @@ struct AddTargetView: View {
                             }
                         }
                     }
-                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(title.isBlank)
                 }
             }
         }

--- a/SportsNote_iOS/View/Task/AddTaskView.swift
+++ b/SportsNote_iOS/View/Task/AddTaskView.swift
@@ -66,7 +66,7 @@ struct AddTaskView: View {
                         }
                     }
                     .disabled(
-                        taskTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        taskTitle.isBlank
                             || !groupViewModel.groups.indices.contains(selectedGroupIndex))
                 }
             }

--- a/SportsNote_iOS/View/Task/Components/AddMeasure.swift
+++ b/SportsNote_iOS/View/Task/Components/AddMeasure.swift
@@ -12,7 +12,7 @@ struct AddMeasureView: View {
                 Image(systemName: "plus.circle.fill")
                     .foregroundColor(.blue)
             }
-            .disabled(newMeasureTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .disabled(newMeasureTitle.isBlank)
         }
     }
 }

--- a/SportsNote_iOS/View/Task/TaskDetailView.swift
+++ b/SportsNote_iOS/View/Task/TaskDetailView.swift
@@ -46,7 +46,7 @@ struct TaskDetailView: View {
                         // 全選択して削除→再入力する一連の操作中、空文字になった瞬間の
                         // バリデーションエラーで入力が割り込まれないよう、空白のみの間は
                         // 保存をスキップし非空になった時点で保存する（issue #115）
-                        guard !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                        guard !newValue.isBlank else { return }
                         persistTaskChanges()
                     }
             }
@@ -238,7 +238,7 @@ struct TaskDetailView: View {
 
     /// 対策追加処理
     private func addMeasure() {
-        guard !newMeasureTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard !newMeasureTitle.isBlank else { return }
 
         // 対策の保存は非同期のため、タイトルをコピーしておかないと保存前にクリアされてしまう
         let titleToSave = newMeasureTitle

--- a/SportsNote_iOSTests/Utils/StringExtensionsTests.swift
+++ b/SportsNote_iOSTests/Utils/StringExtensionsTests.swift
@@ -1,0 +1,49 @@
+//
+//  StringExtensionsTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Claude on 2026/08/11.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+@Suite("StringExtensions Tests")
+struct StringExtensionsTests {
+
+    // MARK: - isBlank Tests
+
+    @Test(
+        "isBlank - 空白のみ（またはブランク）の場合はtrue",
+        arguments: [
+            "",
+            " ",
+            "   ",
+            "\n",
+            "\t",
+            " \n\t ",
+            "　",  // 全角スペース
+            "　　",  // 全角スペースのみ
+        ]
+    )
+    func isBlank_blankInput_returnsTrue(input: String) {
+        #expect(input.isBlank == true)
+    }
+
+    @Test(
+        "isBlank - 非空白文字を含む場合はfalse",
+        arguments: [
+            "タイトル",
+            "a",
+            " タイトル ",
+            "\nタイトル\n",
+            "  a  ",
+            "0",
+        ]
+    )
+    func isBlank_nonBlankInput_returnsFalse(input: String) {
+        #expect(input.isBlank == false)
+    }
+}


### PR DESCRIPTION
## 概要
`title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty`（空白のみ入力かどうかの判定）が7ファイル・8箇所に重複していたため、`String`拡張の共通プロパティ`isBlank`に切り出した。

Closes #163

## 変更ファイル一覧
- `SportsNote_iOS/Utils/StringExtensions.swift`（新規）: `String.isBlank`計算プロパティを追加
- `SportsNote_iOS/View/Group/GroupView.swift`
- `SportsNote_iOS/View/Group/AddGroupView.swift`
- `SportsNote_iOS/View/Target/AddTargetView.swift`
- `SportsNote_iOS/View/Task/AddTaskView.swift`
- `SportsNote_iOS/View/Task/Components/AddMeasure.swift`
- `SportsNote_iOS/View/Task/TaskDetailView.swift`（2箇所）
- `SportsNote_iOS/View/Measures/MeasureDetailView.swift`
- `SportsNote_iOSTests/Utils/StringExtensionsTests.swift`（新規）: `isBlank`のパラメータ化テスト（空文字・半角/全角スペース・タブ・改行・非空白文字列など14ケース）

## ビルド・テスト結果
- `swift-format`: 正常完了
- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild test`: 583件中581件成功。失敗2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`/`sameOrderTiesBreakByTaskID`）は本PRの変更と無関係な既存issue #162由来（本PRの変更ファイルを一切触れていない箇所であり、mainブランチ単体でも同じ2件が失敗することを確認済み）

## 完了条件チェックリスト
- [x] `String`に空白判定用の共通プロパティ（`isBlank`）が追加されている
- [x] 8箇所すべてが共通プロパティを使うように置き換えられている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（既知issue #162由来の無関係な2件を除く）

## クロスレビュー結果
独立エージェントによるクロスレビュー1ラウンドで合格（指摘なし）。参考情報として、issue本文「6ファイル8箇所」は実際には「7ファイル8箇所」（`GroupView.swift`と`AddGroupView.swift`が別ファイル）だったが、issue記述側の数え間違いであり実装上の問題ではない。