### PR TITLE
fix: 課題一覧の並び替えで指を離した直後に一瞬ゴースト表示される問題を修正

### DIFF
--- a/SportsNote_iOS/View/Task/TaskView.swift
+++ b/SportsNote_iOS/View/Task/TaskView.swift
@@ -81,9 +81,15 @@ struct TaskView: View {
                         onMoveTask: { source, destination in
                             // 表示上の並び替えは同期的に即座に反映する(issue #161)。
                             // List.onMoveのタイミングでfilteredTaskListDataが即時更新されないと
-                            // 一瞬元の位置に戻る視覚的な不整合が発生するため、Task{}でラップしない
-                            let mergedTasks = taskViewModel.reorderTaskListData(
-                                from: source, to: destination)
+                            // 一瞬元の位置に戻る視覚的な不整合が発生するため、Task{}でラップしない。
+                            // また、List.onMoveが完了時に行う暗黙のトランジションとこの同期更新が
+                            // 重なると、隣接する行が一瞬ゴースト表示されることがあるため、
+                            // アニメーションを明示的に無効化したトランザクション内で反映する（issue #179）
+                            var transaction = Transaction()
+                            transaction.disablesAnimations = true
+                            let mergedTasks = withTransaction(transaction) {
+                                taskViewModel.reorderTaskListData(from: source, to: destination)
+                            }
                             // Realmへの永続化・Firebase同期は非同期で実行
                             Task {
                                 let result = await taskViewModel.persistTaskOrder(mergedTasks)

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -343,6 +343,12 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
     /// TaskDataをTaskListDataに変換する
     private func convertToTaskListData() {
+        taskListData = buildTaskListData()
+        updateFilteredTaskListData()
+    }
+
+    /// tasksからTaskListData配列を構築する（taskListData/filteredTaskListDataへの反映は呼び出し側の責務）
+    private func buildTaskListData() -> [TaskListData] {
         var taskList = [TaskListData]()
 
         for task in tasks {
@@ -367,8 +373,7 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
             taskList.append(taskListItem)
         }
 
-        taskListData = taskList
-        updateFilteredTaskListData()
+        return taskList
     }
 
     /// フィルタリングされたタスクリストを更新
@@ -544,9 +549,13 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
             // tasks/taskListDataを最新のorderで再取得する。これを怠ると、showCompletedTasksの
             // didSetが並び替え前のtaskListDataからfilteredTaskListDataを再構築してしまい、
-            // 完了課題表示のON/OFF切替時に並び替え結果が失われる（issue #177）
+            // 完了課題表示のON/OFF切替時に並び替え結果が失われる（issue #177）。
+            // ただしfilteredTaskListData自体はreorderTaskListDataが呼び出し側で既に同期的に
+            // 反映済みのため、ここでconvertToTaskListData()経由で再代入すると、List.onMoveの
+            // 移動アニメーションと非同期タイミングで衝突し、ドラッグ終了直後に一瞬ゴースト表示
+            // される（issue #179）。taskListDataのみ最新化しfilteredTaskListDataは触らない
             tasks = try RealmManager.shared.getDataList(clazz: TaskData.self)
-            convertToTaskListData()
+            taskListData = buildTaskListData()
 
             // Firebase同期（バックグラウンド）
             // ログアウト/アカウント削除等でのRealm全削除前に完了を待機できるよう追跡登録する（Issue #84対応）

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -5,6 +5,7 @@
 //  Created by Swift Testing on 2025/11/23.
 //
 
+import Combine
 import Foundation
 import RealmSwift
 import Testing
@@ -1450,6 +1451,49 @@ struct TaskViewModelTests {
         // 完了課題表示をOFFに戻しても、並び替え後の順序（未完了課題のみ）が保持されているべき（issue #177）
         viewModel.showCompletedTasks = false
         #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A"])
+
+        manager.clearAll()
+    }
+
+    @Test(
+        "persistTaskOrder - filteredTaskListDataへの再代入（Combine publish）を発生させない（issue #179回帰）"
+    )
+    func persistTaskOrder_doesNotRepublishFilteredTaskListData() async {
+        let viewModel = TaskViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
+        let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: false)
+        let taskC = TaskViewModelTests.createTestTask(id: "C", groupID: "g1", order: 2, isComplete: false)
+        try? manager.saveItem(taskA)
+        try? manager.saveItem(taskB)
+        try? manager.saveItem(taskC)
+
+        _ = await viewModel.fetchData()
+
+        // reorderTaskListDataでfilteredTaskListDataへの同期反映を先に済ませておく
+        let mergedTasks = viewModel.reorderTaskListData(from: IndexSet(integer: 2), to: 0)
+
+        // reorderTaskListData完了後から購読を開始し、persistTaskOrder実行中にfilteredTaskListDataへの
+        // 再代入（publish）が発生しないことを検証する。List.onMoveの移動アニメーション完了前に
+        // filteredTaskListDataが再度置き換わると、一瞬ゴースト表示される不具合の再発を防ぐ（issue #179）
+        var publishCount = 0
+        var cancellables = Set<AnyCancellable>()
+        viewModel.$filteredTaskListData
+            .dropFirst()  // 購読開始時に現在値が即時発行される分はカウントしない
+            .sink { _ in publishCount += 1 }
+            .store(in: &cancellables)
+
+        let result = await viewModel.persistTaskOrder(mergedTasks)
+        guard case .success = result else {
+            Issue.record("persistTaskOrder failed")
+            manager.clearAll()
+            return
+        }
+
+        #expect(publishCount == 0, "persistTaskOrderはfilteredTaskListDataへ再代入すべきではない")
+        #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A", "B"])
 
         manager.clearAll()
     }


### PR DESCRIPTION
## 概要
issue #179（課題一覧の並び替えで指を離した直後に一瞬ゴースト表示される）に対する2つの修正をまとめたPRです。

### 経緯（重要）
1回目の修正のみを含むコミットは、誤って先にマージ済みのPR #178（[Closes #177](https://github.com/Takatoshi-Miura/SportsNote_iOS/pull/178)）に追加pushしてしまいましたが、PR #178は既にマージ済みだったため反映されず、宙に浮いた状態（`ac4b969`, dangling commit）になっていました。本PRでこれをcherry-pickし、2つ目の修正（Transactionによるアニメーション無効化）と合わせて統合しています。

## 変更内容

### 1. `persistTaskOrder(_:)`のfilteredTaskListData再代入回避（コミット`c176c31`）
`persistTaskOrder(_:)`内で`convertToTaskListData()`を呼ぶと`filteredTaskListData`が再代入され、`reorderTaskListData`による同期更新（List.onMoveの移動アニメーション）と非同期タイミングで衝突し、ドラッグ終了直後に一瞬ゴースト表示されていた。`convertToTaskListData()`を`taskListData`構築ロジック（`buildTaskListData()`）と`filteredTaskListData`反映ロジックに分割し、`persistTaskOrder`では前者のみ呼ぶよう修正。

回帰テスト追加: `persistTaskOrder`実行中に`filteredTaskListData`への再代入（Combine publish）が発生しないことを検証。修正を一時的に退行させて実際にテストが失敗することを手動確認済み。

ユーザー提供の画面録画（フレーム分解）により、この修正でゴーストの継続時間が約0.15秒相当→約0.05秒（1フレーム）に短縮されることを確認。ただし完全な解消には至らなかった。

### 2. List.onMoveの暗黙のトランジション抑制（コミット`e6c7157`）
1の修正後も残っていたごく短いゴースト表示について、SwiftUIの`List`が`.onMove`完了時に持つ暗黙のトランジションと、`reorderTaskListData`によるデータの同期更新が競合している可能性を疑い、`onMoveTask`ハンドラでのデータ更新を`disablesAnimations = true`のトランザクションでラップしてアニメーションを無効化。

**この2つ目の修正は理論的仮説に基づくものです。** クロスレビューでも「未検証のまま実機確認なしでマージするのはリスクが高い」との指摘（must-fix）を受けています。ビルド・既存テストは成功していますが、View層のアニメーション挙動という性質上、機械的に検証する手段がなく、実機/シミュレータでの目視確認が必須です。

## テスト
- swift-format実行済み
- ビルド成功（BUILD SUCCEEDED）
- `TaskViewModelTests` 58件すべて成功

## 完了条件
- [ ] 並び替えモードでドラッグして指を離した際、ゴースト表示が発生しないこと（**実機/シミュレータでの目視確認必須**）
- [x] issue #177の完了条件（完了課題表示ON/OFF切替時に並び順が保持される）が引き続き満たされること
- [x] ビルド成功、既存テストが通ること

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)