### PR TITLE
fix: Group/TaskData/Measures/Note削除時のカスケード論理削除がFirebaseに同期されない不具合を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -20,6 +20,23 @@ extension Measures: SoftDeletable {}
 extension Memo: SoftDeletable {}
 extension Target: SoftDeletable {}
 
+/// RealmManager.logicalDeleteがカスケードで論理削除した子エンティティの集合
+///
+/// Group/TaskData/Measures/Noteの削除時、RealmManager.logicalDeleteは関連する子エンティティ
+/// （TaskData→Measures→Memo等）も同一トランザクション内で再帰的に論理削除するが、
+/// 削除対象本体しかFirebaseに同期されないとカスケード分がクラウド側に反映されない（issue #181）。
+/// 呼び出し元（CRUDViewModelProtocol.deleteDefault）がこのカスケード対象をFirebaseに同期できるように、
+/// logicalDeleteの戻り値として返す。
+struct CascadeDeletedEntities {
+    var tasks: [TaskData] = []
+    var measures: [Measures] = []
+    var memos: [Memo] = []
+
+    var isEmpty: Bool {
+        tasks.isEmpty && measures.isEmpty && memos.isEmpty
+    }
+}
+
 /// userIDを保持するRealmモデルの共通インターフェース
 ///
 /// 保存時のuserID巻き戻し処理（アカウント作成直後のuserID切替タイミングでも
@@ -616,8 +633,12 @@ final class RealmManager {
     /// - Parameters:
     ///   - T: RealmObject を継承したデータ型
     ///   - id: 削除するデータの ID
+    /// - Returns: カスケードで論理削除された子エンティティ（TaskData/Measures/Memo）
+    ///   呼び出し元がFirebaseへの同期対象として利用する（issue #181対応）
     /// - Throws: SportsNoteError削除に失敗した場合
-    internal func logicalDelete<T: Object>(id: String, type: T.Type) throws {
+    @discardableResult
+    internal func logicalDelete<T: Object>(id: String, type: T.Type) throws -> CascadeDeletedEntities {
+        var cascade = CascadeDeletedEntities()
         do {
             let realm = try getRealm()
 
@@ -629,19 +650,25 @@ final class RealmManager {
 
                     // T 型に基づく関連エンティティの削除処理
                     if let note = item as? Note {
-                        deleteRelatedNoteMemos(noteID: note.noteID, realm: realm)
+                        cascade.memos = deleteRelatedNoteMemos(noteID: note.noteID, realm: realm)
                     } else if let group = item as? Group {
-                        deleteRelatedTasks(groupID: group.groupID, realm: realm)
+                        let related = deleteRelatedTasks(groupID: group.groupID, realm: realm)
+                        cascade.tasks = related.tasks
+                        cascade.measures = related.measures
+                        cascade.memos = related.memos
                     } else if let taskData = item as? TaskData {
-                        deleteRelatedMeasures(taskID: taskData.taskID, realm: realm)
+                        let related = deleteRelatedMeasures(taskID: taskData.taskID, realm: realm)
+                        cascade.measures = related.measures
+                        cascade.memos = related.memos
                     } else if let measures = item as? Measures {
-                        deleteRelatedMeasuresMemos(measuresID: measures.measuresID, realm: realm)
+                        cascade.memos = deleteRelatedMeasuresMemos(measuresID: measures.measuresID, realm: realm)
                     }
                 }
             }
         } catch let error {
             throw ErrorMapper.mapRealmError(error, context: "logicalDelete-\(String(describing: T.self))-\(id)")
         }
+        return cascade
     }
 
     /// 任意のオブジェクトを論理削除
@@ -664,46 +691,73 @@ final class RealmManager {
     /// - Parameters:
     ///   - noteID: ノートID
     ///   - realm: Realm トランザクション
-    private func deleteRelatedNoteMemos(noteID: String, realm: Realm) {
+    /// - Returns: 論理削除したMemoの一覧（Firebase同期用）
+    @discardableResult
+    private func deleteRelatedNoteMemos(noteID: String, realm: Realm) -> [Memo] {
         let memos = realm.objects(Memo.self).filter("noteID == %@", noteID)
+        var deletedMemos: [Memo] = []
         for memo in memos {
             markAsDeleted(memo, realm: realm)
+            deletedMemos.append(memo)
         }
+        return deletedMemos
     }
 
     /// Group に関連する TaskData, Measures, Memo を削除
     /// - Parameters:
     ///   - groupID: グループID
     ///   - realm: Realm トランザクション
-    private func deleteRelatedTasks(groupID: String, realm: Realm) {
+    /// - Returns: 論理削除したTaskData/Measures/Memoの一覧（Firebase同期用）
+    private func deleteRelatedTasks(
+        groupID: String, realm: Realm
+    ) -> (
+        tasks: [TaskData], measures: [Measures], memos: [Memo]
+    ) {
         let tasks = realm.objects(TaskData.self).filter("groupID == %@", groupID)
+        var deletedTasks: [TaskData] = []
+        var deletedMeasures: [Measures] = []
+        var deletedMemos: [Memo] = []
         for task in tasks {
             markAsDeleted(task, realm: realm)
-            deleteRelatedMeasures(taskID: task.taskID, realm: realm)
+            deletedTasks.append(task)
+            let related = deleteRelatedMeasures(taskID: task.taskID, realm: realm)
+            deletedMeasures.append(contentsOf: related.measures)
+            deletedMemos.append(contentsOf: related.memos)
         }
+        return (deletedTasks, deletedMeasures, deletedMemos)
     }
 
     /// TaskData に関連する Measures, Memo を削除
     /// - Parameters:
     ///   - taskID: 課題ID
     ///   - realm: Realm トランザクション
-    private func deleteRelatedMeasures(taskID: String, realm: Realm) {
+    /// - Returns: 論理削除したMeasures/Memoの一覧（Firebase同期用）
+    private func deleteRelatedMeasures(taskID: String, realm: Realm) -> (measures: [Measures], memos: [Memo]) {
         let measures = realm.objects(Measures.self).filter("taskID == %@", taskID)
+        var deletedMeasures: [Measures] = []
+        var deletedMemos: [Memo] = []
         for measure in measures {
             markAsDeleted(measure, realm: realm)
-            deleteRelatedMeasuresMemos(measuresID: measure.measuresID, realm: realm)
+            deletedMeasures.append(measure)
+            deletedMemos.append(contentsOf: deleteRelatedMeasuresMemos(measuresID: measure.measuresID, realm: realm))
         }
+        return (deletedMeasures, deletedMemos)
     }
 
     /// Measures に関連する Memo を削除
     /// - Parameters:
     ///   - measuresID: 対策ID
     ///   - realm: Realm トランザクション
-    private func deleteRelatedMeasuresMemos(measuresID: String, realm: Realm) {
+    /// - Returns: 論理削除したMemoの一覧（Firebase同期用）
+    @discardableResult
+    private func deleteRelatedMeasuresMemos(measuresID: String, realm: Realm) -> [Memo] {
         let memos = realm.objects(Memo.self).filter("measuresID == %@", measuresID)
+        var deletedMemos: [Memo] = []
         for memo in memos {
             markAsDeleted(memo, realm: realm)
+            deletedMemos.append(memo)
         }
+        return deletedMemos
     }
 
     /// Realmの全データを削除

--- a/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
+++ b/SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift
@@ -138,7 +138,8 @@ extension CRUDViewModelProtocol where Self: FirebaseSyncable {
             let entityToDelete = try RealmManager.shared.getObjectById(id: id, type: EntityType.self)
 
             // Realm操作はMainActorで実行
-            try RealmManager.shared.logicalDelete(id: id, type: EntityType.self)
+            // logicalDeleteはカスケードで論理削除された子エンティティ（TaskData/Measures/Memo）を返す（issue #181）
+            let cascade = try RealmManager.shared.logicalDelete(id: id, type: EntityType.self)
 
             // Firebase同期はバックグラウンドで実行（削除前に取得したオブジェクトを使用）
             // performBackgroundSync自体が内部でTaskを生成しBackgroundSyncTrackerに追跡登録するため、
@@ -146,6 +147,8 @@ extension CRUDViewModelProtocol where Self: FirebaseSyncable {
             if let entityToDelete = entityToDelete {
                 performBackgroundSync(entityToDelete, isUpdate: true)
             }
+            // カスケードで論理削除された子エンティティもFirebaseに同期する（issue #181）
+            performCascadeBackgroundSync(cascade)
 
             // ローカルキャッシュからの除去はViewModelごとに異なるため呼び出し元に委譲
             try removeFromLocalCache()
@@ -156,5 +159,45 @@ extension CRUDViewModelProtocol where Self: FirebaseSyncable {
             let sportsNoteError = convertToSportsNoteError(error, context: context)
             return .failure(sportsNoteError)
         }
+    }
+
+    /// カスケードで論理削除された子エンティティ（TaskData/Measures/Memo）をバックグラウンドでFirebaseに同期する
+    ///
+    /// Group/TaskData/Measures/Noteの削除時、RealmManager.logicalDeleteは同一トランザクション内で
+    /// 子エンティティも再帰的に論理削除するが、削除対象本体のみをperformBackgroundSyncで同期していると
+    /// カスケード分がFirebaseに反映されず孤立データが残ってしまう（issue #181）。
+    /// performBackgroundSyncと同様、Task生成・BackgroundSyncTrackerへの追跡登録は
+    /// オンライン状態に関わらず同期的に行い（issue #164の回帰パターンを踏襲）、
+    /// 実際のFirebase呼び出しのみTask内でisOnlineAndLoggedInによりガードする。
+    /// - Parameter cascade: logicalDeleteが返したカスケード削除対象
+    private func performCascadeBackgroundSync(_ cascade: CascadeDeletedEntities) {
+        guard !cascade.isEmpty else { return }
+
+        let task = Task {
+            guard isOnlineAndLoggedIn else { return }
+
+            for taskData in cascade.tasks {
+                do {
+                    try await FirebaseManager.shared.updateTask(task: taskData)
+                } catch {
+                    print("Failed to sync cascade-deleted TaskData to Firebase: \(error)")
+                }
+            }
+            for measures in cascade.measures {
+                do {
+                    try await FirebaseManager.shared.updateMeasures(measures: measures)
+                } catch {
+                    print("Failed to sync cascade-deleted Measures to Firebase: \(error)")
+                }
+            }
+            for memo in cascade.memos {
+                do {
+                    try await FirebaseManager.shared.updateMemo(memo: memo)
+                } catch {
+                    print("Failed to sync cascade-deleted Memo to Firebase: \(error)")
+                }
+            }
+        }
+        BackgroundSyncTracker.shared.track(task)
     }
 }

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -376,6 +376,56 @@ struct RealmManagerTests {
         manager.clearAll()
     }
 
+    @Test(
+        "logicalDelete - カスケード削除された子エンティティ（TaskData/Measures/Memo）が戻り値として返る（issue #181回帰）"
+    )
+    func logicalDelete_returnsCascadeDeletedEntities() async throws {
+        let group = Group(groupID: "g-cascade-return", title: "Group", color: 0, order: 0, created_at: Date())
+
+        let task = TaskData()
+        task.taskID = "t-cascade-return"
+        task.groupID = "g-cascade-return"
+
+        let measures = Measures()
+        measures.measuresID = "m-cascade-return"
+        measures.taskID = "t-cascade-return"
+
+        let memo = Memo()
+        memo.memoID = "memo-cascade-return"
+        memo.measuresID = "m-cascade-return"
+
+        try manager.saveItem(group)
+        try manager.saveItem(task)
+        try manager.saveItem(measures)
+        try manager.saveItem(memo)
+
+        // Groupを削除すると、カスケードで論理削除されたTaskData/Measures/Memoが
+        // 戻り値として返り、呼び出し元（CRUDViewModelProtocol.deleteDefault）が
+        // それらをFirebaseに同期できるようになっている必要がある
+        let cascade = try manager.logicalDelete(id: "g-cascade-return", type: Group.self)
+
+        #expect(cascade.tasks.map { $0.taskID } == ["t-cascade-return"])
+        #expect(cascade.measures.map { $0.measuresID } == ["m-cascade-return"])
+        #expect(cascade.memos.map { $0.memoID } == ["memo-cascade-return"])
+        #expect(cascade.isEmpty == false)
+
+        manager.clearAll()
+    }
+
+    @Test("logicalDelete - 子エンティティを持たない削除では空のCascadeDeletedEntitiesが返る")
+    func logicalDelete_returnsEmptyCascadeWhenNoChildren() async throws {
+        let measures = Measures()
+        measures.measuresID = "m-no-children"
+        measures.taskID = "t-no-children"
+        try manager.saveItem(measures)
+
+        let cascade = try manager.logicalDelete(id: "m-no-children", type: Measures.self)
+
+        #expect(cascade.isEmpty == true)
+
+        manager.clearAll()
+    }
+
     // MARK: - 検索機能テスト
 
     @Test("searchNotesByQuery - クエリでノートを検索できる")

--- a/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
@@ -457,6 +457,55 @@ struct GroupViewModelTests {
         manager.clearAll()
     }
 
+    @Test(
+        "delete - カスケードで論理削除された子エンティティ（TaskData/Measures/Memo）もバックグラウンドFirebase同期が追跡登録される（issue #181回帰）"
+    )
+    func delete_tracksCascadeBackgroundSyncForChildEntities() async {
+        let viewModel = GroupViewModel()
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        // 他テストの追跡Taskが残っていないことを保証
+        await BackgroundSyncTracker.shared.waitForAll()
+
+        // 他グループを1つ用意しcanDeleteをtrueにした上で、g1配下にTaskData/Measures/Memoを作成する
+        let group1 = Group(
+            groupID: "g1", title: "Group 1", color: GroupColor.red.rawValue, order: 0, created_at: Date())
+        let group2 = Group(
+            groupID: "g2", title: "Group 2", color: GroupColor.blue.rawValue, order: 1, created_at: Date())
+        try? manager.saveItem(group1)
+        try? manager.saveItem(group2)
+
+        let task = TaskData()
+        task.taskID = "t-cascade-sync"
+        task.groupID = "g1"
+        try? manager.saveItem(task)
+
+        let measures = Measures()
+        measures.measuresID = "m-cascade-sync"
+        measures.taskID = "t-cascade-sync"
+        try? manager.saveItem(measures)
+
+        let memo = Memo()
+        memo.memoID = "memo-cascade-sync"
+        memo.measuresID = "m-cascade-sync"
+        try? manager.saveItem(memo)
+
+        _ = await viewModel.fetchData()
+
+        _ = await viewModel.delete(id: "g1")
+
+        // 削除対象本体（Group）分のTaskに加え、カスケードで論理削除された
+        // TaskData/Measures/Memoをまとめて同期するTaskが1件、delete(id:)から戻った
+        // 時点（追加のawait/yieldを挟まない）で既に追跡登録されている必要がある（issue #181対応）
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 2)
+
+        await BackgroundSyncTracker.shared.waitForAll()
+        #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
+
+        manager.clearAll()
+    }
+
     @Test("saveGroup - 既存インターフェースでグループを保存できる")
     func saveGroup_savesWithLegacyInterface() async {
         let viewModel = GroupViewModel()


### PR DESCRIPTION
## 概要
Group/TaskData/Measures/Noteの削除時、`RealmManager.logicalDelete`はRealm内で関連する子エンティティ（TaskData→Measures→Memo等）を再帰的に論理削除するが、削除対象本体のみがFirebaseに同期され、カスケードで論理削除された子エンティティは一切送信されていなかった。

`RealmManager.logicalDelete`がカスケードで論理削除したTaskData/Measures/Memoを新設の`CascadeDeletedEntities`構造体として呼び出し元に返すように変更し、`CRUDViewModelProtocol.deleteDefault`（Group/TaskData/Measures/NoteのdeleteはすべてこのAPIに集約済み）が削除対象本体だけでなくカスケード分も新設の`performCascadeBackgroundSync`経由でFirebaseに同期するようにした。

### 設計判断の補足
issue本文は「各ViewModelのdelete(id:)を個別修正」を想定していたが、直近マージ済みのissue #40/#32のPRで各ViewModelの`delete(id:)`は既に`CRUDViewModelProtocol.deleteDefault`という共通実装1箇所に集約されていたため、その1箇所（`RealmManager.logicalDelete`の戻り値化＋`deleteDefault`内の`performCascadeBackgroundSync`追加）を変更する設計に切り替えた。

Closes #181

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/RealmManager.swift`: `logicalDelete`が`CascadeDeletedEntities`（tasks/measures/memos）を返すよう変更（`@discardableResult`、既存呼び出し元は非破壊）。`deleteRelatedNoteMemos`/`deleteRelatedTasks`/`deleteRelatedMeasures`/`deleteRelatedMeasuresMemos`も論理削除したオブジェクトの配列を返すよう変更
- `SportsNote_iOS/ViewModel/Protocols/CRUDViewModelProtocol.swift`: `deleteDefault`がcascadeを受け取り、新設の`performCascadeBackgroundSync`でFirebaseに同期（`performBackgroundSync`と同じくTask生成・追跡登録は同期的、実際のFirebase呼び出しのみ`isOnlineAndLoggedIn`でガード）
- `SportsNote_iOSTests/Managers/RealmManagerTests.swift`: `logicalDelete`の戻り値検証テスト2件を追加
- `SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift`: カスケード削除時のFirebase同期Task追跡登録を検証する回帰テストを追加

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 601件全PASS（新規追加分含む）

## 完了条件
- [x] Group/TaskData/Measures/Noteいずれかを削除した際、カスケードで論理削除された子エンティティ（TaskData/Measures/Memo）もFirebaseに同期されること
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功
- [x] 新規回帰テストが追加され成功すること

## クロスレビュー結果
独立コンテキストのエージェントによるレビューを実施し、must-fix指摘なしで合格。
- should-fix: `performCascadeBackgroundSync`はFirebase書き込み失敗時にprintのみでUIへのエラー通知（`showErrorAlert`）を行わない（本体側の`performBackgroundSync`と非対称）。ローカルの`updated_at`は更新済みのため次回`syncAllData()`でリカバリされる想定。issueスコープ外として見送り
- nit: カスケードヘルパーが`isDeleted == false`で絞り込んでおらず、既に個別削除済みの子も再度cascade対象に含まれうるが、冪等な上書きのため実害なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)