### PR TITLE
refactor: fetchData()/save(_:isUpdate:)の重複実装をCRUDViewModelProtocolに共通化

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -20,6 +20,34 @@ extension Measures: SoftDeletable {}
 extension Memo: SoftDeletable {}
 extension Target: SoftDeletable {}
 
+/// userIDを保持するRealmモデルの共通インターフェース
+///
+/// 保存時のuserID巻き戻し処理（アカウント作成直後のuserID切替タイミングでも
+/// Firebase更新が正しいドキュメントIDに対して行われるようにするための処理。issue #74）を
+/// ViewModelのsave(_:isUpdate:)共通実装（CRUDViewModelProtocol.saveDefault）から利用するために使用する
+protocol UserOwnedEntity: Object {
+    var userID: String { get set }
+    /// RealmManager.getObjectByIdでの検索に使用する主キー値
+    var entityID: String { get }
+}
+
+// Realmモデルに対してUserOwnedEntityプロトコルを適用する拡張
+extension Group: UserOwnedEntity {
+    var entityID: String { groupID }
+}
+extension Measures: UserOwnedEntity {
+    var entityID: String { measuresID }
+}
+extension Memo: UserOwnedEntity {
+    var entityID: String { memoID }
+}
+extension Target: UserOwnedEntity {
+    var entityID: String { targetID }
+}
+extension TaskData: UserOwnedEntity {
+    var entityID: String { taskID }
+}
+
 /// Realmデータベースを管理するクラス
 @MainActor
 final class RealmManager {

--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -32,17 +32,11 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
     /// データを取得
     /// - Returns: Result
     func fetchData() async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
+        await fetchDataDefault(context: "GroupViewModel-fetchData") {
             // Realm操作はMainActorで実行
-            groups = try RealmManager.shared.getDataList(clazz: Group.self)
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-fetchData")
-            return .failure(sportsNoteError)
+            self.groups = try RealmManager.shared.getDataList(clazz: Group.self)
+        } onSuccess: {
+            self.hideErrorAlert()
         }
     }
 
@@ -110,31 +104,13 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
     ///   - isUpdate: 更新要否
     /// - Returns: Result
     func save(_ entity: Group, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
-            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
-            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
-            if isUpdate, let existingGroup = try RealmManager.shared.getObjectById(id: entity.groupID, type: Group.self)
-            {
-                entity.userID = existingGroup.userID
-            }
-
-            // Realm操作はMainActorで実行
-            try RealmManager.shared.saveItem(entity)
-
+        await saveDefault(entity, isUpdate: isUpdate, context: "GroupViewModel-save") {
             // Firebase同期はバックグラウンドで実行
-            performBackgroundSync(entity, isUpdate: isUpdate)
+            self.performBackgroundSync(entity, isUpdate: isUpdate)
 
             // UI更新
-            groups = try RealmManager.shared.getDataList(clazz: Group.self)
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-save")
-            return .failure(sportsNoteError)
+            self.groups = try RealmManager.shared.getDataList(clazz: Group.self)
+            self.hideErrorAlert()
         }
     }
 

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -29,16 +29,10 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
     /// データを取得（プロトコル準拠）
     /// - Returns: Result
     func fetchData() async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            measuresList = try RealmManager.shared.getDataList(clazz: Measures.self)
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MeasuresViewModel-fetchData")
-            return .failure(sportsNoteError)
+        await fetchDataDefault(context: "MeasuresViewModel-fetchData") {
+            self.measuresList = try RealmManager.shared.getDataList(clazz: Measures.self)
+        } onSuccess: {
+            self.hideErrorAlert()
         }
     }
 
@@ -127,32 +121,13 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
     ///   - isUpdate: 更新かどうか
     /// - Returns: Result
     func save(_ entity: Measures, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
+        await saveDefault(entity, isUpdate: isUpdate, context: "MeasuresViewModel-save") {
+            // Firebase同期はバックグラウンドで実行
+            self.performBackgroundSync(entity, isUpdate: isUpdate)
 
-        do {
-            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
-            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
-            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
-            if isUpdate,
-                let existingMeasures = try RealmManager.shared.getObjectById(id: entity.measuresID, type: Measures.self)
-            {
-                entity.userID = existingMeasures.userID
-            }
-
-            // 1. Realm操作はMainActorで実行
-            try RealmManager.shared.saveItem(entity)
-
-            // 2. Firebase同期はバックグラウンドで実行
-            performBackgroundSync(entity, isUpdate: isUpdate)
-
-            // 3. UI更新
-            measuresList = try RealmManager.shared.getDataList(clazz: Measures.self)
-
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MeasuresViewModel-save")
-            return .failure(sportsNoteError)
+            // UI更新
+            self.measuresList = try RealmManager.shared.getDataList(clazz: Measures.self)
+            // 元実装通りhideErrorAlert()は呼ばない
         }
     }
 

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -29,17 +29,11 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// データを取得（プロトコル準拠）
     /// - Returns: Result
     func fetchData() async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
+        await fetchDataDefault(context: "MemoViewModel-fetchData") {
             // Realm操作はMainActorで実行
-            memoList = try RealmManager.shared.getDataList(clazz: Memo.self)
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MemoViewModel-fetchData")
-            return .failure(sportsNoteError)
+            self.memoList = try RealmManager.shared.getDataList(clazz: Memo.self)
+        } onSuccess: {
+            self.hideErrorAlert()
         }
     }
 
@@ -56,30 +50,13 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - isUpdate: 更新かどうか
     /// - Returns: Result
     func save(_ entity: Memo, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
-            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
-            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
-            if isUpdate, let existingMemo = try RealmManager.shared.getObjectById(id: entity.memoID, type: Memo.self) {
-                entity.userID = existingMemo.userID
-            }
-
-            // Realm操作はMainActorで実行
-            try RealmManager.shared.saveItem(entity)
-
+        await saveDefault(entity, isUpdate: isUpdate, context: "MemoViewModel-save") {
             // Firebase同期はバックグラウンドで実行
-            performBackgroundSync(entity, isUpdate: isUpdate)
+            self.performBackgroundSync(entity, isUpdate: isUpdate)
 
             // UI更新
-            memoList = try RealmManager.shared.getDataList(clazz: Memo.self)
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MemoViewModel-save")
-            return .failure(sportsNoteError)
+            self.memoList = try RealmManager.shared.getDataList(clazz: Memo.self)
+            self.hideErrorAlert()
         }
     }
 

--- a/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
@@ -42,4 +42,72 @@ extension CRUDViewModelProtocol {
             return .failure(sportsNoteError)
         }
     }
+
+    /// fetchData()の共通実装（isLoadingトグル・エラーハンドリングを一元化）
+    /// - Parameters:
+    ///   - context: エラー変換時のコンテキスト（メソッド名など）
+    ///   - operation: Realm取得と@Publishedプロパティへの代入を行うクロージャ
+    ///   - onSuccess: 取得成功時に追加で実行する処理（例: hideErrorAlert）
+    /// - Returns: 成功時は.success(())、失敗時は.failure(SportsNoteError)
+    func fetchDataDefault(
+        context: String,
+        operation: () throws -> Void,
+        onSuccess: (() -> Void)? = nil
+    ) async -> Result<Void, SportsNoteError> {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            try operation()
+            onSuccess?()
+            return .success(())
+        } catch {
+            let sportsNoteError = convertToSportsNoteError(error, context: context)
+            return .failure(sportsNoteError)
+        }
+    }
+}
+
+extension CRUDViewModelProtocol where EntityType: UserOwnedEntity {
+    /// save(_:isUpdate:)の共通実装（isLoadingトグル・userID巻き戻し・Realm保存・エラーハンドリングを一元化）
+    ///
+    /// Firebase同期・ローカル配列の再取得・ViewModel固有の追加処理（通知送信やhideErrorAlert呼び出しの
+    /// 有無など）はafterSaveクロージャに委譲することで、ViewModelごとに異なる挙動をそのまま維持する。
+    /// - Parameters:
+    ///   - entity: 保存するエンティティ
+    ///   - isUpdate: 更新かどうか
+    ///   - context: エラー変換時のコンテキスト（メソッド名など）
+    ///   - afterSave: Realm保存成功後に実行する処理（Firebase同期・UI更新等をまとめて渡す）
+    /// - Returns: 成功時は.success(())、失敗時は.failure(SportsNoteError)
+    func saveDefault(
+        _ entity: EntityType,
+        isUpdate: Bool,
+        context: String,
+        afterSave: () throws -> Void
+    ) async -> Result<Void, SportsNoteError> {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
+            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
+            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
+            if isUpdate,
+                let existing = try RealmManager.shared.getObjectById(id: entity.entityID, type: EntityType.self)
+            {
+                entity.userID = existing.userID
+            }
+
+            // Realm操作はMainActorで実行
+            try RealmManager.shared.saveItem(entity)
+
+            // Firebase同期・UI更新・追加処理は呼び出し側に委譲
+            try afterSave()
+
+            return .success(())
+        } catch {
+            let sportsNoteError = convertToSportsNoteError(error, context: context)
+            return .failure(sportsNoteError)
+        }
+    }
 }

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -47,24 +47,17 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
     /// データを取得（プロトコル準拠）
     /// - Returns: Result
     func fetchData() async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
+        await fetchDataDefault(context: "TargetViewModel-fetchData") {
             // Realm操作はMainActorで実行
             let allTargets = try RealmManager.shared.getDataList(clazz: Target.self)
 
             // 現在の年月に基づいてフィルタリング
-            yearlyTargets = allTargets.filter { $0.year == currentYear && $0.isYearlyTarget }
-            monthlyTargets = allTargets.filter {
-                $0.year == currentYear && $0.month == currentMonth && !$0.isYearlyTarget
+            self.yearlyTargets = allTargets.filter { $0.year == self.currentYear && $0.isYearlyTarget }
+            self.monthlyTargets = allTargets.filter {
+                $0.year == self.currentYear && $0.month == self.currentMonth && !$0.isYearlyTarget
             }
-
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TargetViewModel-fetchData")
-            return .failure(sportsNoteError)
+        } onSuccess: {
+            self.hideErrorAlert()
         }
     }
 
@@ -101,37 +94,18 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
     ///   - isUpdate: 更新かどうか
     /// - Returns: Result
     func save(_ entity: Target, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
-            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
-            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
-            if isUpdate,
-                let existingTarget = try RealmManager.shared.getObjectById(id: entity.targetID, type: Target.self)
-            {
-                entity.userID = existingTarget.userID
-            }
-
-            // Realm操作はMainActorで実行
-            try RealmManager.shared.saveItem(entity)
-
+        await saveDefault(entity, isUpdate: isUpdate, context: "TargetViewModel-save") {
             // Firebase同期はバックグラウンドで実行
-            performBackgroundSync(entity, isUpdate: isUpdate)
+            self.performBackgroundSync(entity, isUpdate: isUpdate)
 
             // UI更新 - 現在の年月のデータを再取得
             let allTargets = try RealmManager.shared.getDataList(clazz: Target.self)
-            yearlyTargets = allTargets.filter { $0.year == currentYear && $0.isYearlyTarget }
-            monthlyTargets = allTargets.filter {
-                $0.year == currentYear && $0.month == currentMonth && !$0.isYearlyTarget
+            self.yearlyTargets = allTargets.filter { $0.year == self.currentYear && $0.isYearlyTarget }
+            self.monthlyTargets = allTargets.filter {
+                $0.year == self.currentYear && $0.month == self.currentMonth && !$0.isYearlyTarget
             }
 
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TargetViewModel-save")
-            return .failure(sportsNoteError)
+            self.hideErrorAlert()
         }
     }
 

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -44,18 +44,12 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// データを取得（プロトコル準拠）
     /// - Returns: Result
     func fetchData() async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
+        await fetchDataDefault(context: "TaskViewModel-fetchData") {
             // Realm操作はMainActorで実行
-            tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
-            convertToTaskListData()
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TaskViewModel-fetchData")
-            return .failure(sportsNoteError)
+            self.tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
+            self.convertToTaskListData()
+        } onSuccess: {
+            self.hideErrorAlert()
         }
     }
 
@@ -242,36 +236,17 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - isUpdate: 更新かどうか
     /// - Returns: Result
     func save(_ entity: TaskData, isUpdate: Bool = false) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
+        await saveDefault(entity, isUpdate: isUpdate, context: "TaskViewModel-save") {
+            // Firebase同期はバックグラウンドで実行
+            self.performBackgroundSync(entity, isUpdate: isUpdate)
 
-        do {
-            // 更新時は、エンティティ再構築時にUserDefaultsの現在値で上書きされてしまったuserIDを、
-            // Realmに永続化済みの値に戻す（アカウント作成直後のuserID切替タイミングでも
-            // Firebase更新が正しいドキュメントIDに対して行われるようにするため。issue #74）
-            if isUpdate,
-                let existingTask = try RealmManager.shared.getObjectById(id: entity.taskID, type: TaskData.self)
-            {
-                entity.userID = existingTask.userID
-            }
-
-            // 1. Realm操作はMainActorで実行
-            try RealmManager.shared.saveItem(entity)
-
-            // 2. Firebase同期はバックグラウンドで実行
-            performBackgroundSync(entity, isUpdate: isUpdate)
-
-            // 3. UI更新
-            tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
-            convertToTaskListData()
+            // UI更新
+            self.tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
+            self.convertToTaskListData()
 
             // タスク更新通知を送信
-            taskUpdatedPublisher.send()
-
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TaskViewModel-save")
-            return .failure(sportsNoteError)
+            self.taskUpdatedPublisher.send()
+            // 元実装通りhideErrorAlert()は呼ばない
         }
     }
 


### PR DESCRIPTION
## 概要
`GroupViewModel`/`MeasuresViewModel`/`MemoViewModel`/`TargetViewModel`/`TaskViewModel`の5ファイルで完全重複していた`fetchData()`/`save(_:isUpdate:)`の骨格（`isLoading`トグル・`do-catch`・`convertToSportsNoteError`変換・userID巻き戻し処理）を、`CRUDViewModelProtocol`の共通ヘルパーに切り出した。

Closes #40

## 実装内容
- `SportsNote_iOS/Model/Manager/RealmManager.swift`: 既存の`SoftDeletable`と同じ配置パターンで`UserOwnedEntity`プロトコル（`userID`・`entityID`）を新設し、Group/Measures/Memo/Target/TaskDataに適用
- `SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift`: `fetchDataDefault(context:operation:onSuccess:)`と、`EntityType: UserOwnedEntity`に制約した`saveDefault(_:isUpdate:context:afterSave:)`を追加
- 5ViewModel（Group/Measures/Memo/Target/Task）の`fetchData()`/`save(_:isUpdate:)`を上記ヘルパー呼び出し + クロージャに置き換え

## 挙動維持の方針
各ViewModel固有の差分は、クロージャ（`operation`/`onSuccess`/`afterSave`）に元のロジックをそのまま移植する形で維持し、条件分岐を追加しない設計とした:
- `MeasuresViewModel.save`/`TaskViewModel.save`: 元々`hideErrorAlert()`を呼んでいなかった非対称性をそのまま維持
- `TaskViewModel`: `convertToTaskListData()`・`taskUpdatedPublisher.send()`を維持
- `TargetViewModel`: `yearlyTargets`/`monthlyTargets`の2配列フィルタ処理を維持

`NoteViewModel`・`delete(id:)`（issue #32のスコープ）は今回の変更対象外。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/RealmManager.swift`
- `SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift`
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`
- `SportsNote_iOS/ViewModel/MeasuresViewModel.swift`
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`
- `SportsNote_iOS/ViewModel/TargetViewModel.swift`
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`

## ビルド・テスト結果
- `swift-format`: 正常完了
- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild test`: 581件中579件成功。失敗2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`/`sameOrderTiesBreakByTaskID`）は本PRの変更と無関係な既存issue #162由来（本PRが一切触れていない`associateTasksWithMemos`関数のテストで、mainブランチ単体でも同じ2件が失敗することをworktreeで確認済み）

## 完了条件チェックリスト
- [x] 5ViewModelの`fetchData()`/`save(_:isUpdate:)`が共通実装を利用する形に置き換わっている
- [x] 各ViewModel固有の差分（`hideErrorAlert()`呼び出し等）の挙動が変更前と変わらないことを確認する
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（既知issue #162由来の無関係な2件を除く）

## クロスレビュー結果
独立エージェントによるクロスレビュー1ラウンドで合格（指摘なし）。userID巻き戻し処理のマッピング（`UserOwnedEntity.entityID`）・`hideErrorAlert()`呼び出しの有無・各ViewModel固有ロジックの維持を個別に検証済み。