### PR TITLE
fix: 「完了した課題を表示」ON/OFF切替で課題一覧の並び替えが元に戻る不具合を修正

### DIFF
--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -542,6 +542,12 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         do {
             try RealmManager.shared.updateTaskOrder(tasks: mergedTasks)
 
+            // tasks/taskListDataを最新のorderで再取得する。これを怠ると、showCompletedTasksの
+            // didSetが並び替え前のtaskListDataからfilteredTaskListDataを再構築してしまい、
+            // 完了課題表示のON/OFF切替時に並び替え結果が失われる（issue #177）
+            tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
+            convertToTaskListData()
+
             // Firebase同期（バックグラウンド）
             // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）
             let syncTask = Task<Void, Never> {

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -1418,6 +1418,42 @@ struct TaskViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "persistTaskOrder - 完了課題表示ON中に並び替えた後OFFに切り替えても順序が保持される"
+    )
+    func persistTaskOrder_thenToggleShowCompletedTasksOff_orderIsPreserved() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // A(order0,未完了) B(order1,完了) C(order2,未完了)
+        let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
+        let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: true)
+        let taskC = TaskViewModelTests.createTestTask(id: "C", groupID: "g1", order: 2, isComplete: false)
+        try? manager.saveItem(taskA)
+        try? manager.saveItem(taskB)
+        try? manager.saveItem(taskC)
+
+        _ = await viewModel.fetchData()
+
+        // 完了課題を表示した状態でCをAより前に移動（index2->0）
+        viewModel.showCompletedTasks = true
+        let mergedTasks = viewModel.reorderTaskListData(from: IndexSet(integer: 2), to: 0)
+        let result = await viewModel.persistTaskOrder(mergedTasks)
+        guard case .success = result else {
+            Issue.record("persistTaskOrder failed")
+            manager.clearAll()
+            return
+        }
+        #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A", "B"])
+
+        // 完了課題表示をOFFに戻しても、並び替え後の順序（未完了課題のみ）が保持されているべき（issue #177）
+        viewModel.showCompletedTasks = false
+        #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A"])
+
+        manager.clearAll()
+    }
+
     // MARK: - reorderMeasuresListData / persistMeasuresOrder（対策並び替えの同期性）テスト（issue #165）
 
     @Test(


### PR DESCRIPTION
## 概要
課題一覧画面で「完了した課題を表示」をONにした状態で並び替えた後、OFFに切り替えると並び替え前の順序に戻ってしまう不具合を修正しました。

## 原因
`TaskViewModel.swift`の`persistTaskOrder(_:)`（PR #168でissue #161対応のため`moveTask`から分割されたメソッド）が、`RealmManager.shared.updateTaskOrder(tasks:)`でRealmへの永続化を行った後、`self.tasks`・`self.taskListData`を再取得していなかった。

`reorderTaskListData(from:to:)`は`filteredTaskListData`のみを同期的に即時更新する設計のため、ONの間は正しい順序に見える。しかし`showCompletedTasks`の`didSet`が呼ぶ`updateFilteredTaskListData()`は`taskListData`（並び替え前のまま）から`filteredTaskListData`を再構築するため、OFFへの切替時に古い順序へ巻き戻っていた。

`save(_:isUpdate:)`など他のCRUDメソッドは保存後に必ず`self.tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)`で再取得しているが、`persistTaskOrder`だけこのパターンが漏れていた。

## 変更内容
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`: `persistTaskOrder(_:)`内で、Realm永続化成功後に`self.tasks`をRealmから再取得し`convertToTaskListData()`を呼んで`taskListData`・`filteredTaskListData`を最新化するよう修正
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`: 完了課題表示ON中に並び替え、OFFに切り替えても順序が保持されることを検証する回帰テストを追加

## テスト
- swift-format実行済み
- ビルド成功（BUILD SUCCEEDED）
- `TaskViewModelTests` 57件すべて成功（新規回帰テスト含む。既存の`moveTask`/`reorderTaskListData`/`persistMeasuresOrder`系テストにも影響なし）
- 独立したサブエージェントによるクロスレビュー実施（1ラウンド）。must-fix/should-fix/nitいずれの指摘もなし

## 完了条件
- [x] 「完了した課題を表示」ON時に並び替え、OFFに切り替えても並び順が保持される
- [x] `moveTask`（既存の一括ラッパー）の挙動に影響がないこと（既存テストが通ること）
- [x] ビルド成功
- [x] 回帰テスト追加・成功

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)