### PR TITLE
fix: カレンダー連続タップ・Firestoreコールバック重複・RealmManagerのエラー握りつぶしを解消

### DIFF
--- a/SportsNote_iOS/Model/Manager/FirebaseManager.swift
+++ b/SportsNote_iOS/Model/Manager/FirebaseManager.swift
@@ -51,16 +51,10 @@ final class FirebaseManager {
         data: [String: Any]
     ) async throws {
         do {
-            return try await withCheckedThrowingContinuation { continuation in
+            try await withFirestoreContinuation { completion in
                 db.collection(collectionName)
                     .document(documentID)
-                    .setData(data) { error in
-                        if let error = error {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume(returning: ())
-                        }
-                    }
+                    .setData(data, completion: completion)
             }
         } catch let error {
             throw ErrorMapper.mapFirebaseError(error, context: "saveDocument-\(collectionName)-\(documentID)")
@@ -224,21 +218,10 @@ final class FirebaseManager {
         let userID = currentUserID()
 
         do {
-            return try await withCheckedThrowingContinuation { continuation in
+            return try await withFirestoreQueryContinuation { completion in
                 db.collection(collection)
                     .whereField("userID", isEqualTo: userID)
-                    .getDocuments { (querySnapshot, error) in
-                        if let error = error {
-                            continuation.resume(throwing: error)
-                            return
-                        }
-
-                        if let querySnapshot = querySnapshot {
-                            continuation.resume(returning: querySnapshot.documents)
-                        } else {
-                            continuation.resume(returning: [])
-                        }
-                    }
+                    .getDocuments(completion: completion)
             }
         } catch let error {
             throw ErrorMapper.mapFirebaseError(error, context: "getAllDocuments-\(collection)")
@@ -321,15 +304,9 @@ final class FirebaseManager {
         data: [String: Any]
     ) async throws {
         do {
-            return try await withCheckedThrowingContinuation { continuation in
+            try await withFirestoreContinuation { completion in
                 db.collection(collection).document(documentID)
-                    .setData(data, merge: true) { error in
-                        if let error = error {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume(returning: ())
-                        }
-                    }
+                    .setData(data, merge: true, completion: completion)
             }
         } catch let error {
             throw ErrorMapper.mapFirebaseError(error, context: "updateDocument-\(collection)-\(documentID)")

--- a/SportsNote_iOS/Model/Manager/FirestoreContinuation.swift
+++ b/SportsNote_iOS/Model/Manager/FirestoreContinuation.swift
@@ -1,0 +1,41 @@
+@preconcurrency import FirebaseFirestore
+import Foundation
+
+/// Firestoreのコールバックベース API（`(Error?) -> Void`）を `async throws` でラップする
+/// - Parameter operation: コールバックを受け取り、Firestore操作を実行するクロージャ
+/// - Note: `FirebaseManager`/`MigrationManager`がいずれも`@MainActor`のため、
+///   呼び出し元と同一Actorに揃えてSendable境界を跨がないようにする
+@MainActor
+func withFirestoreContinuation(
+    _ operation: (@escaping (Error?) -> Void) -> Void
+) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        operation { error in
+            if let error = error {
+                continuation.resume(throwing: error)
+            } else {
+                continuation.resume(returning: ())
+            }
+        }
+    }
+}
+
+/// Firestoreのコールバックベース API（`(QuerySnapshot?, Error?) -> Void`）を `async throws` でラップし、
+/// 取得した `QueryDocumentSnapshot` の配列を返す
+/// - Parameter operation: コールバックを受け取り、Firestoreクエリを実行するクロージャ
+/// - Note: `FirebaseManager`/`MigrationManager`がいずれも`@MainActor`のため、
+///   呼び出し元と同一Actorに揃えてSendable境界を跨がないようにする
+@MainActor
+func withFirestoreQueryContinuation(
+    _ operation: (@escaping (QuerySnapshot?, Error?) -> Void) -> Void
+) async throws -> [QueryDocumentSnapshot] {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[QueryDocumentSnapshot], Error>) in
+        operation { snapshot, error in
+            if let error = error {
+                continuation.resume(throwing: error)
+            } else {
+                continuation.resume(returning: snapshot?.documents ?? [])
+            }
+        }
+    }
+}

--- a/SportsNote_iOS/Model/Manager/InitializationManager.swift
+++ b/SportsNote_iOS/Model/Manager/InitializationManager.swift
@@ -56,7 +56,12 @@ final class InitializationManager {
     /// フリーノートを作成
     /// ※既に存在する場合は作成しない
     private func createFreeNote() async {
-        if RealmManager.shared.getFreeNote() != nil {
+        do {
+            if try RealmManager.shared.getFreeNote() != nil {
+                return
+            }
+        } catch {
+            print("フリーノートの存在確認に失敗しました: \(error.localizedDescription)")
             return
         }
 
@@ -102,7 +107,11 @@ final class InitializationManager {
         // （未実行/実行中の同期Taskがinvalidate済みRealmオブジェクトへアクセスしてクラッシュ・
         //   同期データが消失するのを防ぐ。Issue #84対応）
         await BackgroundSyncTracker.shared.waitForAll()
-        RealmManager.shared.clearAll()
+        do {
+            try RealmManager.shared.clearAll()
+        } catch {
+            print("Realmデータの全削除に失敗しました: \(error.localizedDescription)")
+        }
         UserDefaultsManager.clearAll()
     }
 

--- a/SportsNote_iOS/Model/Manager/MigrationManager.swift
+++ b/SportsNote_iOS/Model/Manager/MigrationManager.swift
@@ -104,17 +104,11 @@ final class MigrationManager {
     /// - Parameter collection: 対象コレクション名（"TaskData" / "TargetData" / "NoteData"）
     private func fetchOldDocuments(collection: String) async throws -> [QueryDocumentSnapshot] {
         let userID = getUserID()
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withFirestoreQueryContinuation { completion in
             db.collection(collection)
                 .whereField("userID", isEqualTo: userID)
                 .whereField("isDeleted", isEqualTo: false)
-                .getDocuments { snapshot, error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: snapshot?.documents ?? [])
-                    }
-                }
+                .getDocuments(completion: completion)
         }
     }
 
@@ -122,17 +116,12 @@ final class MigrationManager {
     /// isDeleted フィルタを持たず単一ドキュメントを返す点で fetchOldDocuments(collection:) とは構造が異なるため対象外
     private func fetchOldFreeNoteDocument() async throws -> QueryDocumentSnapshot? {
         let userID = getUserID()
-        return try await withCheckedThrowingContinuation { continuation in
+        let documents = try await withFirestoreQueryContinuation { completion in
             db.collection("FreeNoteData")
                 .whereField("userID", isEqualTo: userID)
-                .getDocuments { snapshot, error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: snapshot?.documents.first)
-                    }
-                }
+                .getDocuments(completion: completion)
         }
+        return documents.first
     }
 
     // MARK: - 変換・Realm + Firebase 保存
@@ -289,7 +278,7 @@ final class MigrationManager {
         let userID = getUserID()
         let now = Date()
 
-        if let existingFreeNote = RealmManager.shared.getFreeNote() {
+        if let existingFreeNote = try RealmManager.shared.getFreeNote() {
             // 既存のフリーノートに上書き（managed objectを直接変更するとwriteトランザクション外エラーになるため、
             // 同じnoteIDで新規unmanagedオブジェクトを作成し saveItem(.modified) で上書きする）
             let updatedNote = Note()
@@ -385,29 +374,17 @@ final class MigrationManager {
     ///   - collection: 対象コレクション名（"TaskData" / "TargetData" / "NoteData"）
     ///   - documentID: 対象ドキュメントID
     private func markOldDocumentDeleted(collection: String, documentID: String) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        try await withFirestoreContinuation { completion in
             db.collection(collection).document(documentID)
-                .updateData(["isDeleted": true]) { error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: ())
-                    }
-                }
+                .updateData(["isDeleted": true], completion: completion)
         }
     }
 
     /// 旧 FreeNoteData ドキュメントを論理削除（isDeleted = true）
     private func deleteOldFreeNoteDocument(userID: String) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        try await withFirestoreContinuation { completion in
             db.collection("FreeNoteData").document(userID)
-                .updateData(["isDeleted": true]) { error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: ())
-                    }
-                }
+                .updateData(["isDeleted": true], completion: completion)
         }
     }
 

--- a/SportsNote_iOS/Model/Manager/RealmManager.swift
+++ b/SportsNote_iOS/Model/Manager/RealmManager.swift
@@ -360,53 +360,54 @@ final class RealmManager {
     /// groupIDに合致する完了した課題を取得
     /// - Parameter groupID: groupID
     /// - Returns: 完了した課題のリスト
-    func getCompletedTasksByGroupId(groupID: String) -> [TaskData] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getCompletedTasksByGroupId(groupID: String) throws -> [TaskData] {
         do {
             let realm = try getRealm()
             return realm.objects(TaskData.self)
                 .filter("groupID == %@ AND isComplete == true AND isDeleted == false", groupID)
                 .sorted(byKeyPath: "order", ascending: true)
                 .map { $0 }
-        } catch {
-            print("Error fetching completed tasks: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getCompletedTasksByGroupId")
         }
     }
 
     /// taskIDに合致する対策を取得
     /// - Parameter taskID: taskID
     /// - Returns: 対策のリスト
-    func getMeasuresByTaskID(taskID: String) -> [Measures] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getMeasuresByTaskID(taskID: String) throws -> [Measures] {
         do {
             let realm = try getRealm()
             return realm.objects(Measures.self)
                 .filter("taskID == %@ AND isDeleted == false", taskID)
                 .sorted(byKeyPath: "order", ascending: true)
                 .map { $0 }
-        } catch {
-            print("Error fetching measures: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getMeasuresByTaskID")
         }
     }
 
     /// フリーノートを取得
     /// - Returns: フリーノート（存在しない場合は`nil`）
-    func getFreeNote() -> Note? {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getFreeNote() throws -> Note? {
         do {
             let realm = try getRealm()
             return realm.objects(Note.self)
                 .filter("noteType == %@ AND isDeleted == false", NoteType.free.rawValue)
                 .first
-        } catch {
-            print("Error fetching free note: \(error)")
-            return nil
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getFreeNote")
         }
     }
 
     /// 指定された文字列を含むノートを検索（メモ内容も検索対象）
     /// - Parameter query: 検索する文字列
     /// - Returns: 検索結果のノートリスト
-    func searchNotesByQuery(query: String) -> [Note] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func searchNotesByQuery(query: String) throws -> [Note] {
         do {
             let realm = try getRealm()
 
@@ -459,16 +460,16 @@ final class RealmManager {
 
             // フリーノートを先頭にして、検索結果を日付の降順でソート
             return validFreeNotes + validQueryNotes.sorted(by: { $0.date > $1.date })
-        } catch {
-            print("Error searching notes by query: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "searchNotesByQuery")
         }
     }
 
     /// 指定した日付に合致するノートを取得
     /// - Parameter selectedDate: 日付
     /// - Returns: 指定した日付に合致するノートのリスト
-    func getNotesByDate(selectedDate: Date) -> [Note] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getNotesByDate(selectedDate: Date) throws -> [Note] {
         do {
             let realm = try getRealm()
             let startOfDay = Calendar.current.startOfDay(for: selectedDate)
@@ -478,56 +479,55 @@ final class RealmManager {
                     .filter(
                         "isDeleted == false AND noteType != %@ AND date >= %@ AND date < %@", NoteType.free.rawValue,
                         startOfDay, endOfDay))
-        } catch {
-            print("Error fetching notes by date: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getNotesByDate")
         }
     }
 
     /// すべてのノートを取得（フリーノートは除く）
     /// - Returns: ノートのリスト
-    func getNotes() -> [Note] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getNotes() throws -> [Note] {
         do {
             let realm = try getRealm()
             return Array(
                 realm.objects(Note.self)
                     .filter("isDeleted == false AND noteType != %@", NoteType.free.rawValue)
                     .sorted(byKeyPath: "date", ascending: false))
-        } catch {
-            print("Error fetching notes: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getNotes")
         }
     }
 
     /// measuresIDに合致するメモを取得
     /// - Parameter measuresID: 対策ID
     /// - Returns: 対策IDに関連するメモのリスト
-    func getMemosByMeasuresID(measuresID: String) -> [Memo] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getMemosByMeasuresID(measuresID: String) throws -> [Memo] {
         do {
             let realm = try getRealm()
             return Array(
                 realm.objects(Memo.self)
                     .filter("measuresID == %@ AND isDeleted == false", measuresID)
                     .sorted(byKeyPath: "created_at", ascending: true))
-        } catch {
-            print("Error fetching memos by measuresID: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getMemosByMeasuresID")
         }
     }
 
     /// noteIDに合致するメモを取得
     /// - Parameter noteID: ノートID
     /// - Returns: ノートIDに関連するメモのリスト
-    func getMemosByNoteID(noteID: String) -> [Memo] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getMemosByNoteID(noteID: String) throws -> [Memo] {
         do {
             let realm = try getRealm()
             return Array(
                 realm.objects(Memo.self)
                     .filter("noteID == %@ AND isDeleted == false", noteID)
                     .sorted(byKeyPath: "created_at", ascending: true))
-        } catch {
-            print("Error fetching memos by noteID: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getMemosByNoteID")
         }
     }
 
@@ -538,14 +538,16 @@ final class RealmManager {
     ///   - noteID: ノートID
     ///   - measuresID: 対策ID
     /// - Returns: 該当するMemo（存在しない場合はnil）
-    func findMemo(noteID: String, measuresID: String) -> Memo? {
-        return getMemosByNoteID(noteID: noteID).first(where: { $0.measuresID == measuresID })
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func findMemo(noteID: String, measuresID: String) throws -> Memo? {
+        return try getMemosByNoteID(noteID: noteID).first(where: { $0.measuresID == measuresID })
     }
 
     /// ノートの背景色を取得
     /// - Parameter noteID: ノートID
     /// - Returns: ノートの背景色
-    func getNoteBackgroundColor(noteID: String) -> UIColor {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func getNoteBackgroundColor(noteID: String) throws -> UIColor {
         do {
             let realm = try getRealm()
             if let memo = realm.objects(Memo.self)
@@ -570,9 +572,8 @@ final class RealmManager {
                 }
             }
             return .gray
-        } catch {
-            print("Error fetching note background color: \(error)")
-            return .gray
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "getNoteBackgroundColor")
         }
     }
 
@@ -580,15 +581,15 @@ final class RealmManager {
     /// - Parameters:
     ///   - year: 取得したい目標の年
     /// - Returns: 条件に一致する目標のリスト
-    func fetchYearlyTargets(year: Int) -> [Target] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func fetchYearlyTargets(year: Int) throws -> [Target] {
         do {
             let realm = try getRealm()
             let targets = realm.objects(Target.self)
                 .filter("((isYearlyTarget == true AND year == %@)) AND isDeleted == false", year)
             return Array(targets)
-        } catch {
-            print("Error fetching targets by year and month: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "fetchYearlyTargets")
         }
     }
 
@@ -597,16 +598,16 @@ final class RealmManager {
     ///   - year: 取得したい目標の年
     ///   - month: 取得したい目標の月
     /// - Returns: 条件に一致する目標のリスト
-    func fetchTargetsByYearMonth(year: Int, month: Int) -> [Target] {
+    /// - Throws: SportsNoteErrorデータベースアクセスに失敗した場合
+    func fetchTargetsByYearMonth(year: Int, month: Int) throws -> [Target] {
         do {
             let realm = try getRealm()
             let targets = realm.objects(Target.self)
                 .filter(
                     "((isYearlyTarget == false AND year == %@ AND month == %@)) AND isDeleted == false", year, month)
             return Array(targets)
-        } catch {
-            print("Error fetching targets by year and month: \(error)")
-            return []
+        } catch let error {
+            throw ErrorMapper.mapRealmError(error, context: "fetchTargetsByYearMonth")
         }
     }
 
@@ -707,14 +708,15 @@ final class RealmManager {
     }
 
     /// Realmの全データを削除
-    func clearAll() {
+    /// - Throws: SportsNoteError削除に失敗した場合
+    func clearAll() throws {
         do {
             let realm = try getRealm()
             try realm.write {
                 realm.deleteAll()
             }
         } catch let error {
-            print("Failed to clear Realm: \(error)")
+            throw ErrorMapper.mapRealmError(error, context: "clearAll")
         }
     }
 }

--- a/SportsNote_iOS/View/Target/Components/CalendarView.swift
+++ b/SportsNote_iOS/View/Target/Components/CalendarView.swift
@@ -46,6 +46,7 @@ struct CalendarView: View {
                 }) {
                     Image(systemName: "chevron.left")
                 }
+                .disabled(isAnimating)
 
                 Spacer()
 
@@ -61,6 +62,7 @@ struct CalendarView: View {
                 }) {
                     Image(systemName: "chevron.right")
                 }
+                .disabled(isAnimating)
             }
             .padding(.horizontal)
             .padding(.bottom, 5)
@@ -131,6 +133,9 @@ struct CalendarView: View {
 
     // 月の切り替えを行う関数
     private func changeMonth(isPrevious: Bool) {
+        // アニメーション完了前の連続タップ・スワイプによる多重実行を防ぐ
+        guard !isAnimating else { return }
+
         isAnimating = true
         slideDirection = isPrevious ? -1 : 1  // 前月なら左から右へ、次月なら右から左へ
 

--- a/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MeasuresViewModel.swift
@@ -49,25 +49,37 @@ class MeasuresViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelP
     /// - Parameter measuresID: 対策ID
     /// - Returns: Result
     func fetchMemosByMeasuresID(measuresID: String) async -> Result<Void, SportsNoteError> {
-        memos = RealmManager.shared.getMemosByMeasuresID(measuresID: measuresID)
-        return .success(())
+        do {
+            memos = try RealmManager.shared.getMemosByMeasuresID(measuresID: measuresID)
+            return .success(())
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "MeasuresViewModel-fetchMemosByMeasuresID"))
+        }
     }
 
     /// 課題IDに紐づく対策を取得
     /// - Parameter taskID: 課題ID
     /// - Returns: Result<[Measures], SportsNoteError>
     func getMeasuresByTaskID(taskID: String) async -> Result<[Measures], SportsNoteError> {
-        let measures = RealmManager.shared.getMeasuresByTaskID(taskID: taskID)
-        return .success(measures)
+        do {
+            let measures = try RealmManager.shared.getMeasuresByTaskID(taskID: taskID)
+            return .success(measures)
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "MeasuresViewModel-getMeasuresByTaskID"))
+        }
     }
 
     /// 最も優先度の高い（orderが低い）対策を取得
     /// - Parameter taskID: 課題ID
     /// - Returns: Result<Measures?, SportsNoteError>
     func getMostPriorityMeasures(taskID: String) async -> Result<Measures?, SportsNoteError> {
-        let measuresList = RealmManager.shared.getMeasuresByTaskID(taskID: taskID)
-        let mostPriorityMeasures = measuresList.min { $0.order < $1.order }
-        return .success(mostPriorityMeasures)
+        do {
+            let measuresList = try RealmManager.shared.getMeasuresByTaskID(taskID: taskID)
+            let mostPriorityMeasures = measuresList.min { $0.order < $1.order }
+            return .success(mostPriorityMeasures)
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "MeasuresViewModel-getMostPriorityMeasures"))
+        }
     }
 
     /// 対策を保存する（既存インターフェースとの互換性のため）

--- a/SportsNote_iOS/ViewModel/MemoViewModel.swift
+++ b/SportsNote_iOS/ViewModel/MemoViewModel.swift
@@ -109,7 +109,12 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter measuresID: 対策ID
     /// - Returns: Result<[MeasuresMemo], SportsNoteError>
     func getMemosByMeasuresID(measuresID: String) -> Result<[MeasuresMemo], SportsNoteError> {
-        let memos = RealmManager.shared.getMemosByMeasuresID(measuresID: measuresID)
+        let memos: [Memo]
+        do {
+            memos = try RealmManager.shared.getMemosByMeasuresID(measuresID: measuresID)
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "MemoViewModel-getMemosByMeasuresID"))
+        }
         var measuresMemoList = [MeasuresMemo]()
 
         for memo in memos {
@@ -228,7 +233,13 @@ class MemoViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     ///   - measuresID: 対策ID
     /// - Returns: Result<Void, SportsNoteError>（該当メモが存在しない場合も.success(())を返す）
     func deleteMemoByNoteAndMeasures(noteID: String, measuresID: String) async -> Result<Void, SportsNoteError> {
-        guard let memo = RealmManager.shared.findMemo(noteID: noteID, measuresID: measuresID) else {
+        let foundMemo: Memo?
+        do {
+            foundMemo = try RealmManager.shared.findMemo(noteID: noteID, measuresID: measuresID)
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "MemoViewModel-deleteMemoByNoteAndMeasures"))
+        }
+        guard let memo = foundMemo else {
             return .success(())
         }
         return await delete(id: memo.memoID)

--- a/SportsNote_iOS/ViewModel/NoteViewModel.swift
+++ b/SportsNote_iOS/ViewModel/NoteViewModel.swift
@@ -49,17 +49,21 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         defer { isLoading = false }
 
         // Realm操作はMainActorで実行
-        let allNotes = realmManager.getNotes()
-        if let freeNote = realmManager.getFreeNote() {
-            if !allNotes.contains(where: { $0.noteID == freeNote.noteID }) {
-                notes = [freeNote] + allNotes
+        do {
+            let allNotes = try realmManager.getNotes()
+            if let freeNote = try realmManager.getFreeNote() {
+                if !allNotes.contains(where: { $0.noteID == freeNote.noteID }) {
+                    notes = [freeNote] + allNotes
+                } else {
+                    notes = allNotes
+                }
             } else {
                 notes = allNotes
             }
-        } else {
-            notes = allNotes
+            return .success(())
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "NoteViewModel-fetchData"))
         }
-        return .success(())
     }
 
     /// ターゲット画面用: フリーノートを除外してノートを取得
@@ -69,9 +73,12 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         defer { isLoading = false }
 
         // フリーノートを除外したノートのみ取得（getNotes()は既にフリーノート除外済み）
-        let allNotes = realmManager.getNotes()
-        notes = allNotes
-        return .success(())
+        do {
+            notes = try realmManager.getNotes()
+            return .success(())
+        } catch {
+            return .failure(convertToSportsNoteError(error, context: "NoteViewModel-fetchNotesExcludingFree"))
+        }
     }
 
     /// ノートを取得
@@ -94,8 +101,11 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
 
     /// ノートに紐づくメモを取得
     private func loadMemos() {
-        if let noteID = selectedNote?.noteID {
-            memos = realmManager.getMemosByNoteID(noteID: noteID)
+        guard let noteID = selectedNote?.noteID else { return }
+        do {
+            memos = try realmManager.getMemosByNoteID(noteID: noteID)
+        } catch {
+            showErrorAlert(convertToSportsNoteError(error, context: "NoteViewModel-loadMemos"))
         }
     }
 
@@ -372,12 +382,19 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
                 existingCreatedAt = existingMemo?.created_at
                 existingMeasuresID = existingMemo?.measuresID
             } else {
-                let existingMemos = realmManager.getMemosByNoteID(noteID: noteID)
-                // task.measuresID（現在の最優先対策のID）だけでなく、taskIDに紐づく
-                // 全対策のmeasuresIDのいずれかで検索する。対策の並び替えで最優先対策が
-                // 変わった後も、既存メモを同一課題のものとして正しく検出するため（issue #109）
-                let taskMeasuresIDs = Set(
-                    realmManager.getMeasuresByTaskID(taskID: task.taskID).map { $0.measuresID })
+                let existingMemos: [Memo]
+                let taskMeasuresIDs: Set<String>
+                do {
+                    existingMemos = try realmManager.getMemosByNoteID(noteID: noteID)
+                    // task.measuresID（現在の最優先対策のID）だけでなく、taskIDに紐づく
+                    // 全対策のmeasuresIDのいずれかで検索する。対策の並び替えで最優先対策が
+                    // 変わった後も、既存メモを同一課題のものとして正しく検出するため（issue #109）
+                    taskMeasuresIDs = Set(
+                        try realmManager.getMeasuresByTaskID(taskID: task.taskID).map { $0.measuresID })
+                } catch {
+                    showErrorAlert(convertToSportsNoteError(error, context: "NoteViewModel-updateTaskReflections"))
+                    continue
+                }
                 if let existingMemo = existingMemos.first(where: {
                     taskMeasuresIDs.contains($0.measuresID)
                 }) {
@@ -552,7 +569,12 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
         case .free:
             return .systemGray
         case .practice:
-            return realmManager.getNoteBackgroundColor(noteID: noteID)
+            do {
+                return try realmManager.getNoteBackgroundColor(noteID: noteID)
+            } catch {
+                showErrorAlert(convertToSportsNoteError(error, context: "NoteViewModel-getNoteIndicatorColor"))
+                return .gray
+            }
         case .tournament:
             return .systemOrange
         }
@@ -561,15 +583,23 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// ノートを文字列で検索
     /// - Parameter query: 検索文字列
     func searchNotes(query: String) {
-        let searchResults = realmManager.searchNotesByQuery(query: query)
-        notes = searchResults
+        do {
+            notes = try realmManager.searchNotesByQuery(query: query)
+        } catch {
+            showErrorAlert(convertToSportsNoteError(error, context: "NoteViewModel-searchNotes"))
+        }
     }
 
     /// ノートを日付でフィルタリング
     /// - Parameter date: 日付
     /// - Returns: [Note]
     func filterNotesByDate(_ date: Date) -> [Note] {
-        return realmManager.getNotesByDate(selectedDate: date)
+        do {
+            return try realmManager.getNotesByDate(selectedDate: date)
+        } catch {
+            showErrorAlert(convertToSportsNoteError(error, context: "NoteViewModel-filterNotesByDate"))
+            return []
+        }
     }
 
     /// 指定した日付でノート一覧を更新
@@ -582,7 +612,12 @@ class NoteViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     /// - Parameter noteID: ノートID
     /// - Returns: [Memo]
     func getMemosByNoteID(noteID: String) -> [Memo] {
-        return realmManager.getMemosByNoteID(noteID: noteID)
+        do {
+            return try realmManager.getMemosByNoteID(noteID: noteID)
+        } catch {
+            showErrorAlert(convertToSportsNoteError(error, context: "NoteViewModel-getMemosByNoteID"))
+            return []
+        }
     }
 
 }

--- a/SportsNote_iOS/ViewModel/TargetViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TargetViewModel.swift
@@ -127,7 +127,12 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
 
         // 重複する目標を削除（Realm操作はMainActorで実行）
         if isYearlyTarget {
-            let yearlyTargets = RealmManager.shared.fetchYearlyTargets(year: year)
+            let yearlyTargets: [Target]
+            do {
+                yearlyTargets = try RealmManager.shared.fetchYearlyTargets(year: year)
+            } catch {
+                return .failure(convertToSportsNoteError(error, context: "TargetViewModel-saveTarget"))
+            }
             for existingTarget in yearlyTargets {
                 let deleteResult = await delete(id: existingTarget.targetID)
                 if case .failure(let error) = deleteResult {
@@ -135,7 +140,12 @@ class TargetViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelPro
                 }
             }
         } else {
-            let monthlyTargets = RealmManager.shared.fetchTargetsByYearMonth(year: year, month: month)
+            let monthlyTargets: [Target]
+            do {
+                monthlyTargets = try RealmManager.shared.fetchTargetsByYearMonth(year: year, month: month)
+            } catch {
+                return .failure(convertToSportsNoteError(error, context: "TargetViewModel-saveTarget"))
+            }
             for existingTarget in monthlyTargets {
                 let deleteResult = await delete(id: existingTarget.targetID)
                 if case .failure(let error) = deleteResult {

--- a/SportsNote_iOS/ViewModel/TaskViewModel.swift
+++ b/SportsNote_iOS/ViewModel/TaskViewModel.swift
@@ -431,8 +431,13 @@ class TaskViewModel: ObservableObject, BaseViewModelProtocol, CRUDViewModelProto
     private func getMostPriorityMeasures(taskID: String) -> Measures? {
         // 同期的な処理が必要なため、RealmManagerを直接使用
         // 将来的にはconvertToTaskListData()の非同期化を検討
-        let measuresList = RealmManager.shared.getMeasuresByTaskID(taskID: taskID)
-        return measuresList.min { $0.order < $1.order }
+        do {
+            let measuresList = try RealmManager.shared.getMeasuresByTaskID(taskID: taskID)
+            return measuresList.min { $0.order < $1.order }
+        } catch {
+            showErrorAlert(convertToSportsNoteError(error, context: "TaskViewModel-getMostPriorityMeasures"))
+            return nil
+        }
     }
 
     /// 対策表示上の並び替えを同期的に即時反映する（Realm永続化・Firebase同期は含まない）

--- a/SportsNote_iOSTests/Managers/MigrationManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/MigrationManagerTests.swift
@@ -21,7 +21,7 @@ struct MigrationManagerTests {
 
     init() async throws {
         RealmManager.shared.setupInMemoryRealm()
-        RealmManager.shared.clearAll()
+        try RealmManager.shared.clearAll()
     }
 
     private func makeGroup(title: String, order: Int) -> Group {

--- a/SportsNote_iOSTests/Managers/RealmManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/RealmManagerTests.swift
@@ -48,7 +48,7 @@ struct RealmManagerTests {
         #expect(savedGroup?.title == "Test Group")
 
         // クリーンアップ
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("updateAllUserIds - 全データのUserIDを一括更新できる")
@@ -76,7 +76,7 @@ struct RealmManagerTests {
         #expect(updatedGroup?.userID == "new-user")
         #expect(updatedNote?.userID == "new-user")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getDataList - データ一覧を取得できる（ソート順・論理削除除外）")
@@ -101,7 +101,7 @@ struct RealmManagerTests {
         #expect(results[0].groupID == "g2")  // order順（0 -> 1）
         #expect(results[1].groupID == "g1")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - getDataListIncludingDeleted テスト（issue #26: 同期時の削除復活バグ対策）
@@ -126,7 +126,7 @@ struct RealmManagerTests {
         #expect(results[2].groupID == "g3")
         #expect(results[2].isDeleted == true)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getCount - 有効なデータ件数を取得できる")
@@ -143,7 +143,7 @@ struct RealmManagerTests {
         let count = try manager.getCount(clazz: Note.self)
         #expect(count == 2)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - getMaxOrder テスト（issue #21: order初期値算出の共通ヘルパー）
@@ -153,7 +153,7 @@ struct RealmManagerTests {
         let maxOrder = try manager.getMaxOrder(clazz: Group.self)
         #expect(maxOrder == nil)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getMaxOrder - 複数レコードから最大値を返す")
@@ -165,7 +165,7 @@ struct RealmManagerTests {
         let maxOrder = try manager.getMaxOrder(clazz: Group.self)
         #expect(maxOrder == 5)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getMaxOrder - 論理削除済みレコードは無視される")
@@ -180,7 +180,7 @@ struct RealmManagerTests {
         let maxOrder = try manager.getMaxOrder(clazz: Group.self)
         #expect(maxOrder == 1)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getMaxOrder - predicateによるスコープ絞り込みが機能する")
@@ -211,7 +211,7 @@ struct RealmManagerTests {
         )
         #expect(maxOrderForGroupA == 7)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - getNextOrder テスト（issue #50: order初期値算出ロジックの共通ヘルパー）
@@ -221,7 +221,7 @@ struct RealmManagerTests {
         let nextOrder = manager.getNextOrder(clazz: Group.self)
         #expect(nextOrder == 0)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getNextOrder - 既存データがある場合は最大order+1を返す")
@@ -232,7 +232,7 @@ struct RealmManagerTests {
         let nextOrder = manager.getNextOrder(clazz: Group.self)
         #expect(nextOrder == 6)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getNextOrder - predicateによるスコープ絞り込みが機能する")
@@ -257,7 +257,7 @@ struct RealmManagerTests {
         )
         #expect(nextOrderForGroupA == 4)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - 論理削除テスト
@@ -283,7 +283,7 @@ struct RealmManagerTests {
         #expect(rawNote != nil)
         #expect(rawNote?.isDeleted == true)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("logicalDelete - Targetを論理削除できる（issue #38: SoftDeletable共通化の回帰防止）")
@@ -301,7 +301,7 @@ struct RealmManagerTests {
         #expect(rawTarget != nil)
         #expect(rawTarget?.isDeleted == true)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("logicalDelete - updated_atが更新される（issue #26: Firebase同期時に削除が新しいと判定されるようにするため）")
@@ -319,7 +319,7 @@ struct RealmManagerTests {
         #expect(rawGroup != nil)
         #expect(rawGroup!.updated_at > oldDate)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("logicalDelete - 連鎖削除（Group -> Task -> Measures -> Memo）")
@@ -373,7 +373,7 @@ struct RealmManagerTests {
         #expect(rawMeasures != nil && rawMeasures!.updated_at > oldDate)
         #expect(rawMemo != nil && rawMemo!.updated_at > oldDate)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - 検索機能テスト
@@ -401,18 +401,18 @@ struct RealmManagerTests {
         try manager.saveItem(note3)
 
         // "test"で検索 -> note1 (Free、purposeに"testing"を含む) がヒット
-        let results1 = manager.searchNotesByQuery(query: "test")
+        let results1 = try manager.searchNotesByQuery(query: "test")
         #expect(results1.count == 1)
         #expect(results1.first?.noteID == "n-1")
 
         // "Data"で検索 -> note1 (Free) はpurposeに"Data"を含まないため除外され、note2 (Practice) のみヒット
         // issue #76: フリーノートも内容が一致する場合のみ検索結果に含める
-        let results2 = manager.searchNotesByQuery(query: "Data")
+        let results2 = try manager.searchNotesByQuery(query: "Data")
         #expect(results2.count == 1)
         #expect(results2.contains(where: { $0.noteID == "n-2" }))
         #expect(!results2.contains(where: { $0.noteID == "n-1" }))
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("searchNotesByQuery - issue #76: クエリが非空でフリーノートの内容にも一致しない場合は検索結果が0件になる")
@@ -431,10 +431,10 @@ struct RealmManagerTests {
         try manager.saveItem(practiceNote)
 
         // どのノートの内容にも一致しないクエリで検索 -> 0件（「ノートが見つかりません」表示に到達できる）
-        let results = manager.searchNotesByQuery(query: "存在しないキーワード")
+        let results = try manager.searchNotesByQuery(query: "存在しないキーワード")
         #expect(results.isEmpty)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("searchNotesByQuery - issue #76: クエリが空の場合は従来通りフリーノートを含む全ノートが表示される")
@@ -452,10 +452,10 @@ struct RealmManagerTests {
         try manager.saveItem(practiceNote)
 
         // クエリが空文字の場合、フリーノートは内容に関わらず無条件で結果に含まれる
-        let results = manager.searchNotesByQuery(query: "")
+        let results = try manager.searchNotesByQuery(query: "")
         #expect(results.contains(where: { $0.noteID == "n-free-empty" }))
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getNotesByDate - 日付でノートを取得できる")
@@ -479,11 +479,11 @@ struct RealmManagerTests {
         try manager.saveItem(noteYesterday)
 
         // 今日のノートを取得
-        let results = manager.getNotesByDate(selectedDate: today)
+        let results = try manager.getNotesByDate(selectedDate: today)
         #expect(results.count == 1)
         #expect(results.first?.noteID == "today")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getFreeNote - フリーノートを取得できる")
@@ -499,11 +499,11 @@ struct RealmManagerTests {
         try manager.saveItem(freeNote)
         try manager.saveItem(practiceNote)
 
-        let result = manager.getFreeNote()
+        let result = try manager.getFreeNote()
         #expect(result != nil)
         #expect(result?.noteType == NoteType.free.rawValue)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getNotes - 通常ノート（フリー以外）を日付順で取得できる")
@@ -528,13 +528,13 @@ struct RealmManagerTests {
         try manager.saveItem(note2)
         try manager.saveItem(freeNote)
 
-        let results = manager.getNotes()
+        let results = try manager.getNotes()
 
         #expect(results.count == 2)  // フリーノートは除外
         #expect(results[0].title == "Today")  // 日付降順
         #expect(results[1].title == "Yesterday")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - 特定条件取得テスト
@@ -565,9 +565,9 @@ struct RealmManagerTests {
         try manager.saveItem(task2)
         try manager.saveItem(task3)
 
-        let results = manager.getCompletedTasksByGroupId(groupID: groupID)
+        let results = try manager.getCompletedTasksByGroupId(groupID: groupID)
         #expect(results.count == 1)
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getMeasuresByTaskID - 特定TaskIDの対策を取得できる")
@@ -593,12 +593,12 @@ struct RealmManagerTests {
         try manager.saveItem(m2)
         try manager.saveItem(m3)
 
-        let results = manager.getMeasuresByTaskID(taskID: taskID)
+        let results = try manager.getMeasuresByTaskID(taskID: taskID)
         #expect(results.count == 2)
         #expect(results[0].measuresID == "m2")  // order順
         #expect(results[1].measuresID == "m1")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getMemosByMeasuresID - 特定MeasuresIDのメモを取得できる")
@@ -618,11 +618,11 @@ struct RealmManagerTests {
         try manager.saveItem(memo1)
         try manager.saveItem(memo2)
 
-        let results = manager.getMemosByMeasuresID(measuresID: measuresID)
+        let results = try manager.getMemosByMeasuresID(measuresID: measuresID)
         #expect(results.count == 1)
         #expect(results.first?.memoID == "memo1")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getMemosByNoteID - 特定NoteIDのメモを取得できる")
@@ -641,11 +641,11 @@ struct RealmManagerTests {
         try manager.saveItem(memo1)
         try manager.saveItem(memo2)
 
-        let results = manager.getMemosByNoteID(noteID: noteID)
+        let results = try manager.getMemosByNoteID(noteID: noteID)
         #expect(results.count == 1)
         #expect(results.first?.memoID == "memo1")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("findMemo - noteIDとmeasuresIDが一致するMemoを取得できる")
@@ -663,10 +663,10 @@ struct RealmManagerTests {
         try manager.saveItem(memo1)
         try manager.saveItem(memo2)
 
-        let result = manager.findMemo(noteID: "n1", measuresID: "ms1")
+        let result = try manager.findMemo(noteID: "n1", measuresID: "ms1")
         #expect(result?.memoID == "memo1")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("findMemo - 一致するMemoが存在しない場合はnilを返す")
@@ -677,10 +677,10 @@ struct RealmManagerTests {
         memo1.measuresID = "ms1"
         try manager.saveItem(memo1)
 
-        let result = manager.findMemo(noteID: "n1", measuresID: "ms-not-exist")
+        let result = try manager.findMemo(noteID: "n1", measuresID: "ms-not-exist")
         #expect(result == nil)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("fetchYearlyTargets - 年間目標を取得できる")
@@ -696,11 +696,11 @@ struct RealmManagerTests {
         try manager.saveItem(t2)
         try manager.saveItem(t3)
 
-        let results = manager.fetchYearlyTargets(year: year)
+        let results = try manager.fetchYearlyTargets(year: year)
         #expect(results.count == 1)
         #expect(results.first?.title == "Yearly Target")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("fetchTargetsByYearMonth - 月間目標を取得できる")
@@ -717,11 +717,11 @@ struct RealmManagerTests {
         try manager.saveItem(t2)
         try manager.saveItem(t3)
 
-        let results = manager.fetchTargetsByYearMonth(year: year, month: month)
+        let results = try manager.fetchTargetsByYearMonth(year: year, month: month)
         #expect(results.count == 1)
         #expect(results.first?.title == "May Target")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getNoteBackgroundColor - 正しい背景色を取得できる")
@@ -751,13 +751,13 @@ struct RealmManagerTests {
         try manager.saveItem(memo)
 
         // NoteIDから背景色（Groupの色）を取得
-        let color = manager.getNoteBackgroundColor(noteID: "n-color")
+        let color = try manager.getNoteBackgroundColor(noteID: "n-color")
 
         // GroupColor.blueの色と一致するか確認
         // UIColorの比較は厳密には難しいが、ここではCGColorで比較
         #expect(color.cgColor == GroupColor.blue.color.cgColor)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     @Test("getNoteBackgroundColor - 範囲外のcolor値でもクラッシュせずgrayを返す（issue #43）")
@@ -784,11 +784,11 @@ struct RealmManagerTests {
         try manager.saveItem(measures)
         try manager.saveItem(memo)
 
-        let color = manager.getNoteBackgroundColor(noteID: "n-invalid-color")
+        let color = try manager.getNoteBackgroundColor(noteID: "n-invalid-color")
 
         #expect(color.cgColor == GroupColor.gray.color.cgColor)
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 
     // MARK: - パラメータ化テスト
@@ -806,10 +806,10 @@ struct RealmManagerTests {
 
         try manager.saveItem(note)
 
-        let results = manager.searchNotesByQuery(query: query)
+        let results = try manager.searchNotesByQuery(query: query)
         #expect(!results.isEmpty)
         #expect(results.first?.noteID == "n-param")
 
-        manager.clearAll()
+        try manager.clearAll()
     }
 }

--- a/SportsNote_iOSTests/Managers/SyncManagerTests.swift
+++ b/SportsNote_iOSTests/Managers/SyncManagerTests.swift
@@ -66,7 +66,7 @@ struct SyncManagerTests {
         let rawGroup = RealmManager.shared.getRawObjectById(id: id, type: Group.self)
         #expect(rawGroup?.isDeleted == true)
 
-        RealmManager.shared.clearAll()
+        try RealmManager.shared.clearAll()
     }
 
     @Test(
@@ -99,7 +99,7 @@ struct SyncManagerTests {
         #expect(rawGroup != nil)
         #expect(rawGroup?.isDeleted == true)
 
-        RealmManager.shared.clearAll()
+        try RealmManager.shared.clearAll()
     }
 
     @Test("syncGroup - Realmにのみ存在する新規データはFirebaseへ保存される（既存ロジックの回帰確認）")
@@ -117,7 +117,7 @@ struct SyncManagerTests {
 
         #expect(saveToFirebaseCalledWith?.groupID == "g-only-realm")
 
-        RealmManager.shared.clearAll()
+        try RealmManager.shared.clearAll()
     }
 
     @Test("syncGroup - Firebaseにのみ存在するデータはRealmへ保存される（既存ロジックの回帰確認）")
@@ -134,6 +134,6 @@ struct SyncManagerTests {
         #expect(rawGroup != nil)
         #expect(rawGroup?.groupID == "g-only-firebase")
 
-        RealmManager.shared.clearAll()
+        try RealmManager.shared.clearAll()
     }
 }

--- a/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/GroupViewModelTests.swift
@@ -338,7 +338,7 @@ struct GroupViewModelTests {
     @Test("getGroupColor - 範囲外のcolor値でもクラッシュせずgrayを返す（issue #43）")
     func getGroupColor_returnsGrayForOutOfRangeColor() throws {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let group = Group(
             groupID: "g-invalid-color", title: "Broken Group", color: 99, order: 0, created_at: Date())
@@ -347,7 +347,7 @@ struct GroupViewModelTests {
         let color = GroupViewModel.getGroupColor(groupID: "g-invalid-color")
         #expect(color == .gray)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - CRUD操作テスト
@@ -356,7 +356,7 @@ struct GroupViewModelTests {
     func fetchData_retrievesData() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let group1 = Group(
             groupID: "g1", title: "Group 1", color: GroupColor.red.rawValue, order: 0, created_at: Date())
@@ -371,14 +371,14 @@ struct GroupViewModelTests {
         #expect(viewModel.groups.contains(where: { $0.groupID == "g1" }))
         #expect(viewModel.groups.contains(where: { $0.groupID == "g2" }))
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("save - 新規グループを保存できる")
     func save_savesNewGroup() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let group = Group(
             groupID: "new-g", title: "New Group", color: GroupColor.green.rawValue, order: 0, created_at: Date())
@@ -392,14 +392,14 @@ struct GroupViewModelTests {
         #expect(viewModel.groups.count == 1)
         #expect(viewModel.groups.first?.groupID == "new-g")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("delete - グループを削除できる")
     func delete_deletesGroup() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 2つのグループを作成（canDeleteがtrueになるように）
         let group1 = Group(
@@ -422,7 +422,7 @@ struct GroupViewModelTests {
         #expect(viewModel.groups.count == 1)
         #expect(viewModel.groups.first?.groupID == "g2")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -431,7 +431,7 @@ struct GroupViewModelTests {
     func delete_registersBackgroundSyncTaskBeforeReturning() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 他テストの追跡Taskが残っていないことを保証
         await BackgroundSyncTracker.shared.waitForAll()
@@ -454,14 +454,14 @@ struct GroupViewModelTests {
         await BackgroundSyncTracker.shared.waitForAll()
         #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveGroup - 既存インターフェースでグループを保存できる")
     func saveGroup_savesWithLegacyInterface() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let result = await viewModel.saveGroup(
             title: "Legacy Group",
@@ -476,14 +476,14 @@ struct GroupViewModelTests {
         #expect(viewModel.groups.first?.title == "Legacy Group")
         #expect(viewModel.groups.first?.color == GroupColor.purple.rawValue)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("getColorForGroupAtIndex - グループカラーを取得できる")
     func getColorForGroupAtIndex_retrievesColor() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let group = Group(groupID: "g1", title: "Group 1", color: GroupColor.red.rawValue, order: 0, created_at: Date())
         try? manager.saveItem(group)
@@ -493,14 +493,14 @@ struct GroupViewModelTests {
         let color = viewModel.getColorForGroupAtIndex(0)
         #expect(color == .red)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("getTitleForGroupAtIndex - グループタイトルを取得できる")
     func getTitleForGroupAtIndex_retrievesTitle() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let group = Group(
             groupID: "g1", title: "Test Group", color: GroupColor.red.rawValue, order: 0, created_at: Date())
@@ -511,7 +511,7 @@ struct GroupViewModelTests {
         let title = viewModel.getTitleForGroupAtIndex(0)
         #expect(title == "Test Group")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - order値回帰テスト（issue #21: 削除後の新規追加でorderが逆転する不具合）
@@ -520,7 +520,7 @@ struct GroupViewModelTests {
     func saveGroup_afterDeletion_newGroupGetsMaxOrderPlusOne() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // order 0〜3 のグループ4件を作成
         for i in 0..<4 {
@@ -545,7 +545,7 @@ struct GroupViewModelTests {
         let newGroup = viewModel.groups.first(where: { $0.title == "New Group" })
         #expect(newGroup?.order == 4)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - reorderGroups / persistGroupOrder（グループ並び替えの同期性）テスト（issue #169）
@@ -554,7 +554,7 @@ struct GroupViewModelTests {
     func reorderGroups_synchronouslyUpdatesGroups() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let groupA = GroupViewModelTests.createTestGroup(id: "g-A", title: "A", order: 0)
         let groupB = GroupViewModelTests.createTestGroup(id: "g-B", title: "B", order: 1)
@@ -580,14 +580,14 @@ struct GroupViewModelTests {
         let orderABeforePersist = groupsBeforePersist.first { $0.groupID == "g-A" }?.order
         #expect(orderABeforePersist == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("persistGroupOrder - Realmのorderへ反映後、fetchDataで再取得しても同じ並び順を維持する")
     func persistGroupOrder_updatesRealmOrderAndRefetchesGroups() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let groupA = GroupViewModelTests.createTestGroup(id: "g-A", title: "A", order: 0)
         let groupB = GroupViewModelTests.createTestGroup(id: "g-B", title: "B", order: 1)
@@ -602,7 +602,7 @@ struct GroupViewModelTests {
         let result = await viewModel.persistGroupOrder(reordered)
         guard case .success = result else {
             Issue.record("persistGroupOrder failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
@@ -617,14 +617,14 @@ struct GroupViewModelTests {
         _ = await viewModel.fetchData()
         #expect(viewModel.groups.map { $0.groupID } == ["g-C", "g-A", "g-B"])
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("moveGroup - 表示反映と永続化を一括で行いRealmへ反映される（後方互換ラッパーの回帰確認）")
     func moveGroup_reordersAndPersists() async {
         let viewModel = GroupViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let groupA = GroupViewModelTests.createTestGroup(id: "g-A", title: "A", order: 0)
         let groupB = GroupViewModelTests.createTestGroup(id: "g-B", title: "B", order: 1)
@@ -636,7 +636,7 @@ struct GroupViewModelTests {
         let result = await viewModel.moveGroup(from: IndexSet(integer: 1), to: 0)
         guard case .success = result else {
             Issue.record("moveGroup failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
@@ -647,7 +647,7 @@ struct GroupViewModelTests {
         let orderB = updatedGroups.first { $0.groupID == "g-B" }?.order
         #expect(orderB == 0 && orderA == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）

--- a/SportsNote_iOSTests/ViewModels/MeasuresViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/MeasuresViewModelTests.swift
@@ -285,7 +285,7 @@ struct MeasuresViewModelTests {
     func fetchData_retrievesData() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures1 = Measures(measuresID: "ms1", taskID: "t1", title: "Measures 1", order: 0, created_at: Date())
         let measures2 = Measures(measuresID: "ms2", taskID: "t1", title: "Measures 2", order: 1, created_at: Date())
@@ -298,14 +298,14 @@ struct MeasuresViewModelTests {
         #expect(viewModel.measuresList.contains(where: { $0.measuresID == "ms1" }))
         #expect(viewModel.measuresList.contains(where: { $0.measuresID == "ms2" }))
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("save - 新規対策を保存できる")
     func save_savesNewMeasures() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures = Measures(measuresID: "new-ms", taskID: "t1", title: "New Measures", order: 0, created_at: Date())
 
@@ -318,14 +318,14 @@ struct MeasuresViewModelTests {
         #expect(viewModel.measuresList.count == 1)
         #expect(viewModel.measuresList.first?.measuresID == "new-ms")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("delete - 対策を削除できる")
     func delete_deletesMeasures() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures = Measures(measuresID: "ms1", taskID: "t1", title: "Measures", order: 0, created_at: Date())
         try? manager.saveItem(measures)
@@ -341,7 +341,7 @@ struct MeasuresViewModelTests {
 
         #expect(viewModel.measuresList.isEmpty)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -350,7 +350,7 @@ struct MeasuresViewModelTests {
     func delete_registersBackgroundSyncTaskBeforeReturning() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 他テストの追跡Taskが残っていないことを保証
         await BackgroundSyncTracker.shared.waitForAll()
@@ -369,14 +369,14 @@ struct MeasuresViewModelTests {
         await BackgroundSyncTracker.shared.waitForAll()
         #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("getMeasuresByTaskID - 課題IDに紐づく対策を取得できる")
     func getMeasuresByTaskID_retrievesMeasures() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures1 = Measures(measuresID: "ms1", taskID: "t1", title: "Measures 1", order: 0, created_at: Date())
         let measures2 = Measures(measuresID: "ms2", taskID: "t1", title: "Measures 2", order: 1, created_at: Date())
@@ -395,14 +395,14 @@ struct MeasuresViewModelTests {
             Issue.record("GetMeasuresByTaskID failed")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("getMostPriorityMeasures - 最優先対策を取得できる")
     func getMostPriorityMeasures_retrievesMostPriorityMeasures() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures1 = Measures(measuresID: "ms1", taskID: "t1", title: "Measures 1", order: 2, created_at: Date())
         let measures2 = Measures(measuresID: "ms2", taskID: "t1", title: "Measures 2", order: 0, created_at: Date())
@@ -420,14 +420,14 @@ struct MeasuresViewModelTests {
             Issue.record("GetMostPriorityMeasures failed")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveMeasures - 既存インターフェースで対策を保存できる")
     func saveMeasures_savesWithLegacyInterface() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let result = await viewModel.saveMeasures(
             taskID: "t1",
@@ -441,7 +441,7 @@ struct MeasuresViewModelTests {
         #expect(viewModel.measuresList.count == 1)
         #expect(viewModel.measuresList.first?.title == "Legacy Measures")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - order値回帰テスト（issue #21: 削除後の新規追加でorderが逆転する不具合）
@@ -450,7 +450,7 @@ struct MeasuresViewModelTests {
     func saveMeasures_afterDeletion_newMeasuresGetsMaxOrderPlusOne() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // taskID "t1" に order 0〜2 の対策3件を作成
         for i in 0..<3 {
@@ -474,14 +474,14 @@ struct MeasuresViewModelTests {
         let newMeasures = viewModel.measuresList.first(where: { $0.title == "New Measures" })
         #expect(newMeasures?.order == 3)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveMeasures - 別taskIDの削除件数は新規対策のorderに影響しない")
     func saveMeasures_differentTaskDeletion_doesNotAffectOrder() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // taskID "tA" に対策3件を作成し、全て削除
         for i in 0..<3 {
@@ -505,7 +505,7 @@ struct MeasuresViewModelTests {
         let newMeasures = viewModel.measuresList.first(where: { $0.title == "New B Measures" })
         #expect(newMeasures?.order == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - isDeleted保持回帰テスト（issue #75: 更新時にisDeletedがfalseにリセットされ削除済み対策が復活する不具合）
@@ -514,7 +514,7 @@ struct MeasuresViewModelTests {
     func saveMeasures_updatingDeletedMeasures_keepsIsDeletedTrue() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures = Measures(
             measuresID: "ms-deleted", taskID: "t1", title: "Original", order: 0, created_at: Date())
@@ -541,14 +541,14 @@ struct MeasuresViewModelTests {
         #expect(rawMeasures?.isDeleted == true)
         #expect(rawMeasures?.title == "Edited After Deletion")  // タイトル自体は更新される（isDeletedのみ保護される）
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveMeasures - 未削除の対策を更新した場合はisDeletedがfalseのまま")
     func saveMeasures_updatingActiveMeasures_keepsIsDeletedFalse() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures = Measures(
             measuresID: "ms-active", taskID: "t1", title: "Original", order: 0, created_at: Date())
@@ -564,14 +564,14 @@ struct MeasuresViewModelTests {
         let rawMeasures = manager.getRawObjectById(id: "ms-active", type: Measures.self)
         #expect(rawMeasures?.isDeleted == false)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateMeasuresOrder - 論理削除済みの対策の並び順を更新してもisDeletedはtrueのまま維持される")
     func updateMeasuresOrder_withDeletedMeasures_keepsIsDeletedTrue() async {
         let viewModel = MeasuresViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let measures1 = Measures(measuresID: "ms-1", taskID: "t1", title: "M1", order: 0, created_at: Date())
         let measures2 = Measures(measuresID: "ms-2", taskID: "t1", title: "M2", order: 1, created_at: Date())
@@ -590,7 +590,7 @@ struct MeasuresViewModelTests {
         let rawMeasures1 = manager.getRawObjectById(id: "ms-1", type: Measures.self)
         #expect(rawMeasures1?.isDeleted == true)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）

--- a/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/MemoViewModelTests.swift
@@ -338,7 +338,7 @@ struct MemoViewModelTests {
     func fetchData_retrievesData() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let memo1 = Memo(memoID: "m1", measuresID: "ms1", noteID: "n1", detail: "Detail 1", created_at: Date())
         let memo2 = Memo(memoID: "m2", measuresID: "ms2", noteID: "n2", detail: "Detail 2", created_at: Date())
@@ -351,14 +351,14 @@ struct MemoViewModelTests {
         #expect(viewModel.memoList.contains(where: { $0.memoID == "m1" }))
         #expect(viewModel.memoList.contains(where: { $0.memoID == "m2" }))
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("save - 新規メモを保存できる")
     func save_savesNewMemo() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let memo = Memo(memoID: "new-memo", measuresID: "ms1", noteID: "n1", detail: "New Detail", created_at: Date())
 
@@ -371,14 +371,14 @@ struct MemoViewModelTests {
         #expect(viewModel.memoList.count == 1)
         #expect(viewModel.memoList.first?.memoID == "new-memo")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("delete - メモを削除できる")
     func delete_deletesMemo() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let memo = Memo(memoID: "m1", measuresID: "ms1", noteID: "n1", detail: "Detail", created_at: Date())
         try? manager.saveItem(memo)
@@ -394,7 +394,7 @@ struct MemoViewModelTests {
 
         #expect(viewModel.memoList.isEmpty)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -403,7 +403,7 @@ struct MemoViewModelTests {
     func delete_registersBackgroundSyncTaskBeforeReturning() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 他テストの追跡Taskが残っていないことを保証
         await BackgroundSyncTracker.shared.waitForAll()
@@ -422,14 +422,14 @@ struct MemoViewModelTests {
         await BackgroundSyncTracker.shared.waitForAll()
         #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("getMemosByMeasuresID - 対策IDに紐づくメモを取得できる")
     func getMemosByMeasuresID_retrievesMemos() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let note = Note(purpose: "Purpose", detail: "Detail")
         note.noteID = "n1"
@@ -454,14 +454,14 @@ struct MemoViewModelTests {
             Issue.record("GetMemosByMeasuresID failed")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("deleteMemoByNoteAndMeasures - 一致するメモを論理削除できる")
     func deleteMemoByNoteAndMeasures_deletesMatchingMemo() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let memo = Memo(memoID: "m1", measuresID: "ms1", noteID: "n1", detail: "Detail", created_at: Date())
         try? manager.saveItem(memo)
@@ -472,16 +472,16 @@ struct MemoViewModelTests {
             Issue.record("DeleteMemoByNoteAndMeasures failed")
         }
 
-        #expect(manager.findMemo(noteID: "n1", measuresID: "ms1") == nil)
+        #expect((try? manager.findMemo(noteID: "n1", measuresID: "ms1")) == nil)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("deleteMemoByNoteAndMeasures - 一致するメモが存在しない場合は何もせず成功を返す")
     func deleteMemoByNoteAndMeasures_noMatchReturnsSuccess() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let result = await viewModel.deleteMemoByNoteAndMeasures(noteID: "n1", measuresID: "ms-not-exist")
 
@@ -489,14 +489,14 @@ struct MemoViewModelTests {
             Issue.record("DeleteMemoByNoteAndMeasures should succeed when no match found")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("getMemosByMeasuresID - noteIDが空文字のメモ（旧データのノート未紐付けメモ）も一覧に含まれる")
     func getMemosByMeasuresID_includesMemosWithEmptyNoteID() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let note = Note(purpose: "Purpose", detail: "Detail")
         note.noteID = "n1"
@@ -518,14 +518,14 @@ struct MemoViewModelTests {
             Issue.record("GetMemosByMeasuresID failed")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveMemo - 既存インターフェースでメモを保存できる")
     func saveMemo_savesWithLegacyInterface() async {
         let viewModel = MemoViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let result = await viewModel.saveMemo(
             measuresID: "ms1",
@@ -541,7 +541,7 @@ struct MemoViewModelTests {
             Issue.record("SaveMemo failed")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）

--- a/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/NoteViewModelTests.swift
@@ -338,7 +338,7 @@ struct NoteViewModelTests {
     func fetchData_retrievesData() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // テストデータ作成（フリーノート以外を使用）
         let note1 = Note(purpose: "Purpose 1", detail: "Detail 1")
@@ -355,7 +355,7 @@ struct NoteViewModelTests {
         #expect(viewModel.notes.contains(where: { $0.noteID == note1.noteID }))
         #expect(viewModel.notes.contains(where: { $0.noteID == note2.noteID }))
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
 
@@ -363,7 +363,7 @@ struct NoteViewModelTests {
     func delete_deletesNote() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // テストデータ（フリーノート以外でないと削除できない仕様があるため練習ノートにする）
         let note = Note(purpose: "Purpose", detail: "Detail")
@@ -388,7 +388,7 @@ struct NoteViewModelTests {
         let deletedNote = manager.getRawObjectById(id: note.noteID, type: Note.self)
         #expect(deletedNote?.isDeleted == true)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // NOTE(issue #164): NoteViewModel.delete(id:)は他5ViewModelと異なり
@@ -406,7 +406,7 @@ struct NoteViewModelTests {
     func delete_cannotDeleteFreeNote() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // フリーノート作成
         let note = Note(title: "Free Note")
@@ -429,7 +429,7 @@ struct NoteViewModelTests {
         let existingNote = try? manager.getObjectById(id: note.noteID, type: Note.self)
         #expect(existingNote != nil)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - 検索・フィルタリングテスト
@@ -438,7 +438,7 @@ struct NoteViewModelTests {
     func searchNotes_filtersByQuery() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // データ作成
         let note1 = Note(title: "Swift")
@@ -462,14 +462,14 @@ struct NoteViewModelTests {
         #expect(viewModel.notes.contains(where: { $0.noteID == note1.noteID }))
         #expect(viewModel.notes.contains(where: { $0.noteID == note2.noteID }))
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("filterNotesByDate - 日付でフィルタリングできる")
     func filterNotesByDate_filtersByDate() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let today = Date()
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
@@ -491,7 +491,7 @@ struct NoteViewModelTests {
         #expect(filtered.count == 1)
         #expect(filtered.first?.noteID == noteToday.noteID)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - 各種ノート作成メソッドテスト
@@ -500,7 +500,7 @@ struct NoteViewModelTests {
     func savePracticeNote_savesCorrectly() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         viewModel.savePracticeNoteWithReflections(
             purpose: "Practice Purpose",
@@ -533,7 +533,7 @@ struct NoteViewModelTests {
         #expect(note?.weather == Weather.rainy.rawValue)
         #expect(note?.temperature == 25)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - updateTaskReflections（課題振り返りメモ）のcreated_atテスト
@@ -542,7 +542,7 @@ struct NoteViewModelTests {
     func updateTaskReflections_newMemo_setsCurrentCreatedAt() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let beforeSave = Date()
         let task = TaskListData(
@@ -577,13 +577,13 @@ struct NoteViewModelTests {
             Issue.record("新規作成されたMemoのcreated_atが取得できませんでした")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - task.memoIDがある場合、既存メモのcreated_atが維持される")
     func updateTaskReflections_existingMemoWithMemoID_preservesCreatedAt() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 既存メモをRealmに直接投入（過去のcreated_atを持つ）
         let fixedCreatedAt = Date().addingTimeInterval(-86400)
@@ -628,13 +628,13 @@ struct NoteViewModelTests {
             Issue.record("更新後のMemoのcreated_atが取得できませんでした")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - task.memoIDがなくnoteID+measuresIDで既存メモが見つかる場合もcreated_atが維持される")
     func updateTaskReflections_existingMemoFoundBySearch_preservesCreatedAt() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 既存メモをRealmに直接投入（過去のcreated_atを持つ）
         let fixedCreatedAt = Date().addingTimeInterval(-3600)
@@ -681,7 +681,7 @@ struct NoteViewModelTests {
             Issue.record("更新後のMemoのcreated_atが取得できませんでした")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - updateTaskReflections（課題振り返りメモ）の対策並び替え回帰テスト（issue #109）
@@ -689,7 +689,7 @@ struct NoteViewModelTests {
     @Test("updateTaskReflections - 対策の並び替えでmeasuresIDが変わっても、既存メモが重複作成されず更新される")
     func updateTaskReflections_existingMemoFoundAfterMeasuresReorder_updatesExistingMemo() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 既存メモは並び替え前の最優先対策(measures-old)に対して作成されたもの
         let fixedCreatedAt = Date().addingTimeInterval(-3600)
@@ -733,7 +733,7 @@ struct NoteViewModelTests {
         )
 
         // 新規メモが作られず、既存メモが更新されていること（重複作成されないこと）
-        let memos = manager.getMemosByNoteID(noteID: "note-reorder-1")
+        let memos = (try? manager.getMemosByNoteID(noteID: "note-reorder-1")) ?? []
         #expect(memos.count == 1)
 
         let updatedMemo = try? manager.getObjectById(id: "memo-reorder-1", type: Memo.self)
@@ -745,7 +745,7 @@ struct NoteViewModelTests {
             Issue.record("更新後のMemoのcreated_atが取得できませんでした")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - updateTaskReflections（課題振り返りメモ）の対策付け替え回帰テスト（issue #160）
@@ -753,7 +753,7 @@ struct NoteViewModelTests {
     @Test("updateTaskReflections - 対策の並び替え後、既存メモのmeasuresIDが現在の最優先対策IDに上書きされず維持される（noteID+measuresID検索経由）")
     func updateTaskReflections_existingMemoFoundAfterMeasuresReorder_preservesOriginalMeasuresID() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 既存メモは並び替え前の最優先対策(measures-old)に対して作成されたもの
         let existingMemo = Memo(
@@ -804,13 +804,13 @@ struct NoteViewModelTests {
         #expect(updatedMemo?.measuresID == "measures-old-2")
         #expect(updatedMemo?.detail == "並び替え後の振り返り")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - task.memoIDによる既存メモ編集時も、対策の並び替え後にmeasuresIDが上書きされず維持される")
     func updateTaskReflections_existingMemoWithMemoID_preservesOriginalMeasuresIDAfterReorder() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 既存メモは並び替え前の最優先対策(measures-old-3)に対して作成されたもの
         let existingMemo = Memo(
@@ -848,13 +848,13 @@ struct NoteViewModelTests {
         #expect(updatedMemo?.measuresID == "measures-old-3")
         #expect(updatedMemo?.detail == "並び替え後の振り返り")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - 新規メモ作成時は引き続き現在の最優先対策IDが正しく設定される（回帰確認）")
     func updateTaskReflections_newMemo_usesCurrentMostPriorityMeasuresID() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = NoteViewModel()
         let task = TaskListData(
@@ -876,11 +876,11 @@ struct NoteViewModelTests {
             taskReflections: [task: "新規の振り返り"]
         )
 
-        let memos = manager.getMemosByNoteID(noteID: "note-reorder-4")
+        let memos = (try? manager.getMemosByNoteID(noteID: "note-reorder-4")) ?? []
         #expect(memos.count == 1)
         #expect(memos.first?.measuresID == "measures-new-4")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - updateTaskReflections（課題振り返りメモ）の空文字編集テスト（issue #105）
@@ -888,7 +888,7 @@ struct NoteViewModelTests {
     @Test("updateTaskReflections - 既存メモを空文字に編集した場合、Realm上のdetailが空文字に更新される")
     func updateTaskReflections_existingMemo_savesEmptyDetail() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let existingMemo = Memo(
             memoID: "memo-fixed-3",
@@ -925,13 +925,13 @@ struct NoteViewModelTests {
         #expect(updatedMemo != nil)
         #expect(updatedMemo?.detail == "")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - task.memoIDがなくnoteID+measuresID検索で既存メモが見つかる場合も、空文字への編集が保存される")
     func updateTaskReflections_existingMemoFoundBySearch_savesEmptyDetail() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let existingMemo = Memo(
             memoID: "memo-fixed-4b",
@@ -972,13 +972,13 @@ struct NoteViewModelTests {
         #expect(updatedMemo != nil)
         #expect(updatedMemo?.detail == "")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - 既存メモがない状態で空文字のまま保存しても新規メモは作成されない")
     func updateTaskReflections_noExistingMemo_emptyText_doesNotCreateMemo() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = NoteViewModel()
         let task = TaskListData(
@@ -1000,10 +1000,10 @@ struct NoteViewModelTests {
             taskReflections: [task: ""]
         )
 
-        let memos = manager.getMemosByNoteID(noteID: "note-4")
+        let memos = (try? manager.getMemosByNoteID(noteID: "note-4")) ?? []
         #expect(memos.isEmpty)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - updateTaskReflections（課題振り返りメモ）のFirebase同期テスト
@@ -1012,7 +1012,7 @@ struct NoteViewModelTests {
     func updateTaskReflections_newMemo_triggersFirebaseSyncCall() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskListData(
             taskID: "task-sync-1",
@@ -1035,13 +1035,13 @@ struct NoteViewModelTests {
         #expect(viewModel.memoSyncCallsForTesting.count == 1)
         #expect(viewModel.memoSyncCallsForTesting.first?.isUpdate == false)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - task.memoIDによる既存メモ編集時、Memoの同期呼び出しがisUpdate=trueで発生する")
     func updateTaskReflections_existingMemoWithMemoID_triggersFirebaseSyncCallAsUpdate() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let existingMemo = Memo(
             memoID: "memo-sync-fixed-1",
@@ -1076,13 +1076,13 @@ struct NoteViewModelTests {
         #expect(viewModel.memoSyncCallsForTesting.first?.memoID == "memo-sync-fixed-1")
         #expect(viewModel.memoSyncCallsForTesting.first?.isUpdate == true)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTaskReflections - noteID+measuresID検索で既存メモが見つかる場合もMemoの同期呼び出しがisUpdate=trueで発生する")
     func updateTaskReflections_existingMemoFoundBySearch_triggersFirebaseSyncCallAsUpdate() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let existingMemo = Memo(
             memoID: "memo-sync-fixed-2",
@@ -1122,7 +1122,7 @@ struct NoteViewModelTests {
         #expect(viewModel.memoSyncCallsForTesting.first?.memoID == "memo-sync-fixed-2")
         #expect(viewModel.memoSyncCallsForTesting.first?.isUpdate == true)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("syncMemoToFirebase - オフライン/テスト環境では同期をスキップして成功を返す", arguments: [false, true])
@@ -1147,7 +1147,7 @@ struct NoteViewModelTests {
     func saveTournamentNote_savesCorrectly() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         viewModel.saveTournamentNote(
             target: "Tournament Target",
@@ -1178,14 +1178,14 @@ struct NoteViewModelTests {
         #expect(note?.consciousness == "Consciousness")
         #expect(note?.result == "Result")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveFreeNote - フリーノートを保存できる")
     func saveFreeNote_savesCorrectly() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         viewModel.saveFreeNote(
             title: "Free Title",
@@ -1214,14 +1214,14 @@ struct NoteViewModelTests {
         #expect(note?.title == "Free Title")
         #expect(note?.detail == "Free Detail")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("fetchNotesExcludingFree - フリーノートを除外して取得できる")
     func fetchNotesExcludingFree_excludesFreeNotes() async {
         let viewModel = NoteViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let freeNote = Note(title: "Free")
         freeNote.noteType = NoteType.free.rawValue
@@ -1237,7 +1237,7 @@ struct NoteViewModelTests {
         #expect(viewModel.notes.count == 1)
         #expect(viewModel.notes.first?.noteType == NoteType.practice.rawValue)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）

--- a/SportsNote_iOSTests/ViewModels/TargetViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TargetViewModelTests.swift
@@ -357,7 +357,7 @@ struct TargetViewModelTests {
     func fetchTargetsByYearMonth_retrievesTargets() async {
         let viewModel = TargetViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let target1 = Target(title: "Target 1", year: 2024, month: 11, isYearlyTarget: false)
         let target2 = Target(title: "Target 2", year: 2024, month: 11, isYearlyTarget: false)
@@ -368,14 +368,14 @@ struct TargetViewModelTests {
 
         #expect(viewModel.monthlyTargets.count == 2)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("save - 新規目標を保存できる")
     func save_savesNewTarget() async {
         let viewModel = TargetViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let target = Target(title: "New Target", year: 2024, month: 11, isYearlyTarget: false)
 
@@ -388,14 +388,14 @@ struct TargetViewModelTests {
         _ = await viewModel.fetchTargetsByYearMonth(year: 2024, month: 11)
         #expect(viewModel.monthlyTargets.count == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("delete - 目標を削除できる")
     func delete_deletesTarget() async {
         let viewModel = TargetViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let target = Target(title: "Target", year: 2024, month: 11, isYearlyTarget: false)
         try? manager.saveItem(target)
@@ -411,7 +411,7 @@ struct TargetViewModelTests {
 
         #expect(viewModel.monthlyTargets.isEmpty)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -420,7 +420,7 @@ struct TargetViewModelTests {
     func delete_registersBackgroundSyncTaskBeforeReturning() async {
         let viewModel = TargetViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 他テストの追跡Taskが残っていないことを保証
         await BackgroundSyncTracker.shared.waitForAll()
@@ -439,7 +439,7 @@ struct TargetViewModelTests {
         await BackgroundSyncTracker.shared.waitForAll()
         #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）

--- a/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
+++ b/SportsNote_iOSTests/ViewModels/TaskViewModelTests.swift
@@ -398,7 +398,7 @@ struct TaskViewModelTests {
     @Test("associateTasksWithMemos - measuresIDが指す対策のtaskIDで課題とメモがペアになる")
     func associateTasksWithMemos_matchesTaskByMeasuresID() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         let task = TaskListData(
@@ -433,13 +433,13 @@ struct TaskViewModelTests {
         #expect(pairs.first?.memo.memoID == "memo-1")
         #expect(pairs.first?.memo.detail == "振り返り内容")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - measuresIDが指す対策のtaskIDがtaskListDataに存在しない場合はペアに含まれない")
     func associateTasksWithMemos_noMatchIsExcluded() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         let task = TaskListData(
@@ -473,13 +473,13 @@ struct TaskViewModelTests {
 
         #expect(pairs.isEmpty)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - 対策の並び替えでmeasuresIDが変わっても、taskIDで同一課題として突合される")
     func associateTasksWithMemos_matchesAfterMeasuresReorder() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         // taskListData.measuresIDは並び替え後の現在の最優先対策(measures-B)を指す
@@ -517,13 +517,13 @@ struct TaskViewModelTests {
         #expect(pairs.first?.task.taskID == "task-1")
         #expect(pairs.first?.memo.memoID == "memo-1")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - 同一課題に複数メモが一致する場合はtaskIDで重複排除される")
     func associateTasksWithMemos_dedupesBySameTaskID() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         let task = TaskListData(
@@ -566,13 +566,13 @@ struct TaskViewModelTests {
         #expect(pairs.first?.memo.memoID == "memo-2")
         #expect(pairs.first?.memo.detail == "2件目")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - 複数課題・複数メモで正しくペアが構築される")
     func associateTasksWithMemos_multipleTasksAndMemos() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         let task1 = TaskListData(
@@ -624,13 +624,13 @@ struct TaskViewModelTests {
         #expect(pairs.count == 2)
         #expect(Set(pairs.map { $0.task.taskID }) == Set(["task-1", "task-2"]))
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("associateTasksWithMemos - 戻り値がtask.order昇順にソートされる（issue #137: Dictionary列挙順への依存を排除）")
     func associateTasksWithMemos_sortsResultByTaskOrder() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         // orderが降順になるように課題を用意し、Dictionary経由でも意図した順序に
@@ -690,7 +690,7 @@ struct TaskViewModelTests {
 
         #expect(pairs.map { $0.task.taskID } == ["task-2", "task-3", "task-1"])
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -698,7 +698,7 @@ struct TaskViewModelTests {
     )
     func associateTasksWithMemos_sameOrderTiesBreakByTaskID() async {
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let viewModel = TaskViewModel()
         // 異なるグループの課題はグループ内スコープでorderが採番されるため、
@@ -743,7 +743,7 @@ struct TaskViewModelTests {
 
         #expect(pairs.map { $0.task.taskID } == ["task-a", "task-b"])
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - エラーハンドリングテスト
@@ -924,7 +924,7 @@ struct TaskViewModelTests {
     func fetchData_retrievesData() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task1 = TaskData(
             taskID: "t1", title: "Task 1", cause: "Cause 1", groupID: "g1", order: 0, isComplete: false,
@@ -939,14 +939,14 @@ struct TaskViewModelTests {
 
         #expect(viewModel.tasks.count == 2)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("save - 新規課題を保存できる")
     func save_savesNewTask() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskData(
             taskID: "new-task", title: "New Task", cause: "Cause", groupID: "g1", order: 0, isComplete: false,
@@ -960,14 +960,14 @@ struct TaskViewModelTests {
 
         #expect(viewModel.tasks.count == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("delete - 課題を削除できる")
     func delete_deletesTask() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskData(
             taskID: "t1", title: "Task", cause: "Cause", groupID: "g1", order: 0, isComplete: false, created_at: Date())
@@ -984,7 +984,7 @@ struct TaskViewModelTests {
 
         #expect(viewModel.tasks.isEmpty)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -993,7 +993,7 @@ struct TaskViewModelTests {
     func delete_registersBackgroundSyncTaskBeforeReturning() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // 他テストの追跡Taskが残っていないことを保証
         await BackgroundSyncTracker.shared.waitForAll()
@@ -1013,7 +1013,7 @@ struct TaskViewModelTests {
         await BackgroundSyncTracker.shared.waitForAll()
         #expect(BackgroundSyncTracker.shared.trackedCountForTesting == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - TaskViewModel特有機能テスト
@@ -1022,7 +1022,7 @@ struct TaskViewModelTests {
     func toggleTaskCompletion_togglesCompletion() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskData(
             taskID: "t1", title: "Task", cause: "Cause", groupID: "g1", order: 0, isComplete: false, created_at: Date())
@@ -1035,14 +1035,14 @@ struct TaskViewModelTests {
 
         #expect(viewModel.tasks.first?.isComplete == true)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("fetchTasksByGroupID - グループIDでフィルタリングできる")
     func fetchTasksByGroupID_filtersTasksByGroupID() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task1 = TaskData(
             taskID: "t1", title: "Task 1", cause: "Cause 1", groupID: "g1", order: 0, isComplete: false,
@@ -1062,14 +1062,14 @@ struct TaskViewModelTests {
         #expect(viewModel.tasks.count == 2)
         #expect(viewModel.tasks.allSatisfy { $0.groupID == "g1" })
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTask - 既存課題を更新できる")
     func updateTask_updatesExistingTask() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskData(
             taskID: "t1", title: "Original", cause: "Original Cause", groupID: "g1", order: 0, isComplete: false,
@@ -1082,7 +1082,7 @@ struct TaskViewModelTests {
         #expect(updatedTask?.title == "Updated")
         #expect(updatedTask?.cause == "Updated Cause")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - グループ変更時のorder衝突回帰テスト（issue #106）
@@ -1091,7 +1091,7 @@ struct TaskViewModelTests {
     func updateTask_groupChanged_reassignsOrderToAvoidCollision() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // Group1にTask A（order=0）
         let taskA = TaskData(
@@ -1117,14 +1117,14 @@ struct TaskViewModelTests {
         // Group2内の既存最大order(1)+1に採番され、Task X・Task Yと衝突しないこと
         #expect(updatedTaskA?.order == 2)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("updateTask - グループを変更しない場合、orderは維持される")
     func updateTask_groupUnchanged_preservesOrder() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskData(
             taskID: "task-a", title: "Task A", cause: "", groupID: "group1", order: 3, isComplete: false,
@@ -1137,14 +1137,14 @@ struct TaskViewModelTests {
         let updatedTask = try? manager.getObjectById(id: "task-a", type: TaskData.self)
         #expect(updatedTask?.order == 3)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveNewTaskWithMeasures - 課題と対策を同時に保存できる")
     func saveNewTaskWithMeasures_savesTaskAndMeasures() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let result = await viewModel.saveNewTaskWithMeasures(
             title: "New Task",
@@ -1157,14 +1157,14 @@ struct TaskViewModelTests {
             #expect(task.title == "New Task")
 
             // 対策が保存されているか確認
-            let measures = manager.getMeasuresByTaskID(taskID: task.taskID)
+            let measures = (try? manager.getMeasuresByTaskID(taskID: task.taskID)) ?? []
             #expect(measures.count == 1)
             #expect(measures.first?.title == "Measure 1")
         } else {
             Issue.record("SaveNewTaskWithMeasures failed")
         }
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - order値回帰テスト（issue #21: 削除後の新規追加でorderが逆転する不具合）
@@ -1173,7 +1173,7 @@ struct TaskViewModelTests {
     func saveNewTaskWithMeasures_afterDeletion_newTaskGetsMaxOrderPlusOne() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // groupID "g1" に order 0〜4 の課題5件を作成
         for i in 0..<5 {
@@ -1193,7 +1193,7 @@ struct TaskViewModelTests {
 
         guard case .success(let newTask) = result else {
             Issue.record("saveNewTaskWithMeasures failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
@@ -1201,14 +1201,14 @@ struct TaskViewModelTests {
         // 最大order+1ベースなら5になり、末尾（最新）に表示される
         #expect(newTask.order == 5)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("saveNewTaskWithMeasures - 別グループの削除件数は新規課題のorderに影響しない")
     func saveNewTaskWithMeasures_differentGroupDeletion_doesNotAffectOrder() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // groupID "gA" に課題3件を作成し、全て削除
         for i in 0..<3 {
@@ -1231,20 +1231,20 @@ struct TaskViewModelTests {
 
         guard case .success(let newTask) = result else {
             Issue.record("saveNewTaskWithMeasures failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
         #expect(newTask.order == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("showCompletedTasks - 完了タスクの表示切り替えができる")
     func showCompletedTasks_togglesFilteredTasks() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task1 = TaskData(
             taskID: "t1", title: "Task 1", cause: "Cause 1", groupID: "g1", order: 0, isComplete: false,
@@ -1265,7 +1265,7 @@ struct TaskViewModelTests {
         viewModel.showCompletedTasks = true
         #expect(viewModel.filteredTaskListData.count == 2)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - moveTask（並び替え）テスト
@@ -1274,7 +1274,7 @@ struct TaskViewModelTests {
     func moveTask_doesNotCauseOrderCollisionWhenCompletedTasksHidden() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // A(order0,未完了) B(order1,完了) C(order2,未完了)
         let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
@@ -1292,7 +1292,7 @@ struct TaskViewModelTests {
         let result = await viewModel.moveTask(from: IndexSet(integer: 1), to: 0)
         guard case .success = result else {
             Issue.record("moveTask failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
@@ -1308,14 +1308,14 @@ struct TaskViewModelTests {
         #expect(orderA != nil && orderB != nil && orderC != nil)
         #expect(orderA != orderB)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("moveTask - 完了課題表示ONにした際にorderが重複しない")
     func moveTask_thenShowCompletedTasks_orderIsStable() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
         let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: true)
@@ -1334,14 +1334,14 @@ struct TaskViewModelTests {
         let orders = viewModel.filteredTaskListData.map { $0.order }
         #expect(Set(orders).count == orders.count, "表示ON後もorderが重複していない")
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("moveTask - showCompletedTasksがtrueの場合は全件が並び替え対象になる")
     func moveTask_allTasksVisible_reordersAllCorrectly() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
         let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: true)
@@ -1356,7 +1356,7 @@ struct TaskViewModelTests {
         let result = await viewModel.moveTask(from: IndexSet(integer: 1), to: 0)
         guard case .success = result else {
             Issue.record("moveTask failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
@@ -1365,7 +1365,7 @@ struct TaskViewModelTests {
         let orderB = updatedTasks.first { $0.taskID == "B" }?.order
         #expect(orderB == 0 && orderA == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - reorderTaskListData（表示反映の同期性）テスト（issue #161）
@@ -1376,7 +1376,7 @@ struct TaskViewModelTests {
     func reorderTaskListData_synchronouslyUpdatesFilteredTaskListData() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
         let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: false)
@@ -1406,7 +1406,7 @@ struct TaskViewModelTests {
         let result = await viewModel.persistTaskOrder(mergedTasks)
         guard case .success = result else {
             Issue.record("persistTaskOrder failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
@@ -1416,7 +1416,7 @@ struct TaskViewModelTests {
         let orderB = updatedTasks.first { $0.taskID == "B" }?.order
         #expect(orderC == 0 && orderA == 1 && orderB == 2)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -1425,7 +1425,7 @@ struct TaskViewModelTests {
     func persistTaskOrder_thenToggleShowCompletedTasksOff_orderIsPreserved() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         // A(order0,未完了) B(order1,完了) C(order2,未完了)
         let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
@@ -1443,7 +1443,7 @@ struct TaskViewModelTests {
         let result = await viewModel.persistTaskOrder(mergedTasks)
         guard case .success = result else {
             Issue.record("persistTaskOrder failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
         #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A", "B"])
@@ -1452,7 +1452,7 @@ struct TaskViewModelTests {
         viewModel.showCompletedTasks = false
         #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A"])
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -1461,7 +1461,7 @@ struct TaskViewModelTests {
     func persistTaskOrder_doesNotRepublishFilteredTaskListData() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let taskA = TaskViewModelTests.createTestTask(id: "A", groupID: "g1", order: 0, isComplete: false)
         let taskB = TaskViewModelTests.createTestTask(id: "B", groupID: "g1", order: 1, isComplete: false)
@@ -1488,14 +1488,14 @@ struct TaskViewModelTests {
         let result = await viewModel.persistTaskOrder(mergedTasks)
         guard case .success = result else {
             Issue.record("persistTaskOrder failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
         #expect(publishCount == 0, "persistTaskOrderはfilteredTaskListDataへ再代入すべきではない")
         #expect(viewModel.filteredTaskListData.map { $0.taskID } == ["C", "A", "B"])
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - reorderMeasuresListData / persistMeasuresOrder（対策並び替えの同期性）テスト（issue #165）
@@ -1506,7 +1506,7 @@ struct TaskViewModelTests {
     func reorderMeasuresListData_synchronouslyUpdatesTaskDetailMeasuresList() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskViewModelTests.createTestTask(id: "task-1", groupID: "g1", order: 0)
         try? manager.saveItem(task)
@@ -1533,11 +1533,11 @@ struct TaskViewModelTests {
 
         // この時点ではRealmへの永続化（persistMeasuresOrder）はまだ行われていないため、
         // Realm上のorderは変化していないはず
-        let measuresBeforePersist = manager.getMeasuresByTaskID(taskID: "task-1")
+        let measuresBeforePersist = (try? manager.getMeasuresByTaskID(taskID: "task-1")) ?? []
         let orderABeforePersist = measuresBeforePersist.first { $0.measuresID == "m-A" }?.order
         #expect(orderABeforePersist == 0)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test(
@@ -1546,7 +1546,7 @@ struct TaskViewModelTests {
     func persistMeasuresOrder_updatesRealmOrderAndRefetchesTaskDetail() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskViewModelTests.createTestTask(id: "task-1", groupID: "g1", order: 0)
         try? manager.saveItem(task)
@@ -1563,18 +1563,18 @@ struct TaskViewModelTests {
         _ = await viewModel.fetchTaskDetail(taskID: "task-1")
         guard let reordered = viewModel.reorderMeasuresListData(from: IndexSet(integer: 2), to: 0) else {
             Issue.record("reorderMeasuresListData returned nil")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
         let result = await viewModel.persistMeasuresOrder(reordered)
         guard case .success = result else {
             Issue.record("persistMeasuresOrder failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
-        let updatedMeasures = manager.getMeasuresByTaskID(taskID: "task-1")
+        let updatedMeasures = (try? manager.getMeasuresByTaskID(taskID: "task-1")) ?? []
         let orderC = updatedMeasures.first { $0.measuresID == "m-C" }?.order
         let orderA = updatedMeasures.first { $0.measuresID == "m-A" }?.order
         let orderB = updatedMeasures.first { $0.measuresID == "m-B" }?.order
@@ -1584,13 +1584,13 @@ struct TaskViewModelTests {
         // （＝一旦元の位置に戻ってから正しい位置に変わるスナップバックが発生しない）ことを確認
         #expect(viewModel.taskDetail?.measuresList.map { $0.measuresID } == ["m-C", "m-A", "m-B"])
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     @Test("reorderMeasuresListData - taskDetailがnilの場合はnilを返しクラッシュしない")
     func reorderMeasuresListData_withNilTaskDetail_returnsNil() async {
         let viewModel = TaskViewModel()
-        RealmManager.shared.clearAll()
+        try? RealmManager.shared.clearAll()
 
         #expect(viewModel.taskDetail == nil)
         let reordered = viewModel.reorderMeasuresListData(from: IndexSet(integer: 0), to: 1)
@@ -1600,7 +1600,7 @@ struct TaskViewModelTests {
     @Test("persistMeasuresOrder - 空配列を渡した場合は即座に成功を返す")
     func persistMeasuresOrder_withEmptyArray_returnsSuccessWithoutCallingMeasuresViewModel() async {
         let viewModel = TaskViewModel()
-        RealmManager.shared.clearAll()
+        try? RealmManager.shared.clearAll()
 
         let result = await viewModel.persistMeasuresOrder([])
         guard case .success = result else {
@@ -1613,7 +1613,7 @@ struct TaskViewModelTests {
     func moveMeasures_reordersAndPersists() async {
         let viewModel = TaskViewModel()
         let manager = RealmManager.shared
-        manager.clearAll()
+        try? manager.clearAll()
 
         let task = TaskViewModelTests.createTestTask(id: "task-1", groupID: "g1", order: 0)
         try? manager.saveItem(task)
@@ -1629,16 +1629,16 @@ struct TaskViewModelTests {
         let result = await viewModel.moveMeasures(from: IndexSet(integer: 1), to: 0)
         guard case .success = result else {
             Issue.record("moveMeasures failed")
-            manager.clearAll()
+            try? manager.clearAll()
             return
         }
 
-        let updatedMeasures = manager.getMeasuresByTaskID(taskID: "task-1")
+        let updatedMeasures = (try? manager.getMeasuresByTaskID(taskID: "task-1")) ?? []
         let orderA = updatedMeasures.first { $0.measuresID == "m-A" }?.order
         let orderB = updatedMeasures.first { $0.measuresID == "m-B" }?.order
         #expect(orderB == 0 && orderA == 1)
 
-        manager.clearAll()
+        try? manager.clearAll()
     }
 
     // MARK: - convertFirebaseSyncError テスト（issue #36: エラー二重変換防止）


### PR DESCRIPTION
## 概要
未対応だった3件のissueをまとめて1つのPRで対応した。

### #185: カレンダーの月切替ボタン連続タップ不具合
`CalendarView.swift`の`changeMonth(isPrevious:)`を0.3秒のアニメーション完了前に連続タップ（またはドラッグジェスチャーで連続スワイプ）すると、`isAnimating`/`slideDirection`が多重にリセットされ、アニメーション乱れ・月数ズレが発生していた。

**対応**: `changeMonth(isPrevious:)`の先頭に`guard !isAnimating else { return }`を追加し、多重実行を防止。前月/翌月ボタンにも`.disabled(isAnimating)`を付与してタップ自体を防止した。ドラッグジェスチャー自体は変更していないが、同じガードで同一原因のズレが解消される。

Closes #185

### #186: Firestoreコールバックのasyncラップ重複（refactor）
`FirebaseManager.swift`・`MigrationManager.swift`の計7箇所に、Firestoreのコールバック型APIを`withCheckedThrowingContinuation`で`async`化する実質同一の定型コードが重複していた。

**対応**: 新規ファイル`FirestoreContinuation.swift`に`withFirestoreContinuation`（`(Error?) -> Void`用）・`withFirestoreQueryContinuation`（`(QuerySnapshot?, Error?) -> Void`用）の2つの共通ヘルパーを切り出し、7箇所全てを置き換えた。エラー変換ロジック（`ErrorMapper.mapFirebaseError`）・呼び出し元・Firestoreクエリ内容は変更していない。両ヘルパーは`FirebaseManager`/`MigrationManager`がいずれも`@MainActor`であることに合わせて`@MainActor`を付与し、Swift Concurrencyのsendable境界エラーを回避した。

Closes #186

### #107: RealmManagerのエラー伝播統一（refactor）
`RealmManager.swift`の12メソッドがRealmエラーを`print`で握りつぶし、他の大半のメソッドと異なり`ErrorMapper`経由で呼び出し元に伝播していなかった。自動実装フローが「変更対象8ファイル・呼び出し元20箇所超」を理由に2回スキップし`needs-manual-follow-up`ラベルが付与されていたが、オーナーの指示によりまとめて対応した。

**対応**: 対象12メソッド（`getCompletedTasksByGroupId`/`getMeasuresByTaskID`/`getFreeNote`/`searchNotesByQuery`/`getNotesByDate`/`getNotes`/`getMemosByMeasuresID`/`getMemosByNoteID`/`getNoteBackgroundColor`/`fetchYearlyTargets`/`fetchTargetsByYearMonth`/`clearAll`）を`throws`に変更し、`throw ErrorMapper.mapRealmError(error, context:)`で伝播するよう統一。呼び出し元（7ファイル・20箇所超の本番コード、および約150箇所のテストコード）を以下の方針で対応:
- `Result<T, SportsNoteError>`を返す既存メソッド内: `do-catch`で`.failure(convertToSportsNoteError(...))`を返す
- View直結の同期メソッド（戻り値がResultでない）: `do-catch`で`showErrorAlert(...)`を呼び、既存のフォールバック値（`[]`・`nil`・`.gray`等）を返す
- `InitializationManager`のfire-and-forget処理（`createFreeNote`/`deleteAllData`）: 同ファイル内の既存の`createUncategorizedGroup`と同じ`print`パターンに揃える
- テストコード（非throws async関数）: `try?`で対応

なお`RealmManager.findMemo`は元issueの対象12メソッドには含まれていなかったが、内部で`getMemosByNoteID`を呼んでいるため`throws`化が必要となり、唯一の呼び出し元`MemoViewModel.deleteMemoByNoteAndMeasures`もあわせて対応した。

Closes #107

## ビルド・テスト結果
- ビルド: BUILD SUCCEEDED（Sendable関連の非致命的な警告のみ）
- テスト: 598件全PASS

## クロスレビュー結果
独立コンテキストのエージェントによるレビューを実施し、must-fix指摘なしで合格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)