### PR TITLE
refactor: delete(id:)の重複実装をCRUDViewModelProtocolに共通化

### DIFF
--- a/SportsNote_iOS/ViewModel/GroupViewModel.swift
+++ b/SportsNote_iOS/ViewModel/GroupViewModel.swift
@@ -156,31 +156,17 @@ class GroupViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProt
     /// - Parameter id: ID
     /// - Returns: Result
     func delete(id: String) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 削除前にオブジェクトを取得（論理削除後はisDeleted=trueで取得できなくなるため）
-            let groupToDelete = try RealmManager.shared.getObjectById(id: id, type: Group.self)
-
-            // Realm操作はMainActorで実行
-            try RealmManager.shared.logicalDelete(id: id, type: Group.self)
-
-            // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
-            if let groupToDelete = groupToDelete {
-                Task {
-                    performBackgroundSync(groupToDelete, isUpdate: true)
-                }
+        await deleteDefault(
+            id: id,
+            context: "GroupViewModel-delete",
+            removeFromLocalCache: {
+                // UI更新（他VMのremoveAllとは異なり配列全体を再フェッチする既存挙動を維持）
+                self.groups = try RealmManager.shared.getDataList(clazz: Group.self)
+            },
+            onSuccess: {
+                self.hideErrorAlert()
             }
-
-            // UI更新
-            groups = try RealmManager.shared.getDataList(clazz: Group.self)
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "GroupViewModel-delete")
-            return .failure(sportsNoteError)
-        }
+        )
     }
 
     /// 指定されたIDのエンティティを取得

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -160,31 +160,14 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
     /// - Parameter id: 削除する対策ID
     /// - Returns: Result
     func delete(id: String) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 1. 削除前にオブジェクトを取得（論理削除後はisDeleted=trueで取得できなくなるため）
-            let measuresToDelete = try RealmManager.shared.getObjectById(id: id, type: Measures.self)
-
-            // 2. Realm操作はMainActorで実行
-            try RealmManager.shared.logicalDelete(id: id, type: Measures.self)
-
-            // 3. Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
-            if let measuresToDelete = measuresToDelete {
-                Task {
-                    performBackgroundSync(measuresToDelete, isUpdate: true)
-                }
+        await deleteDefault(
+            id: id,
+            context: "MeasuresViewModel-delete",
+            removeFromLocalCache: {
+                self.measuresList.removeAll(where: { $0.measuresID == id })
             }
-
-            // 4. UI更新
-            measuresList.removeAll(where: { $0.measuresID == id })
-
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MeasuresViewModel-delete")
-            return .failure(sportsNoteError)
-        }
+            // 元実装通りhideErrorAlert()は呼ばない
+        )
     }
 
     /// 対策の並び順を更新

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -87,31 +87,16 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: 削除するエンティティのID
     /// - Returns: Result
     func delete(id: String) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 削除対象のメモを取得（Firebase同期用）
-            let memoToDelete = try RealmManager.shared.getObjectById(id: id, type: Memo.self)
-
-            // Realm操作はMainActorで実行
-            try RealmManager.shared.logicalDelete(id: id, type: Memo.self)
-
-            // Firebase同期はバックグラウンドで実行（論理削除なので更新として扱う）
-            if let memo = memoToDelete {
-                Task {
-                    performBackgroundSync(memo, isUpdate: true)
-                }
+        await deleteDefault(
+            id: id,
+            context: "MemoViewModel-delete",
+            removeFromLocalCache: {
+                self.memoList.removeAll(where: { $0.memoID == id })
+            },
+            onSuccess: {
+                self.hideErrorAlert()
             }
-
-            // UI更新 - 配列から削除
-            memoList.removeAll(where: { $0.memoID == id })
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "MemoViewModel-delete")
-            return .failure(sportsNoteError)
-        }
+        )
     }
 
     /// 指定されたIDのエンティティを取得する（プロトコル準拠）

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -504,37 +504,22 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: 削除するエンティティのID
     /// - Returns: Result
     func delete(id: String) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // フリーノートの削除を防ぐ
-            if let note = notes.first(where: { $0.noteID == id }),
-                note.noteType == NoteType.free.rawValue
-            {
-                return .failure(.systemError(LocalizedStrings.cannotDeleteFreeNote))
-            }
-
-            // 削除前にオブジェクトを取得（論理削除後はisDeleted=trueで取得できなくなるため）
-            let noteToDelete = try realmManager.getObjectById(id: id, type: Note.self)
-
-            // Realm操作はMainActorで実行
-            try realmManager.logicalDelete(id: id, type: Note.self)
-
-            // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
-            if isOnlineAndLoggedIn, let noteToDelete = noteToDelete {
-                Task {
-                    performBackgroundSync(noteToDelete, isUpdate: true)
-                }
-            }
-
-            // UI更新
-            notes.removeAll(where: { $0.noteID == id })
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "NoteViewModel-delete")
-            return .failure(sportsNoteError)
+        // フリーノートの削除を防ぐ（共通処理呼び出し前に判定）
+        if let note = notes.first(where: { $0.noteID == id }),
+            note.noteType == NoteType.free.rawValue
+        {
+            return .failure(.systemError(LocalizedStrings.cannotDeleteFreeNote))
         }
+
+        return await deleteDefault(
+            id: id,
+            context: "NoteViewModel-delete",
+            removeFromLocalCache: {
+                // UI更新
+                self.notes.removeAll(where: { $0.noteID == id })
+            }
+            // 元実装通りhideErrorAlert()は呼ばない
+        )
     }
 
     /// エンティティをFirebaseに同期

--- a/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
@@ -43,3 +43,50 @@ extension CRUDViewModelProtocol {
         }
     }
 }
+
+extension CRUDViewModelProtocol where Self: FirebaseSyncable {
+    /// 指定されたIDのエンティティを削除する共通実装
+    ///
+    /// フロー: 削除前オブジェクト取得 → 論理削除 → Firebase同期をバックグラウンドで実行
+    /// → ローカルキャッシュから除去 → 成功時追加処理 → Result返却
+    /// - Parameters:
+    ///   - id: 削除するエンティティのID
+    ///   - context: エラー変換時のコンテキスト（メソッド名など）
+    ///   - removeFromLocalCache: ローカルの@Publishedプロパティから対象を除去する処理。
+    ///     配列構造・除去方法はViewModelごとに異なるため呼び出し元に委譲する
+    ///   - onSuccess: 削除成功時に追加で実行する処理（例: hideErrorAlert、通知送信）
+    /// - Returns: 成功時は.success(())、失敗時は.failure(SportsNoteError)
+    func deleteDefault(
+        id: String,
+        context: String,
+        removeFromLocalCache: () throws -> Void,
+        onSuccess: (() -> Void)? = nil
+    ) async -> Result<Void, SportsNoteError> {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            // 削除前にオブジェクトを取得（論理削除後はisDeleted=trueで取得できなくなるため）
+            let entityToDelete = try RealmManager.shared.getObjectById(id: id, type: EntityType.self)
+
+            // Realm操作はMainActorで実行
+            try RealmManager.shared.logicalDelete(id: id, type: EntityType.self)
+
+            // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
+            // performBackgroundSync自体が内部でTaskを生成しBackgroundSyncTrackerに追跡登録するため、
+            // ここをさらにTaskでラップする必要はない
+            if let entityToDelete = entityToDelete {
+                performBackgroundSync(entityToDelete, isUpdate: true)
+            }
+
+            // ローカルキャッシュからの除去はViewModelごとに異なるため呼び出し元に委譲
+            try removeFromLocalCache()
+
+            onSuccess?()
+            return .success(())
+        } catch {
+            let sportsNoteError = convertToSportsNoteError(error, context: context)
+            return .failure(sportsNoteError)
+        }
+    }
+}

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -186,33 +186,18 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
     /// - Parameter id: 削除するエンティティのID
     /// - Returns: Result
     func delete(id: String) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 削除対象の目標を取得（Firebase同期用）
-            let targetToDelete = try RealmManager.shared.getObjectById(id: id, type: Target.self)
-
-            // Realm操作はMainActorで実行
-            try RealmManager.shared.logicalDelete(id: id, type: Target.self)
-
-            // Firebase同期はバックグラウンドで実行（論理削除なので更新として扱う）
-            if let target = targetToDelete {
-                Task {
-                    performBackgroundSync(target, isUpdate: true)
-                }
+        await deleteDefault(
+            id: id,
+            context: "TargetViewModel-delete",
+            removeFromLocalCache: {
+                // UI更新 - 配列から削除
+                self.yearlyTargets.removeAll(where: { $0.targetID == id })
+                self.monthlyTargets.removeAll(where: { $0.targetID == id })
+            },
+            onSuccess: {
+                self.hideErrorAlert()
             }
-
-            // UI更新 - 配列から削除
-            yearlyTargets.removeAll(where: { $0.targetID == id })
-            monthlyTargets.removeAll(where: { $0.targetID == id })
-
-            hideErrorAlert()
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TargetViewModel-delete")
-            return .failure(sportsNoteError)
-        }
+        )
     }
 
     /// 指定されたIDのエンティティを取得する（プロトコル準拠）

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -279,35 +279,18 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter id: 削除する課題ID
     /// - Returns: Result
     func delete(id: String) async -> Result<Void, SportsNoteError> {
-        isLoading = true
-        defer { isLoading = false }
-
-        do {
-            // 1. 削除前にオブジェクトを取得（論理削除後はisDeleted=trueで取得できなくなるため）
-            let taskToDelete = try RealmManager.shared.getObjectById(id: id, type: TaskData.self)
-
-            // 2. Realm操作はMainActorで実行
-            try RealmManager.shared.logicalDelete(id: id, type: TaskData.self)
-
-            // 3. Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
-            if let taskToDelete = taskToDelete {
-                Task {
-                    performBackgroundSync(taskToDelete, isUpdate: true)
-                }
+        await deleteDefault(
+            id: id,
+            context: "TaskViewModel-delete",
+            removeFromLocalCache: {
+                self.tasks.removeAll(where: { $0.taskID == id })
+                self.taskListData.removeAll(where: { $0.taskID == id })
+            },
+            onSuccess: {
+                // タスク更新通知を送信（元実装通りhideErrorAlert()は呼ばない）
+                self.taskUpdatedPublisher.send()
             }
-
-            // 4. UI更新
-            tasks.removeAll(where: { $0.taskID == id })
-            taskListData.removeAll(where: { $0.taskID == id })
-
-            // タスク更新通知を送信
-            taskUpdatedPublisher.send()
-
-            return .success(())
-        } catch {
-            let sportsNoteError = convertToSportsNoteError(error, context: "TaskViewModel-delete")
-            return .failure(sportsNoteError)
-        }
+        )
     }
 
     /// TaskDataオブジェクトを作成（新規・更新両対応）


### PR DESCRIPTION
## 概要
`GroupViewModel`/`MeasuresViewModel`/`MemoViewModel`/`TargetViewModel`/`TaskViewModel`/`NoteViewModel`の6ファイルで完全重複していた`delete(id:)`の制御フロー（削除前オブジェクト取得→論理削除→Firebase同期をバックグラウンドで実行→ローカルキャッシュから除去→Result返却）を、`CRUDViewModelProtocol`の共通ヘルパーに切り出した。

Closes #32

## 実装内容
- `SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift`: `extension CRUDViewModelProtocol where Self: FirebaseSyncable { deleteDefault(id:context:removeFromLocalCache:onSuccess:) }`を新規追加
- 6ViewModel（Group/Measures/Memo/Target/Task/Note）の`delete(id:)`を上記ヘルパー呼び出し + クロージャに置き換え

このissueはissue #40（PR #175、`fetchDataDefault`/`saveDefault`/`UserOwnedEntity`追加、mainに未マージ）とは独立にmainから新規ブランチを切っており、それらには一切依存していません（両PRとも`CRUDViewModelProtocol.swift`への追記のみのためコンフリクトなくマージ可能な想定です）。

## 挙動維持の方針
各ViewModel固有の非対称性は、クロージャ（`removeFromLocalCache`/`onSuccess`）に元のロジックをそのまま移植する形で維持した:
- `GroupViewModel`: 配列全体を再フェッチ（他5VMは`removeAll(where:)`）
- `MeasuresViewModel`/`TaskViewModel`/`NoteViewModel`: 元々`hideErrorAlert()`を呼んでいなかった非対称性を維持
- `TargetViewModel`/`TaskViewModel`: 2配列（`yearlyTargets`/`monthlyTargets`、`tasks`/`taskListData`）からの除去を維持
- `TaskViewModel`: `taskUpdatedPublisher.send()`を維持
- `NoteViewModel`: フリーノート削除防止ガードは`deleteDefault`呼び出し前に維持

また、従来6ViewModel全てが`Task { performBackgroundSync(...) }`という外側のTaskラップを行っていましたが、`performBackgroundSync`自体が内部で`Task`を生成し`BackgroundSyncTracker`に追跡登録するため、外側のラップは冗長と判断し解消しました（機能的に等価、クロスレビューで検証済み）。`NoteViewModel`の`isOnlineAndLoggedIn`事前チェックも、`performBackgroundSync`が内部で同じ判定（`syncEntityToFirebaseDefault`の`guard isOnlineAndLoggedIn else { return .success(()) }`）を行うため省略しても最終結果に影響しないことを確認済みです。

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift`
- `SportsNote_iOS/ViewModel/GroupViewModel.swift`
- `SportsNote_iOS/ViewModel/MeasuresViewModel.swift`
- `SportsNote_iOS/ViewModel/MemoViewModel.swift`
- `SportsNote_iOS/ViewModel/TargetViewModel.swift`
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`
- `SportsNote_iOS/ViewModel/NoteViewModel.swift`

## ビルド・テスト結果
- `swift-format`: 正常完了
- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild test`: 581件中579件成功。失敗2件（`TaskViewModelTests.associateTasksWithMemos_sortsResultByTaskOrder`/`sameOrderTiesBreakByTaskID`）は本PRの変更と無関係な既存issue #162由来（本PRが一切触れていない`associateTasksWithMemos`関数のテストで、mainブランチ単体でも同じ2件が失敗することを確認済み）。削除系テスト（Group/Measures/Memo/Note/Target/Task全て、フリーノート削除防止テスト含む）は個別実行ですべて成功

## 完了条件チェックリスト
- [x] 6ViewModelの`delete(id:)`が共通実装を利用する形に置き換わっている
- [x] 各ViewModelの既存の削除系テストが引き続き成功する
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功（既知issue #162由来の無関係な2件を除く）

## クロスレビュー結果
独立エージェントによるクロスレビュー1ラウンドで合格（指摘なし）。ローカルキャッシュ除去ロジック・hideErrorAlert()呼び出しの有無・NoteViewModelのフリーノートガード・isOnlineAndLoggedIn省略の等価性・二重Taskラップ解消の等価性・issue #40への依存混入がないことを個別に検証済み。