### PR TITLE
refactor: Memo.swiftの未使用プロパティnoteDateを削除

### DIFF
--- a/SportsNote_iOS/Model/Memo.swift
+++ b/SportsNote_iOS/Model/Memo.swift
@@ -11,7 +11,6 @@ class Memo: Object {
     @Persisted var isDeleted: Bool
     @Persisted var created_at: Date
     @Persisted var updated_at: Date
-    var noteDate: Date = Date()
 
     /// デフォルトイニシャライザ
     override init() {


### PR DESCRIPTION
## 概要
`Memo.swift`14行目の`var noteDate: Date = Date()`は、他のプロパティ（`memoID`/`userID`/`measuresID`/`noteID`/`detail`/`isDeleted`/`created_at`/`updated_at`）と異なり`@Persisted`が付与されておらずRealmに永続化されない、完全な未使用プロパティ（デッドコード）だった。宣言・デフォルト初期化以外に代入・参照箇所が一切ないことをリポジトリ全体のgrepで確認し、削除した。

Closes #24

## 実装内容
- `SportsNote_iOS/Model/Memo.swift`: 14行目の`var noteDate: Date = Date()`を削除

`MeasuresMemo`構造体（`date`プロパティを持つ、`Memo.noteDate`とは無関係かつ使用されている）は対象外（issue本文の「やらないこと」に明記済み）。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Memo.swift`（1行削除のみ）

## ビルド・テスト結果
- swift-format: 正常完了
- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild test`: 598件全テスト成功

## 完了条件チェックリスト
- [x] `Memo.swift`14行目の未使用プロパティ`noteDate`が削除されている
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功

## クロスレビュー結果
独立エージェントによるクロスレビュー1ラウンドで合格（指摘なし）。コミット済みであること（`git log`/`git show`）、削除後にリポジトリ内へ`noteDate`参照が残っていないこと（`git grep`）、ビルド・テストの成功をいずれも独立に再検証済み。