### PR TITLE
fix: 練習ノート振り返り欄で対策優先度変更後も実際に紐づく対策名を表示する

### DIFF
--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -402,7 +402,22 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 continue
             }
             if let task = taskListData.first(where: { $0.taskID == measures.taskID }) {
-                result[task.taskID] = (task: task, memo: memo)
+                // taskListData由来のtask.measures/measuresIDは常に「現在の最優先対策」を指すため、
+                // 対策の優先度（並び順）を変更した後は、実際にメモが紐づく対策と表示上の対策名が
+                // 乖離してしまう。ここで既に取得済みのmeasures（memo.measuresIDが実際に指す対策）の
+                // title/measuresIDで上書きし、表示専用の対策名をメモが実際に紐づく対策に一致させる（issue #183）
+                let resolvedTask = TaskListData(
+                    taskID: task.taskID,
+                    groupID: task.groupID,
+                    groupColor: task.groupColor,
+                    title: task.title,
+                    measuresID: measures.measuresID,
+                    measures: measures.title,
+                    memoID: task.memoID,
+                    order: task.order,
+                    isComplete: task.isComplete
+                )
+                result[task.taskID] = (task: resolvedTask, memo: memo)
             }
         }
         // Dictionary経由で組み立てるため列挙順が不定になる。task.order昇順にソートし、

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -516,6 +516,52 @@ struct TaskViewModelTests {
         #expect(pairs.count == 1)
         #expect(pairs.first?.task.taskID == "task-1")
         #expect(pairs.first?.memo.memoID == "memo-1")
+        // 対策の優先度変更後も、表示される対策名/IDはメモが実際に紐づく対策（measures-a="Measures A"）の
+        // ままであり、taskListData由来の「現在の最優先対策」（measures-b="Measures B"）にすり替わらないこと
+        // （issue #183回帰: 対策の並び替え後、練習ノートの振り返り欄の対策名表示が実際に紐づく対策と乖離する不具合）
+        #expect(pairs.first?.task.measuresID == "measures-a")
+        #expect(pairs.first?.task.measures == "Measures A")
+
+        manager.clearAll()
+    }
+
+    @Test("associateTasksWithMemos - 新規メモ作成時（並び替えなし）は現在の最優先対策の名前がそのまま表示される（issue #183: 既存動作の回帰なし）")
+    func associateTasksWithMemos_showsCurrentMeasuresNameWhenNoReorderHappened() async {
+        let manager = RealmManager.shared
+        manager.clearAll()
+
+        let viewModel = TaskViewModel()
+        let task = TaskListData(
+            taskID: "task-1",
+            groupID: "group-1",
+            groupColor: .red,
+            title: "Test Task",
+            measuresID: "measures-1",
+            measures: "Test Measures",
+            memoID: nil,
+            order: 0,
+            isComplete: false
+        )
+        viewModel.taskListData = [task]
+
+        try? manager.saveItem(
+            Measures(measuresID: "measures-1", taskID: "task-1", title: "Test Measures", order: 0, created_at: Date())
+        )
+
+        // 並び替えを経ていない新規メモは、taskListDataの最優先対策とmemo.measuresIDが一致する
+        let memo = Memo(
+            memoID: "memo-1",
+            measuresID: "measures-1",
+            noteID: "note-1",
+            detail: "新規メモ",
+            created_at: Date()
+        )
+
+        let pairs = viewModel.associateTasksWithMemos(memos: [memo])
+
+        #expect(pairs.count == 1)
+        #expect(pairs.first?.task.measuresID == "measures-1")
+        #expect(pairs.first?.task.measures == "Test Measures")
 
         manager.clearAll()
     }


### PR DESCRIPTION
## 概要
練習ノートの「取り組んだ課題」振り返り欄に表示される対策名が、対策の優先度（並び順）を変更した後は常に「現在の最優先対策」の名前になってしまい、実際にそのメモが紐づいている対策の名前と一致しない不具合を修正した。issue #160の再オープン後コメントで報告された残課題。

`TaskViewModel.associateTasksWithMemos`が`taskListData`由来の`task`（`measures`/`measuresID`は常に「現在の最優先対策」を指す）をそのまま`(task, memo)`ペアとして返していたため、対策の並び替え後は表示上の対策名だけが実態と乖離していた。既に`getObjectById`で取得済みの、メモが実際に紐づくMeasuresオブジェクトの`title`/`measuresID`で上書きした`TaskListData`を返すよう修正した。

Closes #183

## 変更ファイル一覧
- `SportsNote_iOS/ViewModel/TaskViewModel.swift`: `associateTasksWithMemos`が、taskの他フィールドはそのまま踏襲しつつ`measures`/`measuresID`のみメモが実際に紐づく対策の値で上書きした`resolvedTask`を返すよう修正
- `SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift`: 既存の`associateTasksWithMemos_matchesAfterMeasuresReorder`に対策名/ID一致のアサーションを追加。新規メモ作成時（並び替えなし）は現在の最優先対策名が正しく表示される既存動作の回帰なしを検証する新規テストを追加

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 599件全PASS（新規追加分含む）

## 完了条件
- [x] 再現手順1〜4を実施した際、練習ノートの振り返り欄に表示される対策名が「対策A」（メモが実際に紐づく対策）のまま維持されること
- [x] 新規メモ作成時は引き続き現在の最優先対策の名前が正しく表示されること（既存動作の回帰がないこと）
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 既存テストがすべて成功、および本不具合を再現する回帰テストを追加し成功すること

## クロスレビュー結果
独立コンテキストのエージェントによるレビューを実施し、指摘なしで合格。修正を一時的にロールバックして回帰テストが実際に失敗することも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)