### PR TITLE
fix: 旧アプリマイグレーションで同一課題・同一ノートに重複Memoが生成される問題を修正

### DIFF
--- a/SportsNote_iOS/Model/Manager/MigrationManager.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationManager.swift
@@ -210,6 +210,9 @@ final class MigrationManager {
             measuresPriority: measuresPriority
         )
 
+        // 対策ごとの効果コメントを収集する（Memoへの変換は課題全体でノートIDごとにマージしてから行う。issue #184）
+        var effectivenessByMeasures: [MigrationMemoMerger.MeasuresEffectiveness] = []
+
         for (measuresOrder, measuresTitle) in orderedTitles.enumerated() {
             guard let effectivenessArray = measuresData[measuresTitle] else { continue }
 
@@ -226,27 +229,35 @@ final class MigrationManager {
             try RealmManager.shared.saveItem(measures)
             try await FirebaseManager.shared.saveMeasures(measures: measures)
 
-            // 有効性コメントを Memo に変換
             // effectivenessArray: [ ["コメント文字列": ノートID(Int)], ... ]
+            var comments: [(comment: String, oldNoteID: Int)] = []
             for effectivenessDict in effectivenessArray {
                 for (comment, oldNoteIDInt) in effectivenessDict {
-                    guard !comment.isEmpty else { continue }
-
-                    let memo = Memo()
-                    memo.memoID = UUIDGenerator.generateID()
-                    memo.userID = userID
-                    memo.measuresID = measures.measuresID
-                    // noteID は旧 Int を String に変換して保持（Note 変換時の noteID と整合させる）
-                    memo.noteID = oldNoteIDInt == 0 ? "" : String(oldNoteIDInt)
-                    memo.detail = comment
-                    memo.isDeleted = false
-                    memo.created_at = now
-                    memo.updated_at = now
-
-                    try RealmManager.shared.saveItem(memo)
-                    try await FirebaseManager.shared.saveMemo(memo: memo)
+                    comments.append((comment: comment, oldNoteID: oldNoteIDInt))
                 }
             }
+            effectivenessByMeasures.append(
+                MigrationMemoMerger.MeasuresEffectiveness(measuresID: measures.measuresID, comments: comments))
+        }
+
+        // 旧アプリは効果コメントを対策単位で保持していたため、同一ノートで複数対策にコメントが
+        // 付いていた場合、素直に変換すると同一taskID・同一noteIDだが異なるmeasuresIDを持つ複数の
+        // Memoが生成されてしまう（新データモデルは1課題1メモ/ノートが前提のため、片方が画面から
+        // 見えなくなる。issue #184）。ノートIDごとに1件へマージしてからMemoを生成する
+        let mergedMemos = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+        for merged in mergedMemos {
+            let memo = Memo()
+            memo.memoID = UUIDGenerator.generateID()
+            memo.userID = userID
+            memo.measuresID = merged.measuresID
+            memo.noteID = merged.noteID
+            memo.detail = merged.detail
+            memo.isDeleted = false
+            memo.created_at = now
+            memo.updated_at = now
+
+            try RealmManager.shared.saveItem(memo)
+            try await FirebaseManager.shared.saveMemo(memo: memo)
         }
     }
 

--- a/SportsNote_iOS/Model/Manager/MigrationMemoMerger.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationMemoMerger.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// 旧アプリのmeasuresData（対策単位で保持されていた効果コメント）を、
+/// 新データモデルの「1課題1メモ/ノート」という前提に適合させるため、
+/// 同一の実ノート（旧noteID、0以外）に属する複数対策の効果コメントを1件のMemoにマージする純粋関数
+///
+/// 旧アプリは効果コメントを対策(Measures)単位で保持していたため、同一の練習ノートで
+/// 複数の対策にコメントが付いていた場合、変換時に素直にMemoを生成すると
+/// 同一taskID・同一noteIDだが異なるmeasuresIDを持つ複数のMemoレコードが生成されてしまう。
+/// 新データモデルの`TaskViewModel.associateTasksWithMemos`は「1課題1メモ」を前提に
+/// taskIDでDictionaryキー化するため、後から処理された方でもう一方が画面から見えなくなる
+/// （データ自体はRealm/Firestoreに残るが、ユーザーからは消失したように見える。issue #184）。
+///
+/// 一方、旧noteID == 0（新データモデルでのnoteID = ""、旧アプリでノートに紐付けられなかった
+/// 効果コメント）は、`MemoViewModel.getMemosByMeasuresID`により対策ごとに独立した一覧として
+/// 表示される前提のため、`associateTasksWithMemos`の「1課題1メモ/ノート」制約の対象外であり、
+/// マージ対象にしてはいけない（マージすると異なる対策の独立したコメントが1件に統合され、
+/// 対策詳細画面から一方のコメントが消えてしまう回帰を生む。クロスレビュー指摘により判明）。
+/// そのため実ノートID（0以外）のみをマージキーとして扱い、noteID == ""のコメントは
+/// 対策ごとに個別のMemoとしてそのまま生成する。
+///
+/// `MigrationManager`（Firebase依存でテスト環境ではインスタンス化できない）から独立した
+/// 純粋関数とすることで、Firebase未設定のテスト環境でも単体テスト可能にする
+/// （`MeasuresOrderResolver`と同じ設計方針）
+enum MigrationMemoMerger {
+
+    /// マージ後に生成すべきMemoの情報
+    struct MergedMemo: Equatable {
+        /// メモが紐づく対策ID（実ノートに複数対策のコメントがあり1件へマージされた場合は、
+        /// 呼び出し元が渡した順序（通常はmeasuresPriorityが最優先の対策順）で最初に登場した対策のIDを採用する）
+        let measuresID: String
+        /// 旧Int型noteIDを変換したノートID（Note変換時のnoteIDと整合させるための文字列表現）。
+        /// 空文字は旧アプリでノートに紐付けられなかったコメントを表す
+        let noteID: String
+        /// 本文（実ノートへの複数コメントがマージされた場合は改行区切りで連結する）
+        let detail: String
+    }
+
+    /// 対策ごとの効果コメント一覧
+    struct MeasuresEffectiveness {
+        let measuresID: String
+        /// (コメント文字列, 旧ノートID(Int)) の配列
+        let comments: [(comment: String, oldNoteID: Int)]
+
+        init(measuresID: String, comments: [(comment: String, oldNoteID: Int)]) {
+            self.measuresID = measuresID
+            self.comments = comments
+        }
+    }
+
+    /// - Parameter effectivenessByMeasures: 課題（TaskData）1件に属する対策ごとの効果コメント一覧。
+    ///   呼び出し元でmeasuresOrder順（measuresPriorityが最優先）に並べたものを渡すこと
+    /// - Returns: Memo生成計画。実ノートID（0以外）のコメントは同一noteIDごとに1件へマージし、
+    ///   ノート未紐付け（旧noteID == 0）のコメントはマージせずコメントごとに個別のまま返す。
+    ///   全体を通じて、最初にそのエントリが出現した順（＝measuresPriorityが最優先の対策から
+    ///   処理される前提）を維持する
+    static func merge(effectivenessByMeasures: [MeasuresEffectiveness]) -> [MergedMemo] {
+        var result: [MergedMemo] = []
+        // 実ノートID（0以外）のみをマージキーとして扱う。noteID == ""の位置をこのDictionaryで
+        // 管理しないことで、ノート未紐付けのコメントは常に個別のMergedMemoとして追加される
+        var indexByNoteID: [String: Int] = [:]
+
+        for measuresEffectiveness in effectivenessByMeasures {
+            for (comment, oldNoteIDInt) in measuresEffectiveness.comments {
+                guard !comment.isEmpty else { continue }
+
+                guard oldNoteIDInt != 0 else {
+                    // ノート未紐付けのコメントは対策ごとに独立して表示される前提のため、
+                    // 他の対策のコメントとマージせずそのまま個別のMemoとして追加する
+                    result.append(
+                        MergedMemo(measuresID: measuresEffectiveness.measuresID, noteID: "", detail: comment))
+                    continue
+                }
+
+                // noteID は旧 Int を String に変換して保持（Note 変換時の noteID と整合させる）
+                let noteID = String(oldNoteIDInt)
+
+                if let index = indexByNoteID[noteID] {
+                    // 既に同一ノートのコメントがある場合は本文を追記してマージし、
+                    // measuresIDは先に登場した対策のものを維持する（measuresPriority優先）
+                    let existing = result[index]
+                    result[index] = MergedMemo(
+                        measuresID: existing.measuresID,
+                        noteID: noteID,
+                        detail: existing.detail + "\n" + comment
+                    )
+                } else {
+                    indexByNoteID[noteID] = result.count
+                    result.append(
+                        MergedMemo(
+                            measuresID: measuresEffectiveness.measuresID,
+                            noteID: noteID,
+                            detail: comment
+                        ))
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/SportsNote_iOSTests/Managers/MigrationMemoMergerTests.swift
+++ b/SportsNote_iOSTests/Managers/MigrationMemoMergerTests.swift
@@ -1,0 +1,166 @@
+//
+//  MigrationMemoMergerTests.swift
+//  SportsNote_iOSTests
+//
+//  Created by Swift Testing on 2026/08/11.
+//
+
+import Foundation
+import Testing
+
+@testable import SportsNote_iOS
+
+/// `MigrationMemoMerger`は Realm/UserDefaults/NotificationCenter/シングルトンのいずれにも
+/// 依存しない純粋関数のため、`.serialized`は不要（issue #184、`MeasuresOrderResolverTests`と同方針）
+@Suite("MigrationMemoMerger Tests")
+struct MigrationMemoMergerTests {
+
+    @Test("同一課題内で異なる対策のコメントが同じ旧noteIDを指す場合、1件のMemoにマージされる（issue #184の再現シナリオ）")
+    func merge_sameOldNoteIDAcrossDifferentMeasures_mergesIntoSingleMemo() {
+        // 旧アプリで「対策A」「対策B」の両方に、同じ練習ノート(旧noteID=100)への
+        // 効果コメントが記録されていたケース（対策単位でコメントを持つ旧データモデル特有の状況）
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a", comments: [(comment: "対策Aのコメント", oldNoteID: 100)]),
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-b", comments: [(comment: "対策Bのコメント", oldNoteID: 100)]),
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        // 素直に変換すると同一noteID・異なるmeasuresIDのMemoが2件生成され、
+        // associateTasksWithMemosのtaskIDキー辞書で片方が上書きされ画面から消えてしまう。
+        // マージ後は1件のみになり、本文は両方のコメントを保持する
+        #expect(result.count == 1)
+        #expect(result.first?.noteID == "100")
+        #expect(result.first?.measuresID == "measures-a")  // 先に処理された（＝優先度の高い）対策のIDを維持
+        #expect(result.first?.detail == "対策Aのコメント\n対策Bのコメント")
+    }
+
+    @Test("異なる旧noteIDの場合はマージされず、別々のMemoとして生成される")
+    func merge_differentOldNoteIDs_doesNotMerge() {
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a", comments: [(comment: "1回目の練習", oldNoteID: 100)]),
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-b", comments: [(comment: "2回目の練習", oldNoteID: 200)]),
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        #expect(result.count == 2)
+        #expect(result[0].noteID == "100")
+        #expect(result[0].measuresID == "measures-a")
+        #expect(result[0].detail == "1回目の練習")
+        #expect(result[1].noteID == "200")
+        #expect(result[1].measuresID == "measures-b")
+        #expect(result[1].detail == "2回目の練習")
+    }
+
+    @Test("同一対策・同一ノートに複数コメントがある場合もマージされる")
+    func merge_sameMeasuresSameNoteMultipleComments_merges() {
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a",
+                comments: [(comment: "コメント1", oldNoteID: 100), (comment: "コメント2", oldNoteID: 100)])
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        #expect(result.count == 1)
+        #expect(result.first?.detail == "コメント1\nコメント2")
+    }
+
+    @Test("空文字のコメントは除外される")
+    func merge_emptyComment_isExcluded() {
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a", comments: [(comment: "", oldNoteID: 100)])
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("oldNoteIDが0の場合は空文字のnoteIDに変換される（フリーノート等、旧仕様のnoteID=0を踏襲）")
+    func merge_oldNoteIDZero_convertsToEmptyStringNoteID() {
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a", comments: [(comment: "コメント", oldNoteID: 0)])
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        #expect(result.count == 1)
+        #expect(result.first?.noteID == "")
+    }
+
+    @Test(
+        "oldNoteIDが0（ノート未紐付け）のコメントは、異なる対策間でマージされず個別のMemoのまま生成される（クロスレビュー指摘の回帰防止）"
+    )
+    func merge_oldNoteIDZero_acrossDifferentMeasures_doesNotMerge() {
+        // noteID=""のコメントはMemoViewModel.getMemosByMeasuresIDにより対策ごとに独立して
+        // 一覧表示される前提のため、実ノートへのコメントとは異なりマージしてはいけない。
+        // マージしてしまうと対策Bの「継続できている」が対策Aの「調子が良い」に統合され、
+        // 対策B側の詳細画面からコメントが消えてしまう
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a", comments: [(comment: "調子が良い", oldNoteID: 0)]),
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-b", comments: [(comment: "継続できている", oldNoteID: 0)]),
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        #expect(result.count == 2)
+        #expect(result[0].measuresID == "measures-a")
+        #expect(result[0].noteID == "")
+        #expect(result[0].detail == "調子が良い")
+        #expect(result[1].measuresID == "measures-b")
+        #expect(result[1].noteID == "")
+        #expect(result[1].detail == "継続できている")
+    }
+
+    @Test("oldNoteIDが0の複数コメントと実ノートへのコメントが混在していても、実ノート分のみマージされる")
+    func merge_mixedFreeformAndRealNoteComments_onlyMergesRealNoteComments() {
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a",
+                comments: [(comment: "未紐付けA", oldNoteID: 0), (comment: "ノート100へのA", oldNoteID: 100)]),
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-b",
+                comments: [(comment: "未紐付けB", oldNoteID: 0), (comment: "ノート100へのB", oldNoteID: 100)]),
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        // 未紐付け2件（マージされない）+ ノート100宛て1件（マージされる）= 計3件
+        #expect(result.count == 3)
+        #expect(result.filter { $0.noteID == "" }.count == 2)
+        let merged = result.first { $0.noteID == "100" }
+        #expect(merged?.measuresID == "measures-a")
+        #expect(merged?.detail == "ノート100へのA\nノート100へのB")
+    }
+
+    @Test("入力が空配列の場合は空配列を返す")
+    func merge_emptyInput_returnsEmpty() {
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: [])
+        #expect(result.isEmpty)
+    }
+
+    @Test("戻り値の順序はnoteIDが最初に出現した順（決定的な順序）になる")
+    func merge_resultOrder_matchesFirstOccurrenceOrder() {
+        let effectivenessByMeasures = [
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-a",
+                comments: [(comment: "3回目", oldNoteID: 300), (comment: "1回目", oldNoteID: 100)]),
+            MigrationMemoMerger.MeasuresEffectiveness(
+                measuresID: "measures-b", comments: [(comment: "2回目", oldNoteID: 200)]),
+        ]
+
+        let result = MigrationMemoMerger.merge(effectivenessByMeasures: effectivenessByMeasures)
+
+        #expect(result.map { $0.noteID } == ["300", "100", "200"])
+    }
+}


### PR DESCRIPTION
## 概要
issue #184（練習ノートで同一課題に対して複数のメモが重複して存在するケースがある疑い）の調査issue。コード調査の結果、`MigrationManager.migrateTask`に具体的な再現手順を特定した。

### 再現条件・原因
旧アプリ（UIKit版）で、同一課題内の複数の対策（例: 対策A・対策B）それぞれに、同一の練習ノートへの効果コメントを記録していた場合。旧アプリのデータモデルは効果コメントを「対策単位」で保持していたため（`measuresData: [対策タイトル: [[有効性コメント: ノートID(Int)]]]`）、旧`migrateTask`は対策ごとのループの中で素直にMemoを個別生成しており、同一taskID・同一noteIDだが異なるmeasuresIDを持つ複数のMemoレコードが生成されていた。

新データモデルの`TaskViewModel.associateTasksWithMemos`は「1課題1メモ/ノート」を前提にtaskIDでDictionaryキー化するため（既存テストで意図的な設計として固定化済み）、この場合は後から処理された方のMemoで先のMemoが上書きされ、片方が画面から見えなくなっていた（データ自体はRealm/Firestore上には両方残存）。

詳細な調査結果はissue #184にコメント済み。

Closes #184

## 対応内容
`associateTasksWithMemos`側は変更せず（issue本文の「やらないこと」を踏まえ、根本原因である移行処理側を修正）、新設の`MigrationMemoMerger`（`MeasuresOrderResolver`と同じ設計方針の純粋関数、Firebase非依存で単体テスト可能）で`migrateTask`が対策ごとの効果コメントを実ノートIDごとに1件へマージしてからMemoを生成するように修正した。

### クロスレビューで見つかった問題の修正（ラウンド2で解消）
1回目のクロスレビューで「旧アプリでノートに紐付けられなかった効果コメント（`noteID=""`）まで実ノートと同列にマージ対象としており、`MemoViewModel.getMemosByMeasuresID`（対策ごとに独立表示する設計）側で異なる対策のコメントが誤って統合されてしまう」というmust-fix指摘を受け、実ノートID（0以外）のみをマージ対象とし、ノート未紐付けのコメントはマージせず個別のMemoとして生成するよう修正した。

## 変更ファイル一覧
- `SportsNote_iOS/Model/Manager/MigrationManager.swift`: `migrateTask`が対策ごとの効果コメントを収集後、`MigrationMemoMerger.merge`でマージしてからMemoを生成するよう変更
- `SportsNote_iOS/Model/Manager/MigrationMemoMerger.swift`: 新設。実ノートIDごとに効果コメントをマージする純粋関数
- `SportsNote_iOSTests/Managers/MigrationMemoMergerTests.swift`: 新規テスト9件（同一ノートへの複数対策コメントのマージ、異なるノートは非マージ、ノート未紐付けコメントの非マージ回帰テスト等）

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED
- テスト: 607件全PASS（新規追加分含む）

## 完了条件
- [x] 同一課題に複数のMemoレコードが生成される具体的な再現手順が特定されている
- [x] 対応方針を追記した上で修正・回帰テストを実施しビルド・既存テストが成功すること

## クロスレビュー結果
独立コンテキストのエージェントによるレビューを2ラウンド実施。
- 1ラウンド目: must-fix1件（`noteID=""`の誤マージによる回帰）。修正・テスト追加済み
- 2ラウンド目: 合格。nit1件（`MeasuresEffectiveness`の明示initがコンパイラ合成イニシャライザと同一で冗長）が残るが、動作に影響しないため対応不要と判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)